### PR TITLE
BZ-1012882 - Deploy of springapp war causes continuous auth problems (er...

### DIFF
--- a/uberfire-security/uberfire-security-api/src/main/java/org/uberfire/security/auth/AuthenticationProvider.java
+++ b/uberfire-security/uberfire-security-api/src/main/java/org/uberfire/security/auth/AuthenticationProvider.java
@@ -18,12 +18,14 @@ package org.uberfire.security.auth;
 
 import java.util.Map;
 
+import org.uberfire.security.SecurityContext;
+
 public interface AuthenticationProvider {
 
     void initialize(Map<String, ?> options);
 
     boolean supportsCredential(final Credential credential);
 
-    AuthenticationResult authenticate(final Credential credential) throws AuthenticationException;
+    AuthenticationResult authenticate(final Credential credential, final SecurityContext securityContext) throws AuthenticationException;
 
 }

--- a/uberfire-security/uberfire-security-api/src/main/java/org/uberfire/security/auth/AuthenticationSource.java
+++ b/uberfire-security/uberfire-security-api/src/main/java/org/uberfire/security/auth/AuthenticationSource.java
@@ -18,12 +18,14 @@ package org.uberfire.security.auth;
 
 import java.util.Map;
 
+import org.uberfire.security.SecurityContext;
+
 public interface AuthenticationSource {
 
     void initialize(final Map<String, ?> options);
 
     boolean supportsCredential(final Credential credential);
 
-    boolean authenticate(final Credential credential);
+    boolean authenticate(final Credential credential, final SecurityContext securityContext);
 
 }

--- a/uberfire-security/uberfire-security-server/src/main/java/org/uberfire/security/server/auth/DefaultAuthenticationProvider.java
+++ b/uberfire-security/uberfire-security-server/src/main/java/org/uberfire/security/server/auth/DefaultAuthenticationProvider.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import org.uberfire.security.SecurityContext;
 import org.uberfire.security.auth.AuthenticationException;
 import org.uberfire.security.auth.AuthenticationProvider;
 import org.uberfire.security.auth.AuthenticationResult;
@@ -53,7 +54,7 @@ public class DefaultAuthenticationProvider implements AuthenticationProvider {
     }
 
     @Override
-    public AuthenticationResult authenticate( final Credential credential )
+    public AuthenticationResult authenticate( final Credential credential, final SecurityContext securityContext )
             throws AuthenticationException {
         if ( !supportsCredential( credential ) ) {
             return new AuthenticationResult() {
@@ -78,7 +79,7 @@ public class DefaultAuthenticationProvider implements AuthenticationProvider {
 
         final UserNameCredential realCredential = UserNameCredential.class.cast( credential );
 
-        if ( !authenticationSource.authenticate( realCredential ) ) {
+        if ( !authenticationSource.authenticate( realCredential, securityContext ) ) {
             return new AuthenticationResult() {
                 @Override
                 public List<String> getMessages() {

--- a/uberfire-security/uberfire-security-server/src/main/java/org/uberfire/security/server/auth/HttpAuthenticationManager.java
+++ b/uberfire-security/uberfire-security-server/src/main/java/org/uberfire/security/server/auth/HttpAuthenticationManager.java
@@ -127,7 +127,7 @@ public class HttpAuthenticationManager implements AuthenticationManager {
                 }
 
                 for ( final AuthenticationProvider authProvider : authProviders ) {
-                    final AuthenticationResult result = authProvider.authenticate( credential );
+                    final AuthenticationResult result = authProvider.authenticate( credential, context );
                     if ( result.getStatus().equals( FAILED ) ) {
                         authScheme.challengeClient( httpContext );
                         throw new AuthenticationException( "Invalid credentials." );

--- a/uberfire-security/uberfire-security-server/src/main/java/org/uberfire/security/server/auth/RememberMeCookieAuthProvider.java
+++ b/uberfire-security/uberfire-security-server/src/main/java/org/uberfire/security/server/auth/RememberMeCookieAuthProvider.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import org.uberfire.security.SecurityContext;
 import org.uberfire.security.auth.AuthenticationException;
 import org.uberfire.security.auth.AuthenticationProvider;
 import org.uberfire.security.auth.AuthenticationResult;
@@ -45,7 +46,7 @@ public class RememberMeCookieAuthProvider implements AuthenticationProvider {
     }
 
     @Override
-    public AuthenticationResult authenticate( final Credential credential ) throws AuthenticationException {
+    public AuthenticationResult authenticate( final Credential credential, final SecurityContext securityContext ) throws AuthenticationException {
 
         if ( !supportsCredential( credential ) ) {
             return new AuthenticationResult() {

--- a/uberfire-security/uberfire-security-server/src/main/java/org/uberfire/security/server/auth/source/AbstractDatabaseAuthSource.java
+++ b/uberfire-security/uberfire-security-server/src/main/java/org/uberfire/security/server/auth/source/AbstractDatabaseAuthSource.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.uberfire.security.Role;
+import org.uberfire.security.SecurityContext;
 import org.uberfire.security.auth.AuthenticationSource;
 import org.uberfire.security.auth.Credential;
 import org.uberfire.security.auth.Principal;
@@ -78,7 +79,7 @@ public abstract class AbstractDatabaseAuthSource implements AuthenticationSource
     }
 
     @Override
-    public boolean authenticate( final Credential credential ) {
+    public boolean authenticate( final Credential credential, final SecurityContext securityContext ) {
         final UsernamePasswordCredential usernamePasswd = checkInstanceOf( "credential", credential, UsernamePasswordCredential.class );
 
         Connection connection = null;

--- a/uberfire-security/uberfire-security-server/src/main/java/org/uberfire/security/server/auth/source/HttpServletRequestAuthenticationSource.java
+++ b/uberfire-security/uberfire-security-server/src/main/java/org/uberfire/security/server/auth/source/HttpServletRequestAuthenticationSource.java
@@ -5,9 +5,11 @@ import javax.security.jacc.PolicyContext;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 
+import org.uberfire.security.SecurityContext;
 import org.uberfire.security.auth.Credential;
 import org.uberfire.security.impl.auth.UserNameCredential;
 import org.uberfire.security.impl.auth.UsernamePasswordCredential;
+import org.uberfire.security.server.HttpSecurityContext;
 
 import static org.kie.commons.validation.Preconditions.*;
 
@@ -22,23 +24,23 @@ public class HttpServletRequestAuthenticationSource extends JACCAuthenticationSo
     }
 
     @Override
-    public boolean authenticate( final Credential credential ) {
+    public boolean authenticate( final Credential credential, final SecurityContext securityContext ) {
         try {
             final UserNameCredential userNameCredential = checkInstanceOf( "credential", credential, UserNameCredential.class );
             Subject subject = (Subject) PolicyContext.getContext( "javax.security.auth.Subject.container" );
             if ( subject != null ) {
-                return super.authenticate( credential );
+                return super.authenticate( credential, securityContext );
             }
 
             if ( userNameCredential instanceof UsernamePasswordCredential ) {
-                final HttpServletRequest request = (HttpServletRequest) PolicyContext.getContext( "javax.servlet.http.HttpServletRequest" );
+                final HttpServletRequest request = ((HttpSecurityContext) securityContext).getRequest();
                 try {
                     request.login( userNameCredential.getUserName(), ( (UsernamePasswordCredential) userNameCredential ).getPassword().toString() );
                 } catch ( final ServletException ex ) {
                     return false;
                 }
             }
-            return super.authenticate( credential );
+            return super.authenticate( credential, securityContext );
         } catch ( final Exception e ) {
             return false;
         }

--- a/uberfire-security/uberfire-security-server/src/main/java/org/uberfire/security/server/auth/source/JACCAuthenticationSource.java
+++ b/uberfire-security/uberfire-security-server/src/main/java/org/uberfire/security/server/auth/source/JACCAuthenticationSource.java
@@ -10,6 +10,7 @@ import javax.security.auth.Subject;
 import javax.security.jacc.PolicyContext;
 
 import org.uberfire.security.Role;
+import org.uberfire.security.SecurityContext;
 import org.uberfire.security.auth.AuthenticationSource;
 import org.uberfire.security.auth.Credential;
 import org.uberfire.security.auth.Principal;
@@ -42,7 +43,7 @@ public class JACCAuthenticationSource implements AuthenticationSource,
     }
 
     @Override
-    public boolean authenticate( Credential credential ) {
+    public boolean authenticate( Credential credential, final SecurityContext securityContext ) {
         final UserNameCredential userNameCredential = checkInstanceOf( "credential", credential, UserNameCredential.class );
         try {
             Subject subject = (Subject) PolicyContext.getContext( "javax.security.auth.Subject.container" );

--- a/uberfire-security/uberfire-security-server/src/main/java/org/uberfire/security/server/auth/source/PropertyUserSource.java
+++ b/uberfire-security/uberfire-security-server/src/main/java/org/uberfire/security/server/auth/source/PropertyUserSource.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import java.util.Properties;
 
 import org.uberfire.security.Role;
+import org.uberfire.security.SecurityContext;
 import org.uberfire.security.auth.AuthenticationSource;
 import org.uberfire.security.auth.Credential;
 import org.uberfire.security.auth.Principal;
@@ -101,7 +102,7 @@ public class PropertyUserSource implements AuthenticationSource,
     }
 
     @Override
-    public boolean authenticate( final Credential credential ) {
+    public boolean authenticate( final Credential credential, final SecurityContext securityContext ) {
         final UsernamePasswordCredential usernamePasswd = checkInstanceOf( "credential", credential, UsernamePasswordCredential.class );
 
         final Object pass = credentials.get( usernamePasswd.getUserName() );


### PR DESCRIPTION
...ror 401 - validation fails) in business central

Extended authentication to accept SecurityContext object as part of authenticate method to do not rely on PolicyContext to get hold of HttpServletRequest for BASIC authentication. PolicyContext is JACC specific and thus not always available for instance on servlet containers e.g. Tomcat. 
Moreover there is rather serious bug in JBoss AS7.1.1 and EAP 6.1 that removes HttpServletRequest handler from PolicyContext on application undeployment (any application) making BASIC auth failing due to missing HttpServletRequest in PolicyContext.

Some details about this bug can be found here: https://community.jboss.org/message/822388?tstart=0&_sscc=t
