### PR TITLE
Remove org.uberfire.security.server.authz.cdi.*Interceptor classes from uberfire-security-server beans.xml

### DIFF
--- a/uberfire-security/uberfire-security-server/src/main/resources/META-INF/beans.xml
+++ b/uberfire-security/uberfire-security-server/src/main/resources/META-INF/beans.xml
@@ -3,9 +3,4 @@
        xsi:schemaLocation="
           http://java.sun.com/xml/ns/javaee http://docs.jboss.org/cdi/beans_1_0.xsd">
 
-  <interceptors>
-    <class>org.uberfire.security.server.authz.cdi.RolesInterceptor</class>
-    <class>org.uberfire.security.server.authz.cdi.TraitInterceptor</class>
-  </interceptors>
-
 </beans>


### PR DESCRIPTION
The kie-wb-distribution-wars expect to have to list these in their own beans.xml, so that having a beans.xml in the uberfire-security-server causes problems (Weld sees 2 declarations, etc.. )

Regardless, I think it makes sense to let users decide whether or not to use the beans instead of mandating them to use them by including these lines in the beans.xml
