### PR TITLE
BZ-1079548 - KIE-WB does not honor added repository roles until restart

### DIFF
--- a/uberfire-api/src/main/java/org/uberfire/workbench/type/Cacheable.java
+++ b/uberfire-api/src/main/java/org/uberfire/workbench/type/Cacheable.java
@@ -1,0 +1,16 @@
+package org.uberfire.workbench.type;
+
+public interface Cacheable {
+
+    /**
+     * Instructs any component that would like to cache the object
+     * that in case it's already cached it should be refreshed inside the cache
+     * @return
+     */
+    boolean requiresRefresh();
+
+    /**
+     * Marks the instance as cached. It should be done by the last cache in chain
+     */
+    void markAsCached();
+}

--- a/uberfire-backend/uberfire-backend-api/src/main/java/org/uberfire/backend/organizationalunit/OrganizationalUnit.java
+++ b/uberfire-backend/uberfire-backend-api/src/main/java/org/uberfire/backend/organizationalunit/OrganizationalUnit.java
@@ -4,8 +4,9 @@ import java.util.Collection;
 
 import org.uberfire.backend.repositories.Repository;
 import org.uberfire.security.authz.RuntimeResource;
+import org.uberfire.workbench.type.Cacheable;
 
-public interface OrganizationalUnit extends RuntimeResource {
+public interface OrganizationalUnit extends RuntimeResource, Cacheable {
 
     String getName();
 

--- a/uberfire-backend/uberfire-backend-api/src/main/java/org/uberfire/backend/organizationalunit/impl/OrganizationalUnitImpl.java
+++ b/uberfire-backend/uberfire-backend-api/src/main/java/org/uberfire/backend/organizationalunit/impl/OrganizationalUnitImpl.java
@@ -16,6 +16,7 @@ public class OrganizationalUnitImpl implements OrganizationalUnit {
 
     private Collection<Repository> repositories = new ArrayList<Repository>();
     private Collection<String> roles = new ArrayList<String>();
+    private boolean requiresRefresh = true;
 
     public OrganizationalUnitImpl() {
     }
@@ -90,4 +91,14 @@ public class OrganizationalUnitImpl implements OrganizationalUnit {
               + ", roles=" + roles + "]";
     }
 
+
+    @Override
+    public void markAsCached() {
+        this.requiresRefresh = false;
+    }
+
+    @Override
+    public boolean requiresRefresh() {
+        return requiresRefresh;
+    }
 }

--- a/uberfire-backend/uberfire-backend-api/src/main/java/org/uberfire/backend/repositories/Repository.java
+++ b/uberfire-backend/uberfire-backend-api/src/main/java/org/uberfire/backend/repositories/Repository.java
@@ -5,8 +5,9 @@ import java.util.Map;
 
 import org.uberfire.backend.vfs.Path;
 import org.uberfire.security.authz.RuntimeResource;
+import org.uberfire.workbench.type.Cacheable;
 
-public interface Repository extends RuntimeResource {
+public interface Repository extends RuntimeResource, Cacheable {
 
     String getAlias();
 

--- a/uberfire-backend/uberfire-backend-api/src/main/java/org/uberfire/backend/repositories/impl/git/GitRepository.java
+++ b/uberfire-backend/uberfire-backend-api/src/main/java/org/uberfire/backend/repositories/impl/git/GitRepository.java
@@ -25,6 +25,8 @@ public class GitRepository implements Repository {
 
     private Collection<String> roles = new ArrayList<String>();
 
+    private boolean requiresRefresh = true;
+
     public GitRepository() {
     }
 
@@ -157,4 +159,14 @@ public class GitRepository implements Repository {
                 + ", publicURI=" + publicURIs + "]";
     }
 
+
+    @Override
+    public void markAsCached() {
+        this.requiresRefresh = false;
+    }
+
+    @Override
+    public boolean requiresRefresh() {
+        return requiresRefresh;
+    }
 }

--- a/uberfire-backend/uberfire-backend-server/src/main/java/org/uberfire/backend/server/config/ConfigurationServiceImpl.java
+++ b/uberfire-backend/uberfire-backend-server/src/main/java/org/uberfire/backend/server/config/ConfigurationServiceImpl.java
@@ -65,6 +65,12 @@ public class ConfigurationServiceImpl implements ConfigurationService {
 
     // monitor capabilities
     @Inject
+    @org.uberfire.backend.server.config.Repository
+    private Event<SystemRepositoryChangedEvent> repoChangedEvent;
+    @Inject
+    @OrgUnit
+    private Event<SystemRepositoryChangedEvent> orgUnitChangedEvent;
+    @Inject
     private Event<SystemRepositoryChangedEvent> changedEvent;
     private ExecutorService executorService;
     private CheckConfigurationUpdates configUpdates;
@@ -293,6 +299,11 @@ public class ConfigurationServiceImpl implements ConfigurationService {
                             localLastModifiedValue = currentValue;
                             // invalidate cached values as system repo has changed
                             configuration.clear();
+                            // notify first repository
+                            repoChangedEvent.fire( new SystemRepositoryChangedEvent() );
+                            // then org unit
+                            orgUnitChangedEvent.fire( new SystemRepositoryChangedEvent() );
+                            // lastly all others
                             changedEvent.fire( new SystemRepositoryChangedEvent() );
                         }
                     }

--- a/uberfire-backend/uberfire-backend-server/src/main/java/org/uberfire/backend/server/config/OrgUnit.java
+++ b/uberfire-backend/uberfire-backend-server/src/main/java/org/uberfire/backend/server/config/OrgUnit.java
@@ -1,0 +1,14 @@
+package org.uberfire.backend.server.config;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import javax.inject.Qualifier;
+
+@Qualifier
+@Target({ElementType.FIELD, ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface OrgUnit {
+
+}

--- a/uberfire-backend/uberfire-backend-server/src/main/java/org/uberfire/backend/server/config/Repository.java
+++ b/uberfire-backend/uberfire-backend-server/src/main/java/org/uberfire/backend/server/config/Repository.java
@@ -1,0 +1,14 @@
+package org.uberfire.backend.server.config;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import javax.inject.Qualifier;
+
+@Qualifier
+@Target({ElementType.FIELD, ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Repository {
+
+}

--- a/uberfire-backend/uberfire-backend-server/src/main/java/org/uberfire/backend/server/organizationalunit/OrganizationalUnitServiceImpl.java
+++ b/uberfire-backend/uberfire-backend-server/src/main/java/org/uberfire/backend/server/organizationalunit/OrganizationalUnitServiceImpl.java
@@ -22,6 +22,7 @@ import org.uberfire.backend.server.config.ConfigItem;
 import org.uberfire.backend.server.config.ConfigType;
 import org.uberfire.backend.server.config.ConfigurationFactory;
 import org.uberfire.backend.server.config.ConfigurationService;
+import org.uberfire.backend.server.config.OrgUnit;
 import org.uberfire.backend.server.config.SystemRepositoryChangedEvent;
 
 @Service
@@ -244,7 +245,7 @@ public class OrganizationalUnitServiceImpl implements OrganizationalUnitService 
 
     }
 
-    public void updateRegisteredOU(@Observes SystemRepositoryChangedEvent changedEvent) {
+    public void updateRegisteredOU(@Observes @OrgUnit SystemRepositoryChangedEvent changedEvent) {
         registeredOrganizationalUnits.clear();
         loadOrganizationalUnits();
     }

--- a/uberfire-backend/uberfire-backend-server/src/main/java/org/uberfire/backend/server/repositories/RepositoryServiceImpl.java
+++ b/uberfire-backend/uberfire-backend-server/src/main/java/org/uberfire/backend/server/repositories/RepositoryServiceImpl.java
@@ -322,7 +322,7 @@ public class RepositoryServiceImpl implements RepositoryService {
         return result;
     }
 
-    public void updateRegisteredRepositories(@Observes SystemRepositoryChangedEvent changedEvent) {
+    public void updateRegisteredRepositories(@Observes @org.uberfire.backend.server.config.Repository SystemRepositoryChangedEvent changedEvent) {
         configuredRepositories.clear();
         loadRepositories();
     }

--- a/uberfire-security/uberfire-security-api/src/main/java/org/uberfire/security/authz/AuthorizationResult.java
+++ b/uberfire-security/uberfire-security-api/src/main/java/org/uberfire/security/authz/AuthorizationResult.java
@@ -44,6 +44,11 @@ public interface AuthorizationResult {
         public int hashCode() {
             return 1;
         }
+
+        @Override
+        public String toString() {
+            return "ACCESS_GRANTED";
+        }
     };
 
     final AuthorizationResult ACCESS_ABSTAIN = new AuthorizationResult() {
@@ -72,6 +77,11 @@ public interface AuthorizationResult {
         public int hashCode() {
             return 0;
         }
+
+        @Override
+        public String toString() {
+            return "ACCESS_ABSTAIN";
+        }
     };
 
     final AuthorizationResult ACCESS_DENIED = new AuthorizationResult() {
@@ -99,6 +109,11 @@ public interface AuthorizationResult {
         @Override
         public int hashCode() {
             return -1;
+        }
+
+        @Override
+        public String toString() {
+            return "ACCESS_DENIED";
         }
     };
 

--- a/uberfire-security/uberfire-security-api/src/main/java/org/uberfire/security/impl/authz/RuntimeResourceManager.java
+++ b/uberfire-security/uberfire-security-api/src/main/java/org/uberfire/security/impl/authz/RuntimeResourceManager.java
@@ -27,6 +27,7 @@ import org.uberfire.security.ResourceManager;
 import org.uberfire.security.Role;
 import org.uberfire.security.authz.RuntimeResource;
 import org.uberfire.security.impl.RoleImpl;
+import org.uberfire.workbench.type.Cacheable;
 
 import static java.util.Collections.*;
 
@@ -35,10 +36,6 @@ public class RuntimeResourceManager implements ResourceManager {
     final Map<String, RuntimeRestriction> restrictions = new HashMap<String, RuntimeRestriction>();
 
     private RuntimeRestriction addResource( final RuntimeResource resource ) {
-
-        if ( restrictions.containsKey( resource.getSignatureId() ) ) {
-            return null;
-        }
 
         final RuntimeRestriction runtimeRestriction = new RuntimeRestriction( resource.getRoles(), resource.getTraits() );
         restrictions.put( resource.getSignatureId(), runtimeRestriction );
@@ -64,11 +61,16 @@ public class RuntimeResourceManager implements ResourceManager {
             throw new IllegalArgumentException( "Parameter named 'resource' is not instance of clazz 'RuntimeResource'!" );
         }
 
+        boolean refreshCache = false;
+        if (resource instanceof Cacheable) {
+            refreshCache = ((Cacheable) resource).requiresRefresh();
+        }
+
         final RuntimeResource runtimeResource = (RuntimeResource) resource;
 
         RuntimeRestriction restriction = restrictions.get( runtimeResource.getSignatureId() );
 
-        if ( restriction == null ) {
+        if ( restriction == null || refreshCache ) {
             restriction = addResource( runtimeResource );
         }
 

--- a/uberfire-security/uberfire-security-api/src/test/java/org/uberfire/security/impl/authz/RuntimeAuthorizationManagerTest.java
+++ b/uberfire-security/uberfire-security-api/src/test/java/org/uberfire/security/impl/authz/RuntimeAuthorizationManagerTest.java
@@ -1,0 +1,202 @@
+package org.uberfire.security.impl.authz;
+
+import static org.junit.Assert.*;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Test;
+import org.uberfire.security.Identity;
+import org.uberfire.security.Role;
+import org.uberfire.security.Subject;
+import org.uberfire.security.authz.RuntimeResource;
+import org.uberfire.security.impl.RoleImpl;
+import org.uberfire.workbench.type.Cacheable;
+
+public class RuntimeAuthorizationManagerTest {
+
+    @Test
+    public void testAuthorizeWithCacheRefreshOnRemoveAllRoles() {
+        RuntimeAuthorizationManager authorizationManager = new RuntimeAuthorizationManager();
+
+        RuntimeResource resource = new TestRuntimeResource("test1234", "author");
+        Subject john = new TestIdentity("john", "admin");
+        Subject mary = new TestIdentity("mary", "author");
+
+        assertTrue(resource instanceof Cacheable);
+        assertTrue(((Cacheable) resource).requiresRefresh());
+
+        boolean authorized = authorizationManager.authorize(resource, john);
+        assertFalse(authorized);
+        assertFalse(((Cacheable) resource).requiresRefresh());
+
+        authorized = authorizationManager.authorize(resource, mary);
+        assertTrue(authorized);
+        // now simulate remove of the roles for the resource
+        RuntimeResource resource2 = new TestRuntimeResource("test1234",  null);
+
+        assertTrue(((Cacheable) resource2).requiresRefresh());
+
+        authorized = authorizationManager.authorize(resource2, john);
+        assertTrue(authorized);
+
+        authorized = authorizationManager.authorize(resource2, mary);
+        assertTrue(authorized);
+    }
+
+    @Test
+    public void testAuthorizeWithCacheRefreshOnAddedRole() {
+        RuntimeAuthorizationManager authorizationManager = new RuntimeAuthorizationManager();
+
+        RuntimeResource resource = new TestRuntimeResource("test1234", "author");
+        Subject john = new TestIdentity("john", "admin");
+        Subject mary = new TestIdentity("mary", "author");
+
+        assertTrue(resource instanceof Cacheable);
+        assertTrue(((Cacheable) resource).requiresRefresh());
+
+        boolean authorized = authorizationManager.authorize(resource, john);
+        assertFalse(authorized);
+        assertFalse(((Cacheable) resource).requiresRefresh());
+
+        authorized = authorizationManager.authorize(resource, mary);
+        assertTrue(authorized);
+        // now simulate add of a role for the resource
+        RuntimeResource resource2 = new TestRuntimeResource("test1234",  "admin", "author");
+
+        assertTrue(((Cacheable) resource2).requiresRefresh());
+
+        authorized = authorizationManager.authorize(resource2, john);
+        assertTrue(authorized);
+        assertFalse(((Cacheable) resource2).requiresRefresh());
+
+        authorized = authorizationManager.authorize(resource2, mary);
+        assertTrue(authorized);
+    }
+
+    @Test
+    public void testAuthorizeWithCacheRefreshOnRemovedRole() {
+        RuntimeAuthorizationManager authorizationManager = new RuntimeAuthorizationManager();
+
+        RuntimeResource resource = new TestRuntimeResource("test1234", "admin", "author");
+        Subject john = new TestIdentity("john", "admin");
+        Subject mary = new TestIdentity("mary", "author");
+
+        assertTrue(resource instanceof Cacheable);
+        assertTrue(((Cacheable) resource).requiresRefresh());
+
+        boolean authorized = authorizationManager.authorize(resource, john);
+        assertTrue(authorized);
+        assertFalse(((Cacheable) resource).requiresRefresh());
+
+        authorized = authorizationManager.authorize(resource, mary);
+        assertTrue(authorized);
+        // now simulate remove of a role for the resource
+        RuntimeResource resource2 = new TestRuntimeResource("test1234", "author");
+
+        assertTrue(((Cacheable) resource2).requiresRefresh());
+
+        authorized = authorizationManager.authorize(resource2, john);
+        assertFalse(authorized);
+        assertFalse(((Cacheable) resource2).requiresRefresh());
+
+        authorized = authorizationManager.authorize(resource2, mary);
+        assertTrue(authorized);
+    }
+
+
+    private class TestRuntimeResource implements RuntimeResource, Cacheable {
+
+        private String signatureId;
+        private List<String> roles;
+        private boolean requiresRefresh = true;
+
+        protected TestRuntimeResource(String signatureId, String... roles) {
+            this.signatureId = signatureId;
+            if (roles != null) {
+                this.roles = Arrays.asList(roles);
+            } else {
+                this.roles = Collections.EMPTY_LIST;
+            }
+        }
+
+        @Override
+        public String getSignatureId() {
+            return this.signatureId;
+        }
+
+        @Override
+        public Collection<String> getRoles() {
+            return this.roles;
+        }
+
+        @Override
+        public Collection<String> getTraits() {
+            return Collections.emptySet();
+        }
+
+        @Override
+        public void markAsCached() {
+            this.requiresRefresh = false;
+        }
+
+        @Override
+        public boolean requiresRefresh() {
+            return requiresRefresh;
+        }
+    }
+
+    private class TestIdentity implements Identity {
+
+        private String name;
+        private List<Role> roles;
+
+        protected TestIdentity(String name, String... rolesIn) {
+            this.name = name;
+            this.roles = new ArrayList<Role>();
+
+            for (String role : rolesIn) {
+                roles.add(new RoleImpl(role));
+            }
+        }
+
+        @Override
+        public String getName() {
+            return name;
+        }
+
+        @Override
+        public List<Role> getRoles() {
+            return roles;
+        }
+
+        @Override
+        public boolean hasRole( Role role ) {
+            return roles.contains(role);
+        }
+
+        @Override
+        public Map<String, String> getProperties() {
+            return Collections.emptyMap();
+        }
+
+        @Override
+        public void aggregateProperty( String name,
+                String value ) {
+        }
+
+        @Override
+        public void removeProperty( String name ) {
+        }
+
+        @Override
+        public String getProperty( String name,
+                String defaultValue ) {
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
This change makes the auto refresh of org unit, repository information in case they were modified externally - like kie-config-cli tool, cluster synchronization (or manually by cloning the system repo). PR introduces two main changes:
1. explicit order of events when system repo has been changed so it will load up to date information - first repositories, then org units (as org units include repositories) and then all the rest like deployments
2. allows to refresh values in the cache in uf security layer by being marked as requiresRefresh - default to true after loading, then cache manager can mark is as cached 

will these changes when roles are modified externally or in cluster on one node the automatic refresh would take place securing the repository or org unit directly without the need to restart the server.
