### PR TITLE
Storing current perspective activity on panel manager to enable asking f...

### DIFF
--- a/uberfire-js/src/main/java/org/uberfire/client/JSWorkbenchPerspectiveActivity.java
+++ b/uberfire-js/src/main/java/org/uberfire/client/JSWorkbenchPerspectiveActivity.java
@@ -155,6 +155,7 @@ public class JSWorkbenchPerspectiveActivity implements PerspectiveActivity {
         onStartup( place );
 
         nativePerspective.getPanelManager().setPerspective( perspective );
+        nativePerspective.getPanelManager().setPerspectiveActivity( this );
 
         Set<PartDefinition> parts = nativePerspective.getPanelManager().getRoot().getParts();
         for ( PartDefinition part : parts ) {

--- a/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/mvp/AbstractWorkbenchPerspectiveActivity.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/mvp/AbstractWorkbenchPerspectiveActivity.java
@@ -133,6 +133,7 @@ public abstract class AbstractWorkbenchPerspectiveActivity extends AbstractActiv
     private void initialisePerspective( final PerspectiveDefinition perspective ) {
 
         panelManager.setPerspective( perspective );
+        panelManager.setPerspectiveActivity( this );
 
         Set<PartDefinition> parts = panelManager.getRoot().getParts();
         for ( PartDefinition part : parts ) {

--- a/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/AbstractPanelManagerImpl.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/AbstractPanelManagerImpl.java
@@ -63,6 +63,8 @@ public abstract class AbstractPanelManagerImpl implements PanelManager  {
 
     PerspectiveDefinition perspective;
 
+    PerspectiveActivity perspectiveActivity;
+
     Map<PartDefinition, WorkbenchPartPresenter> mapPartDefinitionToPresenter = new HashMap<PartDefinition, WorkbenchPartPresenter>();
 
     Map<PanelDefinition, WorkbenchPanelPresenter> mapPanelDefinitionToPresenter = new HashMap<PanelDefinition, WorkbenchPanelPresenter>();
@@ -101,6 +103,16 @@ public abstract class AbstractPanelManagerImpl implements PanelManager  {
             }
             container.setWidget( newPresenter.getPanelView() );
         }
+    }
+
+    @Override
+    public void setPerspectiveActivity(PerspectiveActivity perspectiveActivity) {
+        this.perspectiveActivity = perspectiveActivity;
+    }
+
+    @Override
+    public PerspectiveActivity getPerspectiveActivity() {
+        return perspectiveActivity;
     }
 
     protected abstract BeanFactory getBeanFactory();

--- a/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/PanelManager.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/PanelManager.java
@@ -17,6 +17,10 @@ import org.uberfire.workbench.model.menu.Menus;
  */
 public interface PanelManager {
 
+    PerspectiveActivity getPerspectiveActivity();
+
+    void setPerspectiveActivity(final PerspectiveActivity perspectiveActivity);
+
     PerspectiveDefinition getPerspective();
 
     void setPerspective( final PerspectiveDefinition perspective );


### PR DESCRIPTION
I found that the PerspectiveDeinition doesn't store a unique id. Sometimes is needed to check what's the current activity to show a Panel and the only way to check it is by the name (look at https://github.com/droolsjbpm/kie-wb-common/blob/master/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/main/java/org/kie/workbench/common/screens/projecteditor/client/messages/ProblemsService.java#L59), this can be a problem since the name usually is a i18n constant. 
I think that storing the current perspective activity can be usefull to check for a specific activity identifier.
