### PR TITLE
Fix for race condition in ThreadLockServiceImpl

### DIFF
--- a/uberfire-commons/src/main/java/org/uberfire/commons/lock/impl/ThreadLockServiceImpl.java
+++ b/uberfire-commons/src/main/java/org/uberfire/commons/lock/impl/ThreadLockServiceImpl.java
@@ -20,7 +20,7 @@ public class ThreadLockServiceImpl implements LockService {
     }
 
     @Override
-    public void lock() {
+    public synchronized void lock() {
         while ( holder.get() != null ) {
             if ( holder.get().equals( Thread.currentThread() ) ) {
                 stackSize.incrementAndGet();
@@ -36,7 +36,7 @@ public class ThreadLockServiceImpl implements LockService {
     }
 
     @Override
-    public void unlock() {
+    public synchronized void unlock() {
         int size = stackSize.decrementAndGet();
         if ( size == 0 ) {
             holder.set( null );


### PR DESCRIPTION
It looks to me like the following race-condition is possible in lines 23 - 35 of 
the ThreadLockSerivceImpl class.

Given that we're already using Atomic classes, adding a synchronized doesn't affect
performance at all, if that was a concern.

| Thread A | Thread B |
| --- | --- |
| calls `ThreadLockServiceImpl.lock()` |  |
|  | calls `ThreadLockServiceImpl.lock()` |
| `holder.get()` returns `null` |  |
|  | `holder.get()` returns `null` |
| `holder.set( Thread.currentThread() );` |  |
|  | `holder.set( Thread.currentThread() );` |
| `stackSize.set( 1 );` |  |
|  | `stackSize.set( 1 );` |
