### PR TITLE
use configurable auto responsive credentials provider for git server to ...

### DIFF
--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/main/java/org/uberfire/java/nio/fs/jgit/JGitFileSystemProvider.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/main/java/org/uberfire/java/nio/fs/jgit/JGitFileSystemProvider.java
@@ -61,7 +61,6 @@ import org.eclipse.jgit.transport.PreReceiveHook;
 import org.eclipse.jgit.transport.ReceiveCommand;
 import org.eclipse.jgit.transport.ReceivePack;
 import org.eclipse.jgit.transport.ServiceMayNotContinueException;
-import org.eclipse.jgit.transport.UsernamePasswordCredentialsProvider;
 import org.eclipse.jgit.transport.resolver.ReceivePackFactory;
 import org.eclipse.jgit.transport.resolver.RepositoryResolver;
 import org.eclipse.jgit.transport.resolver.ServiceNotAuthorizedException;
@@ -116,6 +115,7 @@ import org.uberfire.java.nio.fs.jgit.daemon.git.Daemon;
 import org.uberfire.java.nio.fs.jgit.daemon.git.DaemonClient;
 import org.uberfire.java.nio.fs.jgit.daemon.ssh.BaseGitCommand;
 import org.uberfire.java.nio.fs.jgit.daemon.ssh.GitSSHService;
+import org.uberfire.java.nio.fs.jgit.util.AutoAnsweredUsernamePasswordCredentialsProvider;
 import org.uberfire.java.nio.fs.jgit.util.CommitContent;
 import org.uberfire.java.nio.fs.jgit.util.CopyCommitContent;
 import org.uberfire.java.nio.fs.jgit.util.DefaultCommitContent;
@@ -351,7 +351,7 @@ public class JGitFileSystemProvider implements FileSystemProvider,
 
     public JGitFileSystemProvider() {
         loadConfig();
-        CredentialsProvider.setDefault( new UsernamePasswordCredentialsProvider( "guest", "" ) );
+        CredentialsProvider.setDefault( new AutoAnsweredUsernamePasswordCredentialsProvider( "guest", "" ) );
 
         if ( DAEMON_ENABLED ) {
             fullHostNames.put( "git", DAEMON_HOST_NAME + ":" + DAEMON_PORT );
@@ -1755,9 +1755,9 @@ public class JGitFileSystemProvider implements FileSystemProvider,
         if ( env != null ) {
             if ( env.containsKey( USER_NAME ) ) {
                 if ( env.containsKey( PASSWORD ) ) {
-                    return new UsernamePasswordCredentialsProvider( env.get( USER_NAME ).toString(), env.get( PASSWORD ).toString() );
+                    return new AutoAnsweredUsernamePasswordCredentialsProvider( env.get( USER_NAME ).toString(), env.get( PASSWORD ).toString() );
                 }
-                return new UsernamePasswordCredentialsProvider( env.get( USER_NAME ).toString(), "" );
+                return new AutoAnsweredUsernamePasswordCredentialsProvider( env.get( USER_NAME ).toString(), "" );
             }
         }
         return CredentialsProvider.getDefault();

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/main/java/org/uberfire/java/nio/fs/jgit/util/AutoAnsweredUsernamePasswordCredentialsProvider.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/main/java/org/uberfire/java/nio/fs/jgit/util/AutoAnsweredUsernamePasswordCredentialsProvider.java
@@ -1,0 +1,81 @@
+package org.uberfire.java.nio.fs.jgit.util;
+
+import org.eclipse.jgit.errors.UnsupportedCredentialItem;
+import org.eclipse.jgit.transport.CredentialItem;
+import org.eclipse.jgit.transport.URIish;
+import org.eclipse.jgit.transport.UsernamePasswordCredentialsProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Allows to directly respond to YesNo questions that might be issued by underlying transport provider.
+ * Example: when connecting to ssh server for the first time user is prompted to accept ssh key of given server
+ * In some cases (like async processing) users can't be involved in the decision thus administrator
+ * should have ability to control it globally as CredentialsProvider is set one for the JVM.
+ *
+ * By default it's configured to auto accept (answer Yes) but this can be altered by setting system property
+ * <code>org.uberfire.git.ssh.accept</code> to <code>false</code> to reject (answer No)
+ */
+public class AutoAnsweredUsernamePasswordCredentialsProvider extends UsernamePasswordCredentialsProvider {
+
+    private static final Logger logger = LoggerFactory.getLogger(AutoAnsweredUsernamePasswordCredentialsProvider.class);
+
+    private boolean accept = Boolean.parseBoolean(System.getProperty("org.uberfire.git.ssh.accept", "true"));
+
+    /**
+     * @inheritDoc
+     */
+    public AutoAnsweredUsernamePasswordCredentialsProvider(String username, String password) {
+        super(username, password);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public AutoAnsweredUsernamePasswordCredentialsProvider(String username, char[] password) {
+        super(username, password);
+    }
+
+    /**
+     * Same as <code>AutoAnsweredUsernamePasswordCredentialsProvider(String username, String password)</code> with addition
+     * to allow to explicitly set what should be the response to YesNo prompts
+     * @param username
+     * @param password
+     * @param accept
+     */
+    public AutoAnsweredUsernamePasswordCredentialsProvider(String username, String password, boolean accept) {
+        super(username, password);
+        this.accept = accept;
+    }
+
+    /**
+     * Same as <code>AutoAnsweredUsernamePasswordCredentialsProvider(String username, char[] password)</code> with addition
+     * to allow to explicitly set what should be the response to YesNo prompts
+     * @param username
+     * @param password
+     * @param accept
+     */
+    public AutoAnsweredUsernamePasswordCredentialsProvider(String username, char[] password, boolean accept) {
+        super(username, password);
+        this.accept = accept;
+    }
+
+    @Override
+    public boolean get(URIish uri, CredentialItem... items) throws UnsupportedCredentialItem {
+        try {
+            return super.get(uri, items);
+        } catch (UnsupportedCredentialItem e) {
+            for (CredentialItem i : items) {
+                if (i instanceof CredentialItem.YesNoType) {
+                    logger.debug("Auto answer to question '{}' with response {}", i.getPromptText(), accept);
+                    ((CredentialItem.YesNoType) i).setValue(accept);
+
+                    return true;
+                } else {
+                    continue;
+                }
+            }
+        }
+        return false;
+    }
+}

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/JGitFileSystemTest.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/JGitFileSystemTest.java
@@ -22,11 +22,11 @@ import java.io.IOException;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.transport.CredentialsProvider;
-import org.eclipse.jgit.transport.UsernamePasswordCredentialsProvider;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.uberfire.java.nio.file.FileStore;
 import org.uberfire.java.nio.file.Path;
+import org.uberfire.java.nio.fs.jgit.util.AutoAnsweredUsernamePasswordCredentialsProvider;
 
 import static org.fest.assertions.api.Assertions.*;
 import static org.mockito.Mockito.*;
@@ -34,7 +34,7 @@ import static org.mockito.Mockito.*;
 public class JGitFileSystemTest extends AbstractTestInfra {
 
     static {
-        CredentialsProvider.setDefault( new UsernamePasswordCredentialsProvider( "guest", "" ) );
+        CredentialsProvider.setDefault( new AutoAnsweredUsernamePasswordCredentialsProvider( "guest", "" ) );
     }
 
     @Test


### PR DESCRIPTION
...allow to be used in background tasks where user interaction is not possible

this pull request aims at providing configurable way of use of default credentials provided used by jgit when interacting with git server. This is a required step to allow to use git server from background threads where interaction with user is not possible so it does allow to directly accept ssh key for given host otherwise (current behavior) it will simply fail as user/system could not reposed properly to prompt issued by ssh server.
