### PR TITLE
NPE check was added in method  onShow( final TabPanel.ShowEvent e )

### DIFF
--- a/uberfire-widgets/uberfire-widgets-commons/src/main/java/org/uberfire/client/common/MultiPageEditorView.java
+++ b/uberfire-widgets/uberfire-widgets-commons/src/main/java/org/uberfire/client/common/MultiPageEditorView.java
@@ -65,9 +65,13 @@ public class MultiPageEditorView
             addShowHandler( new TabPanel.ShowEvent.Handler() {
                 @Override
                 public void onShow( final TabPanel.ShowEvent e ) {
-                    final Page.PageView widget = ( (Page.PageView) ( (LayoutPanel) e.getTarget().getTabPane().getWidget( 0 ) ).getWidget( 0 ) );
-                    scheduleResize( widget );
-                    widget.onFocus();
+                    try {
+                        final Page.PageView widget = ( (Page.PageView) ( (LayoutPanel) e.getTarget().getTabPane().getWidget( 0 ) ).getWidget( 0 ) );
+                        scheduleResize( widget );
+                        widget.onFocus();
+                    } catch ( final Exception ex ) {
+
+                    }
                 }
             } );
         }};


### PR DESCRIPTION
It was detected that in some use cases (for example when a new TabPanel was added to the original TabPanel) the method onShow( final TabPanel.ShowEvent e ) throws an NPE.
The fix basically adds the same tra/catch that already existed for the fist handler.
