### PR TITLE
User Management Editor: Move to mockito 1.1.4 to support CellTable tests

### DIFF
--- a/uberfire-parent-with-dependencies/pom.xml
+++ b/uberfire-parent-with-dependencies/pom.xml
@@ -90,7 +90,7 @@
     <version.org.jboss.ejb3.api>3.1.0</version.org.jboss.ejb3.api>
 
     <osgi.snapshot.qualifier>${maven.build.timestamp}</osgi.snapshot.qualifier>
-    <version.com.google.gwt.gwtmockito>1.1.3</version.com.google.gwt.gwtmockito>
+    <version.com.google.gwt.gwtmockito>1.1.4</version.com.google.gwt.gwtmockito>
   </properties>
 
   <!-- IMPORTANT: Do not declare any build configuration here! Declare it in kie-parent-metadata. -->

--- a/uberfire-widgets/uberfire-widgets-user-management/uberfire-widgets-user-management-client/src/test/java/org/uberfire/user/management/client/UserManagementWidgetTest.java
+++ b/uberfire-widgets/uberfire-widgets-user-management/uberfire-widgets-user-management-client/src/test/java/org/uberfire/user/management/client/UserManagementWidgetTest.java
@@ -29,7 +29,6 @@ import com.google.gwt.view.client.ListDataProvider;
 import com.google.gwtmockito.GwtMock;
 import com.google.gwtmockito.GwtMockitoTestRunner;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -99,7 +98,6 @@ public class UserManagementWidgetTest {
     }
 
     @Test
-    @Ignore("Requires gwtmockito 1.1.4-SNAPSHOT or later")
     public void verifyNewInstanceCreationSequenceHappyCase() {
         verify( table,
                 times( 2 ) ).addColumn( any( Column.class ),
@@ -119,7 +117,6 @@ public class UserManagementWidgetTest {
     }
 
     @Test
-    @Ignore("Requires gwtmockito 1.1.4-SNAPSHOT or later")
     public void verifySetContent() {
         final List<UserInformation> userInformation = Collections.EMPTY_LIST;
         final UserManagerCapabilities capabilities = new UserManagerCapabilities( true,
@@ -136,7 +133,6 @@ public class UserManagementWidgetTest {
     }
 
     @Test
-    @Ignore("Requires gwtmockito 1.1.4-SNAPSHOT or later")
     public void verifySetContentNotReadOnly() {
         final List<UserInformation> userInformation = Collections.EMPTY_LIST;
         final UserManagerCapabilities capabilities = new UserManagerCapabilities( true,
@@ -161,7 +157,6 @@ public class UserManagementWidgetTest {
     }
 
     @Test
-    @Ignore("Requires gwtmockito 1.1.4-SNAPSHOT or later")
     public void verifySetContentReadOnly() {
         final List<UserInformation> userInformation = Collections.EMPTY_LIST;
         final UserManagerCapabilities capabilities = new UserManagerCapabilities( true,
@@ -190,7 +185,6 @@ public class UserManagementWidgetTest {
     }
 
     @Test
-    @Ignore("Requires gwtmockito 1.1.4-SNAPSHOT or later")
     public void verifySetContentIsAddUserSupportedIsFalse() {
         final List<UserInformation> userInformation = Collections.EMPTY_LIST;
         final UserManagerCapabilities capabilities = new UserManagerCapabilities( false,
@@ -216,7 +210,6 @@ public class UserManagementWidgetTest {
     }
 
     @Test
-    @Ignore("Requires gwtmockito 1.1.4-SNAPSHOT or later")
     public void verifySetContentIsUpdateUserPasswordSupportedIsFalse() {
         final List<UserInformation> userInformation = Collections.EMPTY_LIST;
         final UserManagerCapabilities capabilities = new UserManagerCapabilities( true,
@@ -242,7 +235,6 @@ public class UserManagementWidgetTest {
     }
 
     @Test
-    @Ignore("Requires gwtmockito 1.1.4-SNAPSHOT or later")
     public void verifySetContentIsDeleteUserSupportedIsFalse() {
         final List<UserInformation> userInformation = Collections.EMPTY_LIST;
         final UserManagerCapabilities capabilities = new UserManagerCapabilities( true,
@@ -268,7 +260,6 @@ public class UserManagementWidgetTest {
     }
 
     @Test
-    @Ignore("Requires gwtmockito 1.1.4-SNAPSHOT or later")
     public void verifySetContentIsUpdateUserRolesSupportedIsFalse() {
         final List<UserInformation> userInformation = Collections.EMPTY_LIST;
         final UserManagerCapabilities capabilities = new UserManagerCapabilities( true,


### PR DESCRIPTION
Mockito 1.1.4 released :)

Dependency Management version updated and tests, erm, un-@Ignored.
