### PR TITLE
Use uberfire.version property to define version of uberfire-bom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,7 @@
   </licenses>
 
   <properties>
+    <uberfire.version>${project.version}</uberfire.version>
     <!-- IMPORTANT: Do not declare any external dependencies versions here! Declare them in kie-parent-with-dependencies. -->
     <!-- Make build platform independent -->
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/uberfire-parent-with-dependencies/pom.xml
+++ b/uberfire-parent-with-dependencies/pom.xml
@@ -110,7 +110,12 @@
         <groupId>org.uberfire</groupId>
         <artifactId>uberfire-bom</artifactId>
         <type>pom</type>
-        <version>${project.version}</version>
+        <!-- Using ${uberfire.version} instead of ${project.version} enables easier way to create hot fixes
+             (one-off patches). This pom is a parent for all uberfire modules, so when version is changed in
+             one of them, the ${project.version} property changes too and therefore also required version of
+             uberfire-bom. Usage of  this property makes it possible to change version of the (sub)module
+             and still use the original version of uberfire-bom. -->
+        <version>${uberfire.version}</version>
         <scope>import</scope>
       </dependency>
 


### PR DESCRIPTION
I tried to capture the need for this change in the comment in ubefire-parent-with-deps/pom.xml. It is a bit tricky issue to explain, so in case something is not clear, please let me know and I can answer your questions.

Would it be possible to forward port this also into master, so we don't have to deal with this problem in future, when using more recent version of uberfire?
