### PR TITLE
- exposing cached activities by id

### DIFF
--- a/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/mvp/ActivityBeansCache.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/mvp/ActivityBeansCache.java
@@ -182,6 +182,10 @@ public class ActivityBeansCache {
         return ActivityMetaInfo.generate( activityBean );
     }
 
+    public List<String> getActivitiesById() {
+      return new ArrayList<String>(activitiesById.keySet());
+    }
+
     class ActivityAndMetaInfo {
 
         private final IOCBeanDef<Activity> activityBean;


### PR DESCRIPTION
This is required to access to all the activities available from external services. I've checked with @manstis about the use case and he was ok with it. I do required this for the bpms project. If you guys think that there is another/better way to do it please let me know. 
