### PR TITLE
UF-137: an explicit overload for start batch method in order to support ...

### DIFF
--- a/uberfire-io/src/main/java/org/uberfire/io/IOService.java
+++ b/uberfire-io/src/main/java/org/uberfire/io/IOService.java
@@ -57,17 +57,19 @@ public interface IOService {
 
     void dispose();
 
-    void startBatch( FileSystem[] fs,
+    void startBatch( final FileSystem fs ) throws InterruptedException;
+
+    void startBatch( final FileSystem[] fs,
                      final Option... options ) throws InterruptedException;
 
-    public void startBatch( FileSystem fs,
-                            final Option... options ) throws InterruptedException;
+    void startBatch( final FileSystem fs,
+                     final Option... options ) throws InterruptedException;
 
-    public void startBatch( final FileSystem... fs ) throws InterruptedException;
+    void startBatch( final FileSystem... fs ) throws InterruptedException;
 
     void endBatch();
 
-    FileAttribute<?>[] convert( Map<String, ?> attrs );
+    FileAttribute<?>[] convert( final Map<String, ?> attrs );
 
     Path get( final String first,
               final String... more )

--- a/uberfire-io/src/main/java/org/uberfire/io/impl/AbstractIOService.java
+++ b/uberfire-io/src/main/java/org/uberfire/io/impl/AbstractIOService.java
@@ -131,6 +131,11 @@ public abstract class AbstractIOService implements IOServiceIdentifiable {
     }
 
     @Override
+    public void startBatch( FileSystem fs ) throws InterruptedException {
+        batchProcess( new FileSystem[]{ fs } );
+    }
+
+    @Override
     public void startBatch( FileSystem fs,
                             final Option... options ) throws InterruptedException {
         batchProcess( new FileSystem[]{ fs }, options );

--- a/uberfire-io/src/main/java/org/uberfire/io/impl/cluster/IOServiceClusterImpl.java
+++ b/uberfire-io/src/main/java/org/uberfire/io/impl/cluster/IOServiceClusterImpl.java
@@ -1,9 +1,5 @@
 package org.uberfire.io.impl.cluster;
 
-import static org.uberfire.commons.validation.PortablePreconditions.*;
-import static org.uberfire.commons.validation.Preconditions.*;
-import static org.uberfire.io.impl.cluster.ClusterMessageType.*;
-
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.InputStream;
@@ -61,6 +57,7 @@ import org.uberfire.java.nio.file.attribute.FileAttribute;
 import org.uberfire.java.nio.file.attribute.FileAttributeView;
 import org.uberfire.java.nio.file.attribute.FileTime;
 
+import static org.uberfire.commons.validation.PortablePreconditions.checkNotNull;
 import static org.uberfire.commons.validation.Preconditions.*;
 import static org.uberfire.io.impl.cluster.ClusterMessageType.*;
 
@@ -212,6 +209,11 @@ public class IOServiceClusterImpl implements IOClusteredService {
     public void dispose() {
         clusterService.dispose();
         service.dispose();
+    }
+
+    @Override
+    public void startBatch( FileSystem fs ) throws InterruptedException {
+        startBatch( new FileSystem[]{ fs } );
     }
 
     @Override


### PR DESCRIPTION
...a single file system as parameter, otherwise java compiler can't resolve between `startBatch( final FileSystem... fs )` and `startBatch( FileSystem fs, final Option... options )`
