### PR TITLE
BZ-1126497 - kie-config-cli: problems connecting in on-line mode

### DIFF
--- a/uberfire-backend/uberfire-backend-server/src/main/java/org/uberfire/backend/server/security/FileSystemResourceAdaptor.java
+++ b/uberfire-backend/uberfire-backend-server/src/main/java/org/uberfire/backend/server/security/FileSystemResourceAdaptor.java
@@ -1,9 +1,14 @@
 package org.uberfire.backend.server.security;
 
+import java.util.Collection;
+import java.util.Collections;
+
+import org.uberfire.java.nio.base.FileSystemId;
 import org.uberfire.java.nio.file.FileSystem;
 import org.uberfire.security.Resource;
+import org.uberfire.security.authz.RuntimeResource;
 
-public class FileSystemResourceAdaptor implements Resource {
+public class FileSystemResourceAdaptor implements RuntimeResource {
 
     private final FileSystem fileSystem;
 
@@ -13,5 +18,24 @@ public class FileSystemResourceAdaptor implements Resource {
 
     public FileSystem getFileSystem() {
         return fileSystem;
+    }
+
+    @Override
+    public String getSignatureId() {
+        if (fileSystem instanceof FileSystemId) {
+            return ((FileSystemId) fileSystem).id();
+        }
+        return fileSystem.toString();
+    }
+
+    @Override
+    public Collection<String> getRoles() {
+
+        return Collections.emptyList();
+    }
+
+    @Override
+    public Collection<String> getTraits() {
+        return Collections.emptyList();
     }
 }

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/main/java/org/uberfire/java/nio/fs/jgit/daemon/ssh/GitSSHService.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/main/java/org/uberfire/java/nio/fs/jgit/daemon/ssh/GitSSHService.java
@@ -43,9 +43,9 @@ public class GitSSHService {
         sshd.setCommandFactory( new CommandFactory() {
             public Command createCommand( String command ) {
                 if ( command.startsWith( "git-upload-pack" ) ) {
-                    return new GitUploadCommand( command, repositoryResolver, authorizationManager );
+                    return new GitUploadCommand( command, repositoryResolver, getAuthorizationManager() );
                 } else if ( command.startsWith( "git-receive-pack" ) ) {
-                    return new GitReceiveCommand( command, repositoryResolver, authorizationManager, receivePackFactory );
+                    return new GitReceiveCommand( command, repositoryResolver, getAuthorizationManager(), receivePackFactory );
                 } else {
                     return new UnknownCommand( command );
                 }
@@ -56,7 +56,7 @@ public class GitSSHService {
             public boolean authenticate( final String username,
                                          final String password,
                                          final ServerSession session ) {
-                return userPassAuthenticator.authenticate( username, password, new Session() {
+                return getUserPassAuthenticator().authenticate( username, password, new Session() {
                     @Override
                     public void setSubject( final Subject value ) {
                         session.setAttribute( BaseGitCommand.SUBJECT_KEY, value );


### PR DESCRIPTION
fixes to allow to use git ssh service from both regular git clients and kie-config-cli tool. Currently authorization will not be performed as there is no way to pass roles required for given repository/filesystem as Repository was moved out from UF and now it's part of Guvnor. Though I believe it would make sense to allow to set roles on FileSystem as well so access to it could be enforced.
