### PR TITLE
BZ-1164738 - EJB invocation issues thrown when working with the product

### DIFF
--- a/uberfire-commons/src/main/java/org/uberfire/commons/async/SimpleAsyncExecutorService.java
+++ b/uberfire-commons/src/main/java/org/uberfire/commons/async/SimpleAsyncExecutorService.java
@@ -11,6 +11,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import javax.ejb.Asynchronous;
+import javax.ejb.Lock;
+import javax.ejb.LockType;
 import javax.ejb.Singleton;
 import javax.ejb.Startup;
 import javax.ejb.TransactionAttribute;
@@ -91,6 +93,7 @@ public class SimpleAsyncExecutorService {
     }
 
     @Asynchronous
+    @Lock(LockType.READ)
     public void execute( final Runnable r ) {
         if ( executorService != null ) {
             jobs.add( executorService.submit( r ) );


### PR DESCRIPTION
This in one of three commits (various repositories) to resolve EAP issue with asynchronous ejb methods:

``` plain
Invocation failed on component SimpleAsyncExecutorService for method public void 
org.uberfire.commons.async.SimpleAsyncExecutorService.execute(java.lang.Runnable): 
javax.ejb.ConcurrentAccessTimeoutException: JBAS014373: EJB 3.1 PFD2 4.8.5.5.1 concurrent access 
timeout on org.jboss.invocation.InterceptorContext$Invocation@755032d4 - could not obtain lock within 
5000MILLISECONDS
```

There are several BZ for bpms/brms and this might affect actual indexation of file systems in case it fails - usually bigger filesystem that indexation takes more than 5 seconds.

P.S.
I believe (once approved) it needs to be back ported to 0.5.x branch as well.
