### PR TITLE
Fix failing tests + make Git tests more robust

### DIFF
--- a/uberfire-io/src/test/java/org/uberfire/io/attribute/DotFileAttrViewTest.java
+++ b/uberfire-io/src/test/java/org/uberfire/io/attribute/DotFileAttrViewTest.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.commons.io.FileUtils;
+import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -144,6 +145,12 @@ public class DotFileAttrViewTest {
                 created = true;
             }
         }
+    }
+
+    @After
+    public void tearDown() {
+        // dispose the IOService or it will badly influence the tests executed after
+        ioService.dispose();
     }
 
     @AfterClass

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/JGitFileSystemProviderEncodingTest.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/JGitFileSystemProviderEncodingTest.java
@@ -30,6 +30,18 @@ import org.uberfire.java.nio.file.FileSystem;
 
 public class JGitFileSystemProviderEncodingTest extends AbstractTestInfra {
 
+    private int gitDaemonPort;
+
+    @Override
+    public Map<String, String> getGitPreferences() {
+        Map<String, String> gitPrefs = super.getGitPreferences();
+        gitPrefs.put("org.uberfire.nio.git.daemon.enabled", "true");
+        // use different port for every test -> easy to run tests in parallel
+        gitDaemonPort = findFreePort();
+        gitPrefs.put("org.uberfire.nio.git.daemon.port", String.valueOf(gitDaemonPort));
+        return gitPrefs;
+    }
+
     @Test
     public void test() throws IOException {
         final URI originRepo = URI.create( "git://encoding-origin-name" );
@@ -53,7 +65,7 @@ public class JGitFileSystemProviderEncodingTest extends AbstractTestInfra {
         final URI newRepo = URI.create( "git://my-encoding-repo-name" );
 
         final Map<String, Object> env = new HashMap<String, Object>() {{
-            put( JGitFileSystemProvider.GIT_ENV_KEY_DEFAULT_REMOTE_NAME, "git://localhost:9418/encoding-origin-name" );
+            put( JGitFileSystemProvider.GIT_ENV_KEY_DEFAULT_REMOTE_NAME, "git://localhost:" + gitDaemonPort + "/encoding-origin-name" );
             put( "listMode", "ALL" );
         }};
 

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/JGitFileSystemProviderTest.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/JGitFileSystemProviderTest.java
@@ -63,6 +63,17 @@ import static org.uberfire.java.nio.fs.jgit.util.JGitUtil.*;
 
 public class JGitFileSystemProviderTest extends AbstractTestInfra {
 
+    private int gitDaemonPort;
+
+    @Override
+    public Map<String, String> getGitPreferences() {
+        Map<String, String> gitPrefs = super.getGitPreferences();
+        gitPrefs.put("org.uberfire.nio.git.daemon.enabled", "true");
+        gitDaemonPort = findFreePort();
+        gitPrefs.put("org.uberfire.nio.git.daemon.port", String.valueOf(gitDaemonPort));
+        return gitPrefs;
+    }
+
     @Test
     @Ignore
     public void testDaemob() throws InterruptedException {
@@ -162,7 +173,7 @@ public class JGitFileSystemProviderTest extends AbstractTestInfra {
         final URI newRepo = URI.create( "git://my-repo-name" );
 
         final Map<String, Object> env = new HashMap<String, Object>() {{
-            put( JGitFileSystemProvider.GIT_ENV_KEY_DEFAULT_REMOTE_NAME, "git://localhost:9418/my-simple-test-origin-name" );
+            put( JGitFileSystemProvider.GIT_ENV_KEY_DEFAULT_REMOTE_NAME, "git://localhost:" + gitDaemonPort + "/my-simple-test-origin-name" );
             put( "listMode", "ALL" );
         }};
 
@@ -178,7 +189,7 @@ public class JGitFileSystemProviderTest extends AbstractTestInfra {
             put( "fileXXXXX.txt", tempFile( "temp" ) );
         }} );
 
-        provider.getFileSystem( URI.create( "git://my-repo-name?sync=git://localhost:9418/my-simple-test-origin-name&force" ) );
+        provider.getFileSystem( URI.create( "git://my-repo-name?sync=git://localhost:" + gitDaemonPort + "/my-simple-test-origin-name&force" ) );
 
         assertThat( fs ).isNotNull();
 
@@ -198,7 +209,7 @@ public class JGitFileSystemProviderTest extends AbstractTestInfra {
             put( "fileYYYY.txt", tempFile( "tempYYYY" ) );
         }} );
 
-        provider.getFileSystem( URI.create( "git://my-repo-name?sync=git://localhost:9418/my-simple-test-origin-name&force" ) );
+        provider.getFileSystem( URI.create( "git://my-repo-name?sync=git://localhost:" + gitDaemonPort + "/my-simple-test-origin-name&force" ) );
 
         assertThat( fs.getRootDirectories() ).hasSize( 3 );
 
@@ -229,7 +240,7 @@ public class JGitFileSystemProviderTest extends AbstractTestInfra {
         final URI newRepo = URI.create( "git://my-repo" );
 
         final Map<String, Object> env = new HashMap<String, Object>() {{
-            put( JGitFileSystemProvider.GIT_ENV_KEY_DEFAULT_REMOTE_NAME, "git://localhost:9418/my-simple-test-origin-repo" );
+            put( JGitFileSystemProvider.GIT_ENV_KEY_DEFAULT_REMOTE_NAME, "git://localhost:" + gitDaemonPort + "/my-simple-test-origin-repo" );
             put( "listMode", "ALL" );
         }};
 
@@ -248,7 +259,7 @@ public class JGitFileSystemProviderTest extends AbstractTestInfra {
         final URI newRepo2 = URI.create( "git://my-repo2" );
 
         final Map<String, Object> env2 = new HashMap<String, Object>() {{
-            put( JGitFileSystemProvider.GIT_ENV_KEY_DEFAULT_REMOTE_NAME, "git://localhost:9418/my-simple-test-origin-repo" );
+            put( JGitFileSystemProvider.GIT_ENV_KEY_DEFAULT_REMOTE_NAME, "git://localhost:" + gitDaemonPort + "/my-simple-test-origin-repo" );
             put( "listMode", "ALL" );
         }};
 
@@ -258,7 +269,7 @@ public class JGitFileSystemProviderTest extends AbstractTestInfra {
             put( "file1UserBranch.txt", tempFile( "tempX" ) );
         }} );
 
-        provider.getFileSystem( URI.create( "git://my-repo2?sync=git://localhost:9418/my-simple-test-origin-repo&force" ) );
+        provider.getFileSystem(URI.create( "git://my-repo2?sync=git://localhost:" + gitDaemonPort + "/my-simple-test-origin-repo&force" ) );
 
         assertThat( fs2.getRootDirectories() ).hasSize( 5 );
 
@@ -293,7 +304,7 @@ public class JGitFileSystemProviderTest extends AbstractTestInfra {
             put( "file2UserBranch.txt", tempFile( "tempX" ) );
         }} );
 
-        provider.getFileSystem( URI.create( "git://my-repo2?sync=git://localhost:9418/my-simple-test-origin-repo&force" ) );
+        provider.getFileSystem( URI.create( "git://my-repo2?sync=git://localhost:" + gitDaemonPort + "/my-simple-test-origin-repo&force" ) );
 
         assertThat( fs2.getRootDirectories() ).hasSize( 7 );
 

--- a/uberfire-workbench/uberfire-workbench-client/src/test/java/org/uberfire/client/mvp/PlaceRequestHistoryMapperImplTest.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/test/java/org/uberfire/client/mvp/PlaceRequestHistoryMapperImplTest.java
@@ -29,7 +29,9 @@ public class PlaceRequestHistoryMapperImplTest {
     private PlaceRequestHistoryMapperImpl placeRequestHistoryMapper;
 
     @BeforeClass
-    public static void registerBean() {
+    public static void setupBeans() {
+        IOC.getBeanManager().destroyAllBeans();
+
         final ObservablePath opath = new ObservablePathImpl();
 
         IOC.getBeanManager().registerBean( new IOCBeanDef<ObservablePath>() {


### PR DESCRIPTION
 * the tests were failing just when executed directly
   using Maven (running from IDE was OK). However,
   the clean-up should be done anyway.
 * the Git tests are using random new port every
   time. This makes them more robust in case there
   is rogue process listeting on the default port

I think it makes sense to cherry-pick the fixes also into master and 0.6.x.