### PR TITLE
 UF-173 : VersionRecords that have the same timestamp are in the wrong order

### DIFF
--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/main/java/org/uberfire/java/nio/fs/jgit/util/JGitUtil.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/main/java/org/uberfire/java/nio/fs/jgit/util/JGitUtil.java
@@ -1007,14 +1007,6 @@ public final class JGitUtil {
 
         Collections.reverse( records );
 
-        Collections.sort( records, new Comparator<VersionRecord>() {
-            @Override
-            public int compare( final VersionRecord o1,
-                                final VersionRecord o2 ) {
-                return o1.date().compareTo( o2.date() );
-            }
-        } );
-
         return new VersionAttributes() {
             @Override
             public VersionHistory history() {

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/main/java/org/uberfire/java/nio/fs/jgit/util/JGitUtil.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/main/java/org/uberfire/java/nio/fs/jgit/util/JGitUtil.java
@@ -1005,6 +1005,8 @@ public final class JGitUtil {
             }
         }
 
+        Collections.reverse( records );
+
         Collections.sort( records, new Comparator<VersionRecord>() {
             @Override
             public int compare( final VersionRecord o1,

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/JGitUtilTest.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/JGitUtilTest.java
@@ -19,14 +19,19 @@ package org.uberfire.java.nio.fs.jgit;
 import java.io.File;
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.List;
 
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.transport.CredentialsProvider;
 import org.junit.Test;
+import org.uberfire.java.nio.base.version.VersionAttributes;
+import org.uberfire.java.nio.base.version.VersionRecord;
 import org.uberfire.java.nio.fs.jgit.util.JGitUtil;
 
 import static org.eclipse.jgit.api.ListBranchCommand.ListMode.*;
-import static org.fest.assertions.api.Assertions.*;
+import static org.fest.assertions.api.Assertions.assertThat;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
 import static org.uberfire.java.nio.fs.jgit.util.JGitUtil.PathType.*;
 import static org.uberfire.java.nio.fs.jgit.util.JGitUtil.*;
 
@@ -129,4 +134,37 @@ public class JGitUtilTest extends AbstractTestInfra {
         assertThat( JGitUtil.checkPath( git, "master", "path/to" ).getK1() ).isEqualTo( DIRECTORY );
     }
 
+    @Test
+    public void testBuildVersionAttributes() throws Exception {
+
+        final File parentFolder = createTempDirectory();
+        final File gitFolder = new File(parentFolder, "mytest.git");
+
+        final Git git = JGitUtil.newRepository(gitFolder, true);
+
+        commit(git, "master", "name", "name@example.com", "commit 1", null, null, false, new HashMap<String, File>() {{
+            put("path/to/file2.txt", tempFile("who"));
+        }});
+        commit(git, "master", "name", "name@example.com", "commit 2", null, null, false, new HashMap<String, File>() {{
+            put("path/to/file2.txt", tempFile("you"));
+        }});
+        commit(git, "master", "name", "name@example.com", "commit 3", null, null, false, new HashMap<String, File>() {{
+            put("path/to/file2.txt", tempFile("gonna"));
+        }});
+        commit(git, "master", "name", "name@example.com", "commit 4", null, null, false, new HashMap<String, File>() {{
+            put("path/to/file2.txt", tempFile("call?"));
+        }});
+
+        JGitFileSystem jGitFileSystem = mock(JGitFileSystem.class);
+        when(jGitFileSystem.gitRepo()).thenReturn(git);
+
+        VersionAttributes versionAttributes = JGitUtil.buildVersionAttributes(jGitFileSystem, "master", "path/to/file2.txt");
+
+        List<VersionRecord> records = versionAttributes.history().records();
+        assertEquals("commit 1", records.get(0).comment());
+        assertEquals("commit 2", records.get(1).comment());
+        assertEquals("commit 3", records.get(2).comment());
+        assertEquals("commit 4", records.get(3).comment());
+
+    }
 }


### PR DESCRIPTION
Removed the Collections.sort that did not do the trick if the commits were committed at the same millisecond.
Added Collections.reverse since the list of VersionRecords is just in a reverse order.