### PR TITLE
BZ-1221380: remove use of cookies (that have 4k limit) what, depending

### DIFF
--- a/uberfire-docs/src/main/asciidoc/tutorial.asciidoc
+++ b/uberfire-docs/src/main/asciidoc/tutorial.asciidoc
@@ -1182,7 +1182,7 @@ as a "classpath entry of interest to Errai".
 # https://github.com/errai/errai/blob/master/errai-docs/src/main/asciidoc/reference.asciidoc#erraiappproperties
 # for details.
 
-errai.security.user_cookie_enabled=true
+errai.security.user_on_hostpage_enabled=true
 ------
 
 Since we want Errai's client-side security system to pay attention to

--- a/uberfire-showcase/uberfire-webapp/src/main/resources/ErraiApp.properties
+++ b/uberfire-showcase/uberfire-webapp/src/main/resources/ErraiApp.properties
@@ -31,4 +31,4 @@
 # https://docs.jboss.org/author/display/ERRAI/ErraiApp.properties
 # for details.
 
-errai.security.user_cookie_enabled=true
+errai.security.user_on_hostpage_enabled=true

--- a/uberfire-showcase/uberfire-webapp/src/main/webapp/WEB-INF/web.xml
+++ b/uberfire-showcase/uberfire-webapp/src/main/webapp/WEB-INF/web.xml
@@ -43,6 +43,16 @@
     <url-pattern>*.erraiBus</url-pattern>
   </filter-mapping>
 
+  <filter>
+    <filter-name>Host Page Patch</filter-name>
+    <filter-class>org.jboss.errai.security.server.servlet.UserHostPageFilter</filter-class>
+  </filter>
+
+  <filter-mapping>
+    <filter-name>Host Page Patch</filter-name>
+    <url-pattern>/showcase.html</url-pattern>
+  </filter-mapping>
+
   <servlet>
     <servlet-name>GoogleGadget</servlet-name>
     <servlet-class>org.uberfire.backend.server.impl.GoogleGadgetServlet</servlet-class>

--- a/uberfire-workbench/uberfire-workbench-client-tests/src/main/resources/ErraiApp.properties
+++ b/uberfire-workbench/uberfire-workbench-client-tests/src/main/resources/ErraiApp.properties
@@ -31,5 +31,5 @@
 # https://docs.jboss.org/author/display/ERRAI/ErraiApp.properties
 # for details.
 
-errai.security.user_cookie_enabled=true
+errai.security.user_on_hostpage_enabled=true
 errai.ioc.enabled.alternatives=org.uberfire.wbtest.client.config.WorkbenchServicesProxySessionImpl


### PR DESCRIPTION
of the number of roles/groups of a user, can be reached. new solution
`patches` the host page (UserHostPageFilter) with user's info that now
is supported on errai client security.