### PR TITLE
[BZ-1207318] change package name for copied the Apache commons-io classes

### DIFF
--- a/uberfire-nio2-backport/uberfire-nio2-model/src/main/java/org/uberfire/apache/commons/io/FilenameUtils.java
+++ b/uberfire-nio2-backport/uberfire-nio2-model/src/main/java/org/uberfire/apache/commons/io/FilenameUtils.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.commons.io;
+package org.uberfire.apache.commons.io;
 
 import java.io.File;
 import java.io.IOException;

--- a/uberfire-nio2-backport/uberfire-nio2-model/src/main/java/org/uberfire/apache/commons/io/IOCase.java
+++ b/uberfire-nio2-backport/uberfire-nio2-model/src/main/java/org/uberfire/apache/commons/io/IOCase.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.commons.io;
+package org.uberfire.apache.commons.io;
 
 import java.io.Serializable;
 

--- a/uberfire-nio2-backport/uberfire-nio2-model/src/main/java/org/uberfire/java/nio/base/AbstractPath.java
+++ b/uberfire-nio2-backport/uberfire-nio2-model/src/main/java/org/uberfire/java/nio/base/AbstractPath.java
@@ -29,7 +29,7 @@ import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.regex.Pattern;
 
-import org.apache.commons.io.FilenameUtils;
+import org.uberfire.apache.commons.io.FilenameUtils;
 import org.uberfire.commons.data.Pair;
 import org.uberfire.java.nio.EncodingUtil;
 import org.uberfire.java.nio.IOException;


### PR DESCRIPTION
 * the classes are basically the same as in commons-io jar,
   so adding the commons-io dependency should be transparent
   for users of the nio2-model