### PR TITLE
Upgrade Helix from 0.6.2-incubating to 0.6.5

### DIFF
--- a/uberfire-parent-with-dependencies/pom.xml
+++ b/uberfire-parent-with-dependencies/pom.xml
@@ -84,7 +84,7 @@
     <version.org.hamcrest>1.3</version.org.hamcrest>
 
     <version.org.apache.lucene>4.0.0</version.org.apache.lucene>
-    <version.org.apache.helix>0.6.2-incubating</version.org.apache.helix>
+    <version.org.apache.helix>0.6.5</version.org.apache.helix>
     <version.org.eclipse.jgit>3.7.1.201504261725-r</version.org.eclipse.jgit>
     <version.com.jcraft>0.1.50</version.com.jcraft>
 


### PR DESCRIPTION
@porcelli as we discussed, this should be safe change -- all the the automated tests for KIE WB clustering have passed.