### PR TITLE
Place Hid event on Uberfire

### DIFF
--- a/uberfire-api/src/main/java/org/uberfire/mvp/PlaceRequest.java
+++ b/uberfire-api/src/main/java/org/uberfire/mvp/PlaceRequest.java
@@ -34,6 +34,8 @@ public interface PlaceRequest {
 
     String getIdentifier();
 
+    void setIdentifier(String identifier);
+
     String getFullIdentifier();
 
     String getParameter( final String key,

--- a/uberfire-api/src/main/java/org/uberfire/mvp/impl/DefaultPlaceRequest.java
+++ b/uberfire-api/src/main/java/org/uberfire/mvp/impl/DefaultPlaceRequest.java
@@ -26,11 +26,9 @@ import org.jboss.errai.common.client.api.annotations.Portable;
 import org.uberfire.mvp.PlaceRequest;
 
 @Portable
-public class DefaultPlaceRequest
-implements
-PlaceRequest {
+public class DefaultPlaceRequest implements PlaceRequest {
 
-    protected final String identifier;
+    protected String identifier;
 
     protected final Map<String, String> parameters = new HashMap<String, String>();
 
@@ -145,6 +143,11 @@ PlaceRequest {
     @Override
     public String getIdentifier() {
         return identifier;
+    }
+
+    @Override
+    public void setIdentifier( String identifier ) {
+        this.identifier = identifier;
     }
 
     @Override

--- a/uberfire-api/src/main/java/org/uberfire/mvp/impl/PathPlaceRequest.java
+++ b/uberfire-api/src/main/java/org/uberfire/mvp/impl/PathPlaceRequest.java
@@ -26,7 +26,11 @@ public class PathPlaceRequest extends DefaultPlaceRequest {
 
     public PathPlaceRequest( final Path path ) {
         super( NULL );
-        this.path = IOC.getBeanManager().lookupBean( ObservablePath.class ).getInstance().wrap( path );
+        this.path = createObservablePath( path );
+    }
+
+    protected ObservablePath createObservablePath( Path path ) {
+        return IOC.getBeanManager().lookupBean( ObservablePath.class ).getInstance().wrap( path );
     }
 
     public PathPlaceRequest( final Path path,
@@ -38,7 +42,7 @@ public class PathPlaceRequest extends DefaultPlaceRequest {
     public PathPlaceRequest( final Path path,
                              final String id ) {
         super( id );
-        this.path = IOC.getBeanManager().lookupBean( ObservablePath.class ).getInstance().wrap( path );
+        this.path = createObservablePath( path );
     }
 
     public PathPlaceRequest( final Path path,

--- a/uberfire-workbench/uberfire-workbench-client-views-bs2/src/main/java/org/uberfire/client/views/bs2/listbar/ListBarWidgetImpl.java
+++ b/uberfire-workbench/uberfire-workbench-client-views-bs2/src/main/java/org/uberfire/client/views/bs2/listbar/ListBarWidgetImpl.java
@@ -369,6 +369,7 @@ public class ListBarWidgetImpl
                 return true;
             }
             parts.add( currentPart.getK1() );
+            panelManager.onPartHid(currentPart.getK1());
             currentPart.getK2().getElement().getStyle().setDisplay( NONE );
         }
 

--- a/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/PanelManager.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/PanelManager.java
@@ -180,6 +180,11 @@ public interface PanelManager {
     PanelDefinition getPanelForPlace( PlaceRequest place );
 
     /**
+     * @param the part that has been hid
+     */
+    void onPartHid(PartDefinition part);
+
+    /**
      * @param part the part that has been maximized
      */
     void onPartMaximized( PartDefinition part );

--- a/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/PanelManagerImpl.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/PanelManagerImpl.java
@@ -1,17 +1,5 @@
 package org.uberfire.client.workbench;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import javax.annotation.PostConstruct;
-import javax.annotation.PreDestroy;
-import javax.enterprise.context.ApplicationScoped;
-import javax.enterprise.event.Event;
-import javax.enterprise.event.Observes;
-import javax.enterprise.inject.Instance;
-import javax.inject.Inject;
-
 import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.core.client.Scheduler.ScheduledCommand;
 import com.google.gwt.event.logical.shared.AttachEvent;
@@ -25,14 +13,7 @@ import org.jboss.errai.ioc.client.container.SyncBeanManager;
 import org.uberfire.client.mvp.PerspectiveActivity;
 import org.uberfire.client.mvp.PlaceManager;
 import org.uberfire.client.mvp.UIPart;
-import org.uberfire.client.workbench.events.ChangeTitleWidgetEvent;
-import org.uberfire.client.workbench.events.DropPlaceEvent;
-import org.uberfire.client.workbench.events.PanelFocusEvent;
-import org.uberfire.client.workbench.events.PlaceGainFocusEvent;
-import org.uberfire.client.workbench.events.PlaceLostFocusEvent;
-import org.uberfire.client.workbench.events.PlaceMaximizedEvent;
-import org.uberfire.client.workbench.events.PlaceMinimizedEvent;
-import org.uberfire.client.workbench.events.SelectPlaceEvent;
+import org.uberfire.client.workbench.events.*;
 import org.uberfire.client.workbench.panels.DockingWorkbenchPanelPresenter;
 import org.uberfire.client.workbench.panels.WorkbenchPanelPresenter;
 import org.uberfire.client.workbench.part.WorkbenchPartPresenter;
@@ -45,7 +26,19 @@ import org.uberfire.workbench.model.Position;
 import org.uberfire.workbench.model.impl.PanelDefinitionImpl;
 import org.uberfire.workbench.model.menu.Menus;
 
-import static org.uberfire.commons.validation.PortablePreconditions.*;
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.event.Event;
+import javax.enterprise.event.Observes;
+import javax.enterprise.inject.Instance;
+import javax.inject.Inject;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.uberfire.commons.validation.PortablePreconditions.checkNotNull;
 
 /**
  * Standard implementation of {@link PanelManager}.
@@ -70,6 +63,9 @@ public class PanelManagerImpl implements PanelManager {
 
     @Inject
     protected Event<PlaceMinimizedEvent> placeMinimizedEventEvent;
+
+    @Inject
+    protected Event<PlaceHidEvent> placeHidEvent;
 
     @Inject
     protected SyncBeanManager iocManager;
@@ -287,6 +283,11 @@ public class PanelManagerImpl implements PanelManager {
     @Override
     public void onPartMinimized( final PartDefinition part ) {
         placeMinimizedEventEvent.fire( new PlaceMinimizedEvent( part.getPlace() ) );
+    }
+
+    @Override
+    public void onPartHid( final PartDefinition part ) {
+        placeHidEvent.fire( new PlaceHidEvent( part.getPlace() ) );
     }
 
     @Override

--- a/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/events/PlaceHidEvent.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/events/PlaceHidEvent.java
@@ -1,0 +1,37 @@
+/*
+ *
+ *  * Copyright 2012 JBoss Inc
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ *  * use this file except in compliance with the License. You may obtain a copy of
+ *  * the License at
+ *  *
+ *  * http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  * License for the specific language governing permissions and limitations under
+ *  * the License.
+ *
+ */
+package org.uberfire.client.workbench.events;
+
+import org.uberfire.mvp.PlaceRequest;
+
+/**
+ * Fired by the framework each time a workbench editor or screen gets hid.
+ */
+public class PlaceHidEvent extends AbstractPlaceEvent {
+
+    public PlaceHidEvent(final PlaceRequest place) {
+        super(place);
+    }
+
+    @Override
+    public String toString() {
+        return "PlaceHidEvent [place=" + getPlace() + "]";
+    }
+
+
+}

--- a/uberfire-workbench/uberfire-workbench-client/src/test/java/org/uberfire/client/mvp/ActivityManagerImplTest.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/test/java/org/uberfire/client/mvp/ActivityManagerImplTest.java
@@ -1,0 +1,25 @@
+package org.uberfire.client.mvp;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class ActivityManagerImplTest {
+
+    private ActivityManager activityManager;
+
+
+    @Before
+    public void setUp() throws Exception {
+        activityManager = new ActivityManagerImpl();
+
+    }
+
+    @Test
+    public void test(){
+        assertTrue(true);
+    }
+
+
+}


### PR DESCRIPTION
When a editor is hid in ListBarWidgetImpl, we would like to generate a event (PlaceHidEvent). This should work like Focus/Maximized events.

We have to change ActivityManagerImpl, because when the part is associated with PathPlaceRequest, the place identifier was null (making impossible to
identify which place was hidden).

So in order to do that, when an activity is resolved by ActivityManagerImpl, I've made a lookup on resolvePlaceIdentifierForPathPlaceRequest method.

This feature request was generated by the need for hide the docks when Data Modeller was put in the background.