### PR TITLE
WAS problem with UF background tasks like lucene indexes due to wrong

### DIFF
--- a/uberfire-commons/src/main/java/org/uberfire/commons/async/SimpleAsyncExecutorService.java
+++ b/uberfire-commons/src/main/java/org/uberfire/commons/async/SimpleAsyncExecutorService.java
@@ -2,7 +2,6 @@ package org.uberfire.commons.async;
 
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
-import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
@@ -24,7 +23,7 @@ import static javax.ejb.TransactionAttributeType.*;
 @Singleton
 @Startup
 @TransactionAttribute(NOT_SUPPORTED)
-public class SimpleAsyncExecutorService implements Executor {
+public class SimpleAsyncExecutorService {
 
     private static final Logger LOG = LoggerFactory.getLogger( SimpleAsyncExecutorService.class );
 
@@ -94,7 +93,6 @@ public class SimpleAsyncExecutorService implements Executor {
 
     @Asynchronous
     @Lock(LockType.READ)
-    @Override
     public void execute( final Runnable r ) {
         if ( executorService != null ) {
             jobs.add( executorService.submit( r ) );


### PR DESCRIPTION
component being used - does not use EJB for async operations but simple
thread pool and thus has no access to CDI beans, fails with:
java.lang.ClassCastException:
com.ibm.ejs.container.deploy.java.util.concurrent.EJSLocal0SGSimpleAsyncExecutorService_ef40626b
incompatible with org.uberfire.commons.async.SimpleAsyncExecutorService

Revert "by implement an interface, it makes easy to mock"

This reverts commit bae32af57249f244937718b40fa67b58b039494f.