### PR TITLE
UF-225 Skipping unlock when RuntimeException is thrown in AbstractIOService.endBatch()

### DIFF
--- a/uberfire-io/src/main/java/org/uberfire/io/impl/AbstractIOService.java
+++ b/uberfire-io/src/main/java/org/uberfire/io/impl/AbstractIOService.java
@@ -162,6 +162,18 @@ public abstract class AbstractIOService implements IOServiceIdentifiable,
             return;
         }
 
+        try {
+            cleanUpAndUnsetBatchModeOnFileSystems();
+        }
+        catch ( Exception e ){
+            throw new RuntimeException( "Exception cleaning and unsetting batch mode on FS." );
+        }
+        finally {
+            batchLockControl.unlock();
+        }
+    }
+
+    private void cleanUpAndUnsetBatchModeOnFileSystems() {
         if ( !fileSystems.isEmpty() ) {
             cleanupClosedFileSystems();
         }
@@ -169,8 +181,6 @@ public abstract class AbstractIOService implements IOServiceIdentifiable,
         for ( final FileSystem fs : fileSystems ) {
             unsetBatchModeOn( fs );
         }
-
-        batchLockControl.unlock();
     }
 
     @Override
@@ -193,7 +203,7 @@ public abstract class AbstractIOService implements IOServiceIdentifiable,
         Files.setAttribute( fs.getRootDirectories().iterator().next(), FileSystemState.FILE_SYSTEM_STATE_ATTR, FileSystemState.BATCH );
     }
 
-    private void unsetBatchModeOn( FileSystem fs ) {
+    void unsetBatchModeOn( FileSystem fs ) {
         Files.setAttribute( fs.getRootDirectories().iterator().next(), FileSystemState.FILE_SYSTEM_STATE_ATTR, FileSystemState.NORMAL );
     }
 


### PR DESCRIPTION
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1251358

Description of problem:


AbstractIOService.java
======================

        public void endBatch() {
            if ( !batchLockControl.isLocked() ) {
                throw new RuntimeException( "There is no batch process." );
            }

            if ( batchLockControl.getHoldCount() > 1 ) {
                batchLockControl.unlock();
                return;
            }

            if ( !fileSystems.isEmpty() ) {
                cleanupClosedFileSystems();
            }

            for ( final FileSystem fs : fileSystems ) {
                unsetBatchModeOn( fs );
            }

            batchLockControl.unlock();
        }  


If an RuntimeException is thrown before "batchLockControl.unlock()", the lock is not released so subsequent threads will wait for the lock forever. 

(for example)

    RULE throwEx
    CLASS org.uberfire.io.impl.AbstractIOService
    METHOD unsetBatchModeOn
    AT ENTRY
    IF TRUE
      DO throw new RuntimeException("dummy");
    ENDRULE



Solution:
===========

In  order to reproduce this, I've created a new test and a fix for it.

However, even if the lock is released the exception of the FS would leave the UF in an inconsistent state. Anyway, this PR raises an exception if that happens (and releases the lock).