### PR TITLE
UF-226: restore the use of Executor interface in order to work on

### DIFF
--- a/uberfire-commons/src/main/java/org/uberfire/commons/async/SimpleAsyncExecutorService.java
+++ b/uberfire-commons/src/main/java/org/uberfire/commons/async/SimpleAsyncExecutorService.java
@@ -2,6 +2,7 @@ package org.uberfire.commons.async;
 
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
+import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
@@ -23,7 +24,7 @@ import static javax.ejb.TransactionAttributeType.*;
 @Singleton
 @Startup
 @TransactionAttribute(NOT_SUPPORTED)
-public class SimpleAsyncExecutorService {
+public class SimpleAsyncExecutorService implements Executor {
 
     private static final Logger LOG = LoggerFactory.getLogger( SimpleAsyncExecutorService.class );
 
@@ -93,6 +94,7 @@ public class SimpleAsyncExecutorService {
 
     @Asynchronous
     @Lock(LockType.READ)
+    @Override
     public void execute( final Runnable r ) {
         if ( executorService != null ) {
             jobs.add( executorService.submit( r ) );


### PR DESCRIPTION
WF/EAP. A improved solution still needed in the upcoming days that
would make it work not only on EAP/WF but also on WAS.
So it's clear that this quick fix will break UF on WAS for now.