### PR TITLE
[UF-229] Configurable Workbench: Dynamic Screens are not proper displayed in Editor Screen on LayoutEditor and new Activity getIdentifier() method.

### DIFF
--- a/uberfire-js/src/main/java/org/uberfire/client/editor/JSEditorActivity.java
+++ b/uberfire-js/src/main/java/org/uberfire/client/editor/JSEditorActivity.java
@@ -72,6 +72,11 @@ public class JSEditorActivity extends AbstractWorkbenchEditorActivity {
         nativeEditor.onShutdown();
     }
 
+    @Override
+    public String getIdentifier() {
+        return nativeEditor.getId();
+    }
+
     private void setupObservablePathCallBacks() {
         path.onConcurrentUpdate( new ParameterizedCommand<ObservablePath.OnConcurrentUpdateEvent>() {
             @Override

--- a/uberfire-js/src/main/java/org/uberfire/client/screen/JSWorkbenchScreenActivity.java
+++ b/uberfire-js/src/main/java/org/uberfire/client/screen/JSWorkbenchScreenActivity.java
@@ -38,6 +38,11 @@ public class JSWorkbenchScreenActivity implements WorkbenchScreenActivity {
     }
 
     @Override
+    public String getIdentifier() {
+        return nativePlugin.getId();
+    }
+
+    @Override
     public boolean onMayClose() {
         return nativePlugin.onMayClose();
     }

--- a/uberfire-js/src/main/java/org/uberfire/client/splash/JSSplashScreenActivity.java
+++ b/uberfire-js/src/main/java/org/uberfire/client/splash/JSSplashScreenActivity.java
@@ -69,6 +69,11 @@ public class JSSplashScreenActivity implements SplashScreenActivity {
         return place;
     }
 
+    @Override
+    public String getIdentifier() {
+        return nativeSplashScreen.getId();
+    }
+
     public void init() {
         if ( !splashFilter.displayNextTime() ) {
             return;

--- a/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/mvp/AbstractWorkbenchPerspectiveActivity.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/mvp/AbstractWorkbenchPerspectiveActivity.java
@@ -34,9 +34,6 @@ public abstract class AbstractWorkbenchPerspectiveActivity extends AbstractActiv
     public abstract PerspectiveDefinition getDefaultPerspectiveLayout();
 
     @Override
-    public abstract String getIdentifier();
-
-    @Override
     public boolean isDefault() {
         return false;
     }

--- a/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/mvp/Activity.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/mvp/Activity.java
@@ -88,9 +88,15 @@ public interface Activity extends RuntimeFeatureResource {
 
     /**
      * Returns the PlaceRequest that this Activity is currently tied to.
-     * 
+     *
      * @return the PlaceRequest that this activity was started for, or null if this activity is not in the started
      *         state.
      */
     PlaceRequest getPlace();
+
+    /**
+     * Returns the unique identifier for this perspective. Should match the CDI bean name (the argument to the
+     * activity's {@code @Named} annotation).
+     */
+    String getIdentifier();
 }

--- a/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/mvp/ActivityBeansInfo.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/mvp/ActivityBeansInfo.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2015 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.uberfire.client.mvp;
+
+import org.jboss.errai.ioc.client.container.IOC;
+import org.jboss.errai.ioc.client.container.IOCBeanDef;
+import org.jboss.errai.ioc.client.container.SyncBeanManager;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Named;
+import java.lang.annotation.Annotation;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+
+@ApplicationScoped
+public class ActivityBeansInfo {
+
+    public List<String> getAvailableWorkbenchScreensIds() {
+        return lookupBeansId( WorkbenchScreenActivity.class );
+    }
+
+    public List<String> getAvailablePerspectivesIds() {
+        return lookupBeansId( PerspectiveActivity.class );
+    }
+
+    public List<String> getAvailableSplashScreensIds() {
+        return lookupBeansId( SplashScreenActivity.class );
+    }
+
+    public List<String> getAvailableWorkbenchEditorsIds() {
+        return lookupBeansId( WorkbenchEditorActivity.class );
+    }
+
+    private List<String> lookupBeansId( Class<?> activityClass ) {
+        final Collection<? extends IOCBeanDef<?>> screens = getBeanManager().lookupBeans( activityClass );
+        List<String> result = new ArrayList<String>();
+        for (final IOCBeanDef<?> beanDef : screens) {
+            result.add( getId( beanDef ) );
+        }
+        Collections.sort( result );
+        return result;
+    }
+
+    SyncBeanManager getBeanManager() {
+        return IOC.getBeanManager();
+    }
+
+
+    private String getId( final IOCBeanDef<?> beanDef ) {
+        for (final Annotation annotation : beanDef.getQualifiers()) {
+            if (isNamed( annotation )) {
+                return ((Named) annotation).value();
+            }
+        }
+        if (hasBeanName( beanDef )) {
+            return beanDef.getName();
+        }
+        return "";
+    }
+
+    boolean isNamed( Annotation annotation ) {
+        return annotation instanceof Named;
+    }
+
+    private boolean hasBeanName( IOCBeanDef<?> beanDef ) {
+        return beanDef.getName() != null && !beanDef.getName().isEmpty();
+    }
+}

--- a/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/mvp/ActivityManagerImpl.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/mvp/ActivityManagerImpl.java
@@ -16,7 +16,6 @@
 
 package org.uberfire.client.mvp;
 
-import org.jboss.errai.ioc.client.container.IOC;
 import org.jboss.errai.ioc.client.container.IOCBeanDef;
 import org.jboss.errai.ioc.client.container.SyncBeanManager;
 import org.jboss.errai.security.shared.api.identity.User;
@@ -29,8 +28,6 @@ import org.uberfire.security.authz.AuthorizationManager;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
-import javax.inject.Named;
-import java.lang.annotation.Annotation;
 import java.util.*;
 
 import static java.util.Collections.*;
@@ -107,28 +104,8 @@ public class ActivityManagerImpl implements ActivityManager {
     private void resolvePathPlaceRequestIdentifier( PlaceRequest placeRequest, Set<Activity> activities ) {
         if ( activities!=null && !activities.isEmpty() ) {
             final Activity activity = activities.iterator().next();
-            resolvePathPlaceRequestIdentifier( placeRequest, activity );
+            placeRequest.setIdentifier( activity.getIdentifier() );
         }
-    }
-
-    private void resolvePathPlaceRequestIdentifier( PlaceRequest placeRequest, Activity activity ) {
-        Set<Annotation> annotations = lookupActivityAnnotations( activity );
-        for ( Annotation annotation : annotations ) {
-            if ( annotation instanceof Named ) {
-                String resolvedPlaceIdentifier = ( (Named) annotation ).value();
-                placeRequest.setIdentifier( resolvedPlaceIdentifier );
-                break;
-            }
-        }
-    }
-
-    protected Set<Annotation> lookupActivityAnnotations( Activity activity ) {
-        IOCBeanDef<? extends Activity> iocBeanDef = IOC.getBeanManager().lookupBean( activity.getClass() );
-        Set<Annotation> qualifiers = iocBeanDef.getQualifiers();
-        if ( qualifiers == null ) {
-            return new HashSet<Annotation>();
-        }
-        return qualifiers;
     }
 
     @Override

--- a/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/mvp/PerspectiveActivity.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/mvp/PerspectiveActivity.java
@@ -34,12 +34,6 @@ public interface PerspectiveActivity extends ContextSensitiveActivity {
     PerspectiveDefinition getDefaultPerspectiveLayout();
 
     /**
-     * Returns the unique identifier for this perspective. Should match the CDI bean name (the argument to the
-     * activity's {@code @Named} annotation).
-     */
-    String getIdentifier();
-
-    /**
      * Returns true if this perspective should be displayed automatically when the application starts. Each application
      * needs exactly one default perspective.
      *

--- a/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/widgets/notfound/ActivityNotFoundPresenter.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/widgets/notfound/ActivityNotFoundPresenter.java
@@ -89,6 +89,11 @@ public class ActivityNotFoundPresenter extends AbstractPopupActivity {
         view.setRequestedPlaceIdentifier( identifier );
     }
 
+    @Override
+    public String getIdentifier() {
+        return "uf.workbench.activity.notfound";
+    }
+
     public void close() {
         placeManager.closePlace( this.place );
     }

--- a/uberfire-workbench/uberfire-workbench-client/src/test/java/org/uberfire/client/mvp/AbstractPopupActivityTest.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/test/java/org/uberfire/client/mvp/AbstractPopupActivityTest.java
@@ -175,6 +175,11 @@ public class AbstractPopupActivityTest extends AbstractActivityTest {
         public String getTitle() {
             return "Testing Popup Activity";
         }
+
+        @Override
+        public String getIdentifier() {
+            return "fake.popup.Activity";
+        }
     }
 
 }

--- a/uberfire-workbench/uberfire-workbench-client/src/test/java/org/uberfire/client/mvp/ActivityBeansInfoTest.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/test/java/org/uberfire/client/mvp/ActivityBeansInfoTest.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2015 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.client.mvp;
+
+import org.jboss.errai.ioc.client.container.CreationalContext;
+import org.jboss.errai.ioc.client.container.IOCBeanDef;
+import org.jboss.errai.ioc.client.container.SyncBeanManager;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.inject.Named;
+import java.lang.annotation.Annotation;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class ActivityBeansInfoTest {
+
+    private SyncBeanManager syncBeanManager;
+
+    private ActivityBeansInfo activityBeansInfo;
+
+    @Before
+    public void setup(){
+        syncBeanManager = mock( SyncBeanManager.class );
+        activityBeansInfo = new ActivityBeansInfo(){
+            @Override
+            SyncBeanManager getBeanManager() {
+                return syncBeanManager;
+            }
+        };
+    }
+
+    @Test
+    public void getAvaliableWorkbenchScreensIdsTest(){
+        when( syncBeanManager.lookupBeans( WorkbenchScreenActivity.class ) )
+                .thenReturn( generateBeansList() );
+
+        assertEquals( 2 , activityBeansInfo.getAvailableWorkbenchScreensIds().size() );
+        //assert bean order
+        assertEquals( "A" , activityBeansInfo.getAvailableWorkbenchScreensIds().get( 0 ) );
+        assertEquals( "Z" , activityBeansInfo.getAvailableWorkbenchScreensIds().get( 1 ) );
+
+    }
+
+    private Collection<IOCBeanDef<WorkbenchScreenActivity>> generateBeansList() {
+        Collection<IOCBeanDef<WorkbenchScreenActivity>> beans = new ArrayList<IOCBeanDef<WorkbenchScreenActivity>>(  );
+
+        beans.add( generateBeanDef( "Z", true ) );
+        beans.add( generateBeanDef( "A", false ) );
+
+        return beans;
+    }
+
+    private IOCBeanDef<WorkbenchScreenActivity> generateBeanDef(String beanName, final boolean hasAnnotations) {
+        return new IOCBeanDef<WorkbenchScreenActivity>() {
+            @Override
+            public Class<WorkbenchScreenActivity> getType() {
+                return null;
+            }
+
+            @Override
+            public Class<?> getBeanClass() {
+                return null;
+            }
+
+            @Override
+            public Class<? extends Annotation> getScope() {
+                return null;
+            }
+
+            @Override
+            public WorkbenchScreenActivity getInstance() {
+                return null;
+            }
+
+            @Override
+            public WorkbenchScreenActivity getInstance( CreationalContext context ) {
+                return null;
+            }
+
+            @Override
+            public WorkbenchScreenActivity newInstance() {
+                return null;
+            }
+
+            @Override
+            public Set<Annotation> getQualifiers() {
+                final HashSet<Annotation> annotations = new HashSet<Annotation>();
+                if( hasAnnotations ){
+                    annotations.add( new Named(){
+
+                        @Override
+                        public Class<? extends Annotation> annotationType() {
+                            return null;
+                        }
+
+                        @Override
+                        public String value() {
+                            return "Z";
+                        }
+                    } );
+                }
+                return annotations;
+            }
+
+            @Override
+            public boolean matches( Set<Annotation> annotations ) {
+                return false;
+            }
+
+            @Override
+            public String getName() {
+                return "A";
+            }
+
+            @Override
+            public boolean isConcrete() {
+                return false;
+            }
+
+            @Override
+            public boolean isActivated() {
+                return false;
+            }
+        };
+    }
+
+
+}

--- a/uberfire-workbench/uberfire-workbench-client/src/test/java/org/uberfire/client/mvp/ActivityManagerLifecycleTest.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/test/java/org/uberfire/client/mvp/ActivityManagerLifecycleTest.java
@@ -47,16 +47,7 @@ public class ActivityManagerLifecycleTest {
 
     // the activity manager we're unit testing
     @InjectMocks
-    ActivityManagerImpl activityManager = new ActivityManagerImpl() {
-        @Override
-        protected Set<Annotation> lookupActivityAnnotations( Activity activity ) {
-            Set<Annotation> annotations = new HashSet<Annotation>();
-            Named annotation = mock( Named.class );
-            when( annotation.value() ).thenReturn( PATH_PLACE_ID );
-            annotations.add( annotation );
-            return annotations;
-        }
-    };
+    ActivityManagerImpl activityManager = new ActivityManagerImpl();
 
     // things that are useful to individual tests
     PlaceRequest kansas;
@@ -84,6 +75,7 @@ public class ActivityManagerLifecycleTest {
         };
 
         when( pathPlaceActivity.getPlace() ).thenReturn( pathPlace );
+        when( pathPlaceActivity.getIdentifier() ).thenReturn( PATH_PLACE_ID );
         IOCBeanDef<Activity> pathIocBean = makeDependentBean( Activity.class, pathPlaceActivity );
         pathIocBeanSpy = spy( pathIocBean );
         when( activityBeansCache.getActivity( pathPlace.getIdentifier() ) ).thenReturn( pathIocBeanSpy );

--- a/uberfire-workbench/uberfire-workbench-processors-tests/src/test/java/org/uberfire/annotations/processors/WorkbenchEditorProcessorTest.java
+++ b/uberfire-workbench/uberfire-workbench-processors-tests/src/test/java/org/uberfire/annotations/processors/WorkbenchEditorProcessorTest.java
@@ -248,8 +248,8 @@ public class WorkbenchEditorProcessorTest extends AbstractProcessorTest {
         assertCompilationMessage( diagnostics, Kind.ERROR, Diagnostic.NOPOS, Diagnostic.NOPOS, "Methods annotated with @OnStartup must take one argument of type org.uberfire.backend.vfs.Path and an optional second argument of type org.uberfire.mvp.PlaceRequest" );
         assertNotNull( result.getActualCode() );
         assertNotNull( result.getExpectedCode() );
-        assertEquals( result.getActualCode(),
-                      result.getExpectedCode() );
+        assertEquals( result.getExpectedCode(),
+                      result.getActualCode() );
     }
 
     @Test

--- a/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/AnnotatedWithEverything.java
+++ b/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/AnnotatedWithEverything.java
@@ -10,12 +10,12 @@ import org.uberfire.client.annotations.WorkbenchSplashScreen;
 /**
  * A non-functional class that exists only to support the UF-44 regression test.
  */
-@WorkbenchPerspective
-@WorkbenchEditor
-@WorkbenchContext
-@WorkbenchPopup
-@WorkbenchScreen
-@WorkbenchSplashScreen
+@WorkbenchPerspective(identifier = "sample")
+@WorkbenchEditor(identifier = "sample")
+@WorkbenchContext(identifier = "sample")
+@WorkbenchPopup(identifier = "sample")
+@WorkbenchScreen(identifier = "sample")
+@WorkbenchSplashScreen(identifier = "sample")
 public class AnnotatedWithEverything {
 
 }

--- a/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/WorkbenchEditorTest10.expected
+++ b/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/WorkbenchEditorTest10.expected
@@ -93,4 +93,10 @@ public class WorkbenchEditorTest10Activity extends AbstractWorkbenchEditorActivi
     public String getSignatureId() {
         return "org.uberfire.annotations.processors.WorkbenchEditorTest10Activity";
     }
+
+    @Override
+    public String getIdentifier() {
+        return "test10";
+    }
+
 }

--- a/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/WorkbenchEditorTest11.expected
+++ b/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/WorkbenchEditorTest11.expected
@@ -92,4 +92,10 @@ public class WorkbenchEditorTest11Activity extends AbstractWorkbenchEditorActivi
     public String getSignatureId() {
         return "org.uberfire.annotations.processors.WorkbenchEditorTest11Activity";
     }
+
+    @Override
+    public String getIdentifier() {
+        return "test11";
+    }
+
 }

--- a/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/WorkbenchEditorTest12.expected
+++ b/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/WorkbenchEditorTest12.expected
@@ -92,4 +92,10 @@ public class WorkbenchEditorTest12Activity extends AbstractWorkbenchEditorActivi
     public String getSignatureId() {
         return "org.uberfire.annotations.processors.WorkbenchEditorTest12Activity";
     }
+
+    @Override
+    public String getIdentifier() {
+        return "test12";
+    }
+
 }

--- a/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/WorkbenchEditorTest13.expected
+++ b/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/WorkbenchEditorTest13.expected
@@ -85,4 +85,10 @@ public class WorkbenchEditorTest13Activity extends AbstractWorkbenchEditorActivi
     public String getSignatureId() {
         return "org.uberfire.annotations.processors.WorkbenchEditorTest13Activity";
     }
+
+    @Override
+    public String getIdentifier() {
+        return "test13";
+    }
+
 }

--- a/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/WorkbenchEditorTest14.expected
+++ b/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/WorkbenchEditorTest14.expected
@@ -92,4 +92,10 @@ public class WorkbenchEditorTest14Activity extends AbstractWorkbenchEditorActivi
     public String getSignatureId() {
         return "org.uberfire.annotations.processors.WorkbenchEditorTest14Activity";
     }
+
+    @Override
+    public String getIdentifier() {
+        return "test14";
+    }
+
 }

--- a/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/WorkbenchEditorTest15.expected
+++ b/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/WorkbenchEditorTest15.expected
@@ -92,4 +92,10 @@ public class WorkbenchEditorTest15Activity extends AbstractWorkbenchEditorActivi
     public String getSignatureId() {
         return "org.uberfire.annotations.processors.WorkbenchEditorTest15Activity";
     }
+
+    @Override
+    public String getIdentifier() {
+        return "test15";
+    }
+
 }

--- a/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/WorkbenchEditorTest16.expected
+++ b/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/WorkbenchEditorTest16.expected
@@ -85,4 +85,10 @@ public class WorkbenchEditorTest16Activity extends AbstractWorkbenchEditorActivi
     public String getSignatureId() {
         return "org.uberfire.annotations.processors.WorkbenchEditorTest16Activity";
     }
+
+    @Override
+    public String getIdentifier() {
+        return "test16";
+    }
+
 }

--- a/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/WorkbenchEditorTest17.expected
+++ b/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/WorkbenchEditorTest17.expected
@@ -86,4 +86,10 @@ public class WorkbenchEditorTest17Activity extends AbstractWorkbenchEditorActivi
     public String getSignatureId() {
         return "org.uberfire.annotations.processors.WorkbenchEditorTest17Activity";
     }
+
+    @Override
+    public String getIdentifier() {
+        return "test17";
+    }
+
 }

--- a/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/WorkbenchEditorTest18.expected
+++ b/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/WorkbenchEditorTest18.expected
@@ -88,4 +88,10 @@ public class WorkbenchEditorTest18Activity extends AbstractWorkbenchEditorActivi
     public String getSignatureId() {
         return "org.uberfire.annotations.processors.WorkbenchEditorTest18Activity";
     }
+
+    @Override
+    public String getIdentifier() {
+        return "test18";
+    }
+
 }

--- a/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/WorkbenchEditorTest19.expected
+++ b/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/WorkbenchEditorTest19.expected
@@ -86,4 +86,10 @@ public class WorkbenchEditorTest19Activity extends AbstractWorkbenchEditorActivi
     public String getSignatureId() {
         return "org.uberfire.annotations.processors.WorkbenchEditorTest19Activity";
     }
+
+    @Override
+    public String getIdentifier() {
+        return "test19";
+    }
+
 }

--- a/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/WorkbenchEditorTest21.expected
+++ b/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/WorkbenchEditorTest21.expected
@@ -85,4 +85,10 @@ public class WorkbenchEditorTest21Activity extends AbstractWorkbenchEditorActivi
     public String getSignatureId() {
         return "org.uberfire.annotations.processors.WorkbenchEditorTest21Activity";
     }
+
+    @Override
+    public String getIdentifier() {
+        return "test21";
+    }
+
 }

--- a/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/WorkbenchEditorTest22.expected
+++ b/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/WorkbenchEditorTest22.expected
@@ -95,4 +95,10 @@ public class WorkbenchEditorTest22Activity extends AbstractWorkbenchEditorActivi
     public String getSignatureId() {
         return "org.uberfire.annotations.processors.WorkbenchEditorTest22Activity";
     }
+
+    @Override
+    public String getIdentifier() {
+        return "test22";
+    }
+
 }

--- a/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/WorkbenchEditorTest23.expected
+++ b/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/WorkbenchEditorTest23.expected
@@ -85,4 +85,10 @@ public class WorkbenchEditorTest23Activity extends AbstractWorkbenchEditorActivi
     public String getSignatureId() {
         return "org.uberfire.annotations.processors.WorkbenchEditorTest23Activity";
     }
+
+    @Override
+    public String getIdentifier() {
+        return "test23";
+    }
+
 }

--- a/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/WorkbenchEditorTest24.expected
+++ b/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/WorkbenchEditorTest24.expected
@@ -90,4 +90,10 @@ public class WorkbenchEditorTest24Activity extends AbstractWorkbenchEditorActivi
     public String getSignatureId() {
         return "org.uberfire.annotations.processors.WorkbenchEditorTest24Activity";
     }
+
+    @Override
+    public String getIdentifier() {
+        return "test24";
+    }
+
 }

--- a/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/WorkbenchEditorTest25.expected
+++ b/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/WorkbenchEditorTest25.expected
@@ -85,4 +85,10 @@ public class WorkbenchEditorTest25Activity extends AbstractWorkbenchEditorActivi
     public String getSignatureId() {
         return "org.uberfire.annotations.processors.WorkbenchEditorTest25Activity";
     }
+
+    @Override
+    public String getIdentifier() {
+        return "test25";
+    }
+
 }

--- a/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/WorkbenchEditorTest26.expected
+++ b/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/WorkbenchEditorTest26.expected
@@ -90,4 +90,10 @@ public class WorkbenchEditorTest26Activity extends AbstractWorkbenchEditorActivi
     public String getSignatureId() {
         return "org.uberfire.annotations.processors.WorkbenchEditorTest26Activity";
     }
+
+    @Override
+    public String getIdentifier() {
+        return "test26";
+    }
+
 }

--- a/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/WorkbenchEditorTest5.expected
+++ b/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/WorkbenchEditorTest5.expected
@@ -85,4 +85,10 @@ public class WorkbenchEditorTest5Activity extends AbstractWorkbenchEditorActivit
     public String getSignatureId() {
         return "org.uberfire.annotations.processors.WorkbenchEditorTest5Activity";
     }
+
+    @Override
+    public String getIdentifier() {
+        return "test5";
+    }
+
 }

--- a/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/WorkbenchEditorTest6.expected
+++ b/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/WorkbenchEditorTest6.expected
@@ -85,4 +85,10 @@ public class WorkbenchEditorTest6Activity extends AbstractWorkbenchEditorActivit
     public String getSignatureId() {
         return "org.uberfire.annotations.processors.WorkbenchEditorTest6Activity";
     }
+
+    @Override
+    public String getIdentifier() {
+        return "test6";
+    }
+
 }

--- a/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/WorkbenchEditorTest7.expected
+++ b/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/WorkbenchEditorTest7.expected
@@ -85,4 +85,10 @@ public class WorkbenchEditorTest7Activity extends AbstractWorkbenchEditorActivit
     public String getSignatureId() {
         return "org.uberfire.annotations.processors.WorkbenchEditorTest7Activity";
     }
+
+    @Override
+    public String getIdentifier() {
+        return "test7";
+    }
+
 }

--- a/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/WorkbenchEditorTest8.expected
+++ b/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/WorkbenchEditorTest8.expected
@@ -121,4 +121,10 @@ public class WorkbenchEditorTest8Activity extends AbstractWorkbenchEditorActivit
     public String getSignatureId() {
         return "org.uberfire.annotations.processors.WorkbenchEditorTest8Activity";
     }
+
+    @Override
+    public String getIdentifier() {
+        return "test8";
+    }
+
 }

--- a/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/WorkbenchEditorTest9.expected
+++ b/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/WorkbenchEditorTest9.expected
@@ -92,4 +92,10 @@ public class WorkbenchEditorTest9Activity extends AbstractWorkbenchEditorActivit
     public String getSignatureId() {
         return "org.uberfire.annotations.processors.WorkbenchEditorTest9Activity";
     }
+
+    @Override
+    public String getIdentifier() {
+        return "test9";
+    }
+
 }

--- a/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/WorkbenchPopupTest11.expected
+++ b/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/WorkbenchPopupTest11.expected
@@ -82,4 +82,10 @@ public class WorkbenchPopupTest11Activity extends AbstractPopupActivity {
     public String getSignatureId() {
         return "org.uberfire.annotations.processors.WorkbenchPopupTest11Activity";
     }
+
+    @Override
+    public String getIdentifier() {
+        return "test11";
+    }
+
 }

--- a/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/WorkbenchPopupTest12.expected
+++ b/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/WorkbenchPopupTest12.expected
@@ -80,4 +80,10 @@ public class WorkbenchPopupTest12Activity extends AbstractPopupActivity {
     public String getSignatureId() {
         return "org.uberfire.annotations.processors.WorkbenchPopupTest12Activity";
     }
+
+    @Override
+    public String getIdentifier() {
+        return "test12";
+    }
+
 }

--- a/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/WorkbenchPopupTest3.expected
+++ b/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/WorkbenchPopupTest3.expected
@@ -77,4 +77,10 @@ public class WorkbenchPopupTest3Activity extends AbstractPopupActivity {
     public String getSignatureId() {
         return "org.uberfire.annotations.processors.WorkbenchPopupTest3Activity";
     }
+
+    @Override
+    public String getIdentifier() {
+        return "test3";
+    }
+
 }

--- a/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/WorkbenchPopupTest4.expected
+++ b/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/WorkbenchPopupTest4.expected
@@ -77,4 +77,10 @@ public class WorkbenchPopupTest4Activity extends AbstractPopupActivity {
     public String getSignatureId() {
         return "org.uberfire.annotations.processors.WorkbenchPopupTest4Activity";
     }
+
+    @Override
+    public String getIdentifier() {
+        return "test4";
+    }
+
 }

--- a/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/WorkbenchPopupTest5.expected
+++ b/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/WorkbenchPopupTest5.expected
@@ -77,4 +77,10 @@ public class WorkbenchPopupTest5Activity extends AbstractPopupActivity {
     public String getSignatureId() {
         return "org.uberfire.annotations.processors.WorkbenchPopupTest5Activity";
     }
+
+    @Override
+    public String getIdentifier() {
+        return "test5";
+    }
+
 }

--- a/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/WorkbenchPopupTest6.expected
+++ b/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/WorkbenchPopupTest6.expected
@@ -83,4 +83,10 @@ public class WorkbenchPopupTest6Activity extends AbstractPopupActivity {
     public String getSignatureId() {
         return "org.uberfire.annotations.processors.WorkbenchPopupTest6Activity";
     }
+
+    @Override
+    public String getIdentifier() {
+        return "test6";
+    }
+
 }

--- a/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/WorkbenchPopupTest7.expected
+++ b/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/WorkbenchPopupTest7.expected
@@ -83,4 +83,10 @@ public class WorkbenchPopupTest7Activity extends AbstractPopupActivity {
     public String getSignatureId() {
         return "org.uberfire.annotations.processors.WorkbenchPopupTest7Activity";
     }
+
+    @Override
+    public String getIdentifier() {
+        return "test7";
+    }
+
 }

--- a/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/WorkbenchPopupTest8.expected
+++ b/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/WorkbenchPopupTest8.expected
@@ -83,4 +83,10 @@ public class WorkbenchPopupTest8Activity extends AbstractPopupActivity {
     public String getSignatureId() {
         return "org.uberfire.annotations.processors.WorkbenchPopupTest8Activity";
     }
+
+    @Override
+    public String getIdentifier() {
+        return "test8";
+    }
+
 }

--- a/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/WorkbenchScreenTest10.expected
+++ b/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/WorkbenchScreenTest10.expected
@@ -85,4 +85,10 @@ public class WorkbenchScreenTest10Activity extends AbstractWorkbenchScreenActivi
     public String getSignatureId() {
         return "org.uberfire.annotations.processors.WorkbenchScreenTest10Activity";
     }
+
+    @Override
+    public String getIdentifier() {
+        return "test10";
+    }
+
 }

--- a/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/WorkbenchScreenTest11.expected
+++ b/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/WorkbenchScreenTest11.expected
@@ -91,4 +91,10 @@ public class WorkbenchScreenTest11Activity extends AbstractWorkbenchScreenActivi
     public String getSignatureId() {
         return "org.uberfire.annotations.processors.WorkbenchScreenTest11Activity";
     }
+
+    @Override
+    public String getIdentifier() {
+        return "test11";
+    }
+
 }

--- a/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/WorkbenchScreenTest12.expected
+++ b/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/WorkbenchScreenTest12.expected
@@ -91,4 +91,10 @@ public class WorkbenchScreenTest12Activity extends AbstractWorkbenchScreenActivi
     public String getSignatureId() {
         return "org.uberfire.annotations.processors.WorkbenchScreenTest12Activity";
     }
+
+    @Override
+    public String getIdentifier() {
+        return "test12";
+    }
+
 }

--- a/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/WorkbenchScreenTest14.expected
+++ b/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/WorkbenchScreenTest14.expected
@@ -84,4 +84,10 @@ public class WorkbenchScreenTest14Activity extends AbstractWorkbenchScreenActivi
     public String getSignatureId() {
         return "org.uberfire.annotations.processors.WorkbenchScreenTest14Activity";
     }
+
+    @Override
+    public String getIdentifier() {
+        return "test14";
+    }
+
 }

--- a/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/WorkbenchScreenTest15.expected
+++ b/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/WorkbenchScreenTest15.expected
@@ -77,4 +77,10 @@ public class WorkbenchScreenTest15Activity extends AbstractWorkbenchScreenActivi
     public String getSignatureId() {
         return "org.uberfire.annotations.processors.WorkbenchScreenTest15Activity";
     }
+
+    @Override
+    public String getIdentifier() {
+        return "test15";
+    }
+
 }

--- a/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/WorkbenchScreenTest17.expected
+++ b/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/WorkbenchScreenTest17.expected
@@ -82,4 +82,10 @@ public class WorkbenchScreenTest17Activity extends AbstractWorkbenchScreenActivi
     public String getSignatureId() {
         return "org.uberfire.annotations.processors.WorkbenchScreenTest17Activity";
     }
+
+    @Override
+    public String getIdentifier() {
+        return "test17";
+    }
+
 }

--- a/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/WorkbenchScreenTest18.expected
+++ b/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/WorkbenchScreenTest18.expected
@@ -83,4 +83,10 @@ public class WorkbenchScreenTest18Activity extends AbstractWorkbenchScreenActivi
     public String getSignatureId() {
         return "org.uberfire.annotations.processors.WorkbenchScreenTest18Activity";
     }
+
+    @Override
+    public String getIdentifier() {
+        return "test18";
+    }
+
 }

--- a/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/WorkbenchScreenTest19.expected
+++ b/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/WorkbenchScreenTest19.expected
@@ -80,4 +80,10 @@ public class WorkbenchScreenTest19Activity extends AbstractWorkbenchScreenActivi
     public String getSignatureId() {
         return "org.uberfire.annotations.processors.WorkbenchScreenTest19Activity";
     }
+
+    @Override
+    public String getIdentifier() {
+        return "test19";
+    }
+
 }

--- a/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/WorkbenchScreenTest21.expected
+++ b/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/WorkbenchScreenTest21.expected
@@ -83,4 +83,10 @@ public class WorkbenchScreenTest21Activity extends AbstractWorkbenchScreenActivi
     public String getSignatureId() {
         return "org.uberfire.annotations.processors.WorkbenchScreenTest21Activity";
     }
+
+    @Override
+    public String getIdentifier() {
+        return "test21";
+    }
+
 }

--- a/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/WorkbenchScreenTest23.expected
+++ b/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/WorkbenchScreenTest23.expected
@@ -77,4 +77,10 @@ public class WorkbenchScreenTest23Activity extends AbstractWorkbenchScreenActivi
     public String getSignatureId() {
         return "org.uberfire.annotations.processors.WorkbenchScreenTest23Activity";
     }
+
+    @Override
+    public String getIdentifier() {
+        return "test23";
+    }
+
 }

--- a/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/WorkbenchScreenTest24.expected
+++ b/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/WorkbenchScreenTest24.expected
@@ -82,4 +82,10 @@ public class WorkbenchScreenTest24Activity extends AbstractWorkbenchScreenActivi
     public String getSignatureId() {
         return "org.uberfire.annotations.processors.WorkbenchScreenTest24Activity";
     }
+
+    @Override
+    public String getIdentifier() {
+        return "test24";
+    }
+
 }

--- a/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/WorkbenchScreenTest25.expected
+++ b/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/WorkbenchScreenTest25.expected
@@ -77,4 +77,10 @@ public class WorkbenchScreenTest25Activity extends AbstractWorkbenchScreenActivi
     public String getSignatureId() {
         return "org.uberfire.annotations.processors.WorkbenchScreenTest25Activity";
     }
+
+    @Override
+    public String getIdentifier() {
+        return "test25";
+    }
+
 }

--- a/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/WorkbenchScreenTest26.expected
+++ b/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/WorkbenchScreenTest26.expected
@@ -82,4 +82,10 @@ public class WorkbenchScreenTest26Activity extends AbstractWorkbenchScreenActivi
     public String getSignatureId() {
         return "org.uberfire.annotations.processors.WorkbenchScreenTest26Activity";
     }
+
+    @Override
+    public String getIdentifier() {
+        return "test26";
+    }
+
 }

--- a/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/WorkbenchScreenTest27.expected
+++ b/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/WorkbenchScreenTest27.expected
@@ -77,4 +77,10 @@ public class WorkbenchScreenTest27Activity extends AbstractWorkbenchScreenActivi
     public String getSignatureId() {
         return "org.uberfire.annotations.processors.WorkbenchScreenTest27Activity";
     }
+
+    @Override
+    public String getIdentifier() {
+        return "test27";
+    }
+
 }

--- a/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/WorkbenchScreenTest28.expected
+++ b/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/WorkbenchScreenTest28.expected
@@ -87,4 +87,10 @@ public class WorkbenchScreenTest28Activity extends AbstractWorkbenchScreenActivi
     public String getSignatureId() {
         return "org.uberfire.annotations.processors.WorkbenchScreenTest28Activity";
     }
+
+    @Override
+    public String getIdentifier() {
+        return "test28";
+    }
+
 }

--- a/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/WorkbenchScreenTest5.expected
+++ b/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/WorkbenchScreenTest5.expected
@@ -77,4 +77,10 @@ public class WorkbenchScreenTest5Activity extends AbstractWorkbenchScreenActivit
     public String getSignatureId() {
         return "org.uberfire.annotations.processors.WorkbenchScreenTest5Activity";
     }
+
+    @Override
+    public String getIdentifier() {
+        return "test5";
+    }
+
 }

--- a/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/WorkbenchScreenTest6.expected
+++ b/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/WorkbenchScreenTest6.expected
@@ -77,4 +77,10 @@ public class WorkbenchScreenTest6Activity extends AbstractWorkbenchScreenActivit
     public String getSignatureId() {
         return "org.uberfire.annotations.processors.WorkbenchScreenTest6Activity";
     }
+
+    @Override
+    public String getIdentifier() {
+        return "test6";
+    }
+
 }

--- a/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/WorkbenchScreenTest7.expected
+++ b/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/WorkbenchScreenTest7.expected
@@ -77,4 +77,10 @@ public class WorkbenchScreenTest7Activity extends AbstractWorkbenchScreenActivit
     public String getSignatureId() {
         return "org.uberfire.annotations.processors.WorkbenchScreenTest7Activity";
     }
+
+    @Override
+    public String getIdentifier() {
+        return "test7";
+    }
+
 }

--- a/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/WorkbenchScreenTest8.expected
+++ b/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/WorkbenchScreenTest8.expected
@@ -112,4 +112,10 @@ public class WorkbenchScreenTest8Activity extends AbstractWorkbenchScreenActivit
     public String getSignatureId() {
         return "org.uberfire.annotations.processors.WorkbenchScreenTest8Activity";
     }
+
+    @Override
+    public String getIdentifier() {
+        return "test8";
+    }
+
 }

--- a/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/WorkbenchScreenTest9.expected
+++ b/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/WorkbenchScreenTest9.expected
@@ -84,4 +84,10 @@ public class WorkbenchScreenTest9Activity extends AbstractWorkbenchScreenActivit
     public String getSignatureId() {
         return "org.uberfire.annotations.processors.WorkbenchScreenTest9Activity";
     }
+
+    @Override
+    public String getIdentifier() {
+        return "test9";
+    }
+
 }

--- a/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/WorkbenchSplashScreenTest6.expected
+++ b/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/WorkbenchSplashScreenTest6.expected
@@ -90,4 +90,10 @@ public class WorkbenchSplashScreenTest6Activity extends AbstractSplashScreenActi
     public String getSignatureId() {
         return "org.uberfire.annotations.processors.WorkbenchSplashScreenTest6Activity";
     }
+
+    @Override
+    public String getIdentifier() {
+        return "test6";
+    }
+
 }

--- a/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/WorkbenchSplashScreenTest7.expected
+++ b/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/WorkbenchSplashScreenTest7.expected
@@ -93,4 +93,10 @@ public class WorkbenchSplashScreenTest7Activity extends AbstractSplashScreenActi
     public String getSignatureId() {
         return "org.uberfire.annotations.processors.WorkbenchSplashScreenTest7Activity";
     }
+
+    @Override
+    public String getIdentifier() {
+        return "test7";
+    }
+
 }

--- a/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/WorkbenchSplashScreenTest9.expected
+++ b/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/WorkbenchSplashScreenTest9.expected
@@ -93,4 +93,10 @@ public class WorkbenchSplashScreenTest9Activity extends AbstractSplashScreenActi
     public String getSignatureId() {
         return "org.uberfire.annotations.processors.WorkbenchSplashScreenTest9Activity";
     }
+
+    @Override
+    public String getIdentifier() {
+        return "test9";
+    }
+
 }

--- a/uberfire-workbench/uberfire-workbench-processors/src/main/resources/org/uberfire/annotations/processors/templates/activityContext.ftl
+++ b/uberfire-workbench/uberfire-workbench-processors/src/main/resources/org/uberfire/annotations/processors/templates/activityContext.ftl
@@ -129,4 +129,9 @@ public class ${className} extends AbstractWorkbenchContextActivity {
     public String getSignatureId() {
         return "${packageName}.${className}";
     }
+
+    @Override
+    public String getIdentifier() {
+        return "${identifier}";
+    }
 }

--- a/uberfire-workbench/uberfire-workbench-processors/src/main/resources/org/uberfire/annotations/processors/templates/activityEditor.ftl
+++ b/uberfire-workbench/uberfire-workbench-processors/src/main/resources/org/uberfire/annotations/processors/templates/activityEditor.ftl
@@ -273,4 +273,10 @@ public class ${className} extends AbstractWorkbenchEditorActivity {
     public String getSignatureId() {
         return "${packageName}.${className}";
     }
+
+    @Override
+    public String getIdentifier() {
+        return "${identifier}";
+    }
+
 }

--- a/uberfire-workbench/uberfire-workbench-processors/src/main/resources/org/uberfire/annotations/processors/templates/activityScreen.ftl
+++ b/uberfire-workbench/uberfire-workbench-processors/src/main/resources/org/uberfire/annotations/processors/templates/activityScreen.ftl
@@ -247,4 +247,10 @@ public class ${className} extends AbstractWorkbenchScreenActivity {
     public String getSignatureId() {
         return "${packageName}.${className}";
     }
+
+    @Override
+    public String getIdentifier() {
+        return "${identifier}";
+    }
+
 }

--- a/uberfire-workbench/uberfire-workbench-processors/src/main/resources/org/uberfire/annotations/processors/templates/popupScreen.ftl
+++ b/uberfire-workbench/uberfire-workbench-processors/src/main/resources/org/uberfire/annotations/processors/templates/popupScreen.ftl
@@ -167,4 +167,10 @@ public class ${className} extends AbstractPopupActivity {
     public String getSignatureId() {
         return "${packageName}.${className}";
     }
+
+    @Override
+    public String getIdentifier() {
+        return "${identifier}";
+    }
+
 }

--- a/uberfire-workbench/uberfire-workbench-processors/src/main/resources/org/uberfire/annotations/processors/templates/splashScreen.ftl
+++ b/uberfire-workbench/uberfire-workbench-processors/src/main/resources/org/uberfire/annotations/processors/templates/splashScreen.ftl
@@ -193,4 +193,10 @@ public class ${className} extends AbstractSplashScreenActivity {
     public String getSignatureId() {
         return "${packageName}.${className}";
     }
+
+    @Override
+    public String getIdentifier() {
+        return "${identifier}";
+    }
+
 }


### PR DESCRIPTION
This PR and the related [PR on uberfire-extensions](https://github.com/uberfire/uberfire-extensions/pull/79) group three changes:

1-) In order to prevent this (i.e. ActivityManagerImpl):

    private void resolvePathPlaceRequestIdentifier( PlaceRequest placeRequest, Activity activity ) {
        Set<Annotation> annotations = lookupActivityAnnotations( activity );
        for ( Annotation annotation : annotations ) {
            if ( annotation instanceof Named ) {
                String resolvedPlaceIdentifier = ( (Named) annotation ).value();
                placeRequest.setIdentifier( resolvedPlaceIdentifier );
                break;
            }
        }
    }

I've created a new method called String getIdentifier() on Activity.java

This requires a lot of changes in UF in order to support and generate this method.


Also, to solve:

2-) Dynamic screens are without the name in edit screen (they are blank) (after reload)
3-) When new static perspective plugin is created and browser is refreshed, it is not displayed in perspective plugin list.

I've created a class called ActivityBeansInfo, to list information about all beans available on class path and remove duplicated code on  [Edit Screens](https://github.com/uberfire/uberfire-extensions/blob/be19ebb86ece6016e368482519eeee20ae77cea3/uberfire-runtime-plugins/uberfire-runtime-plugins-client/src/main/java/org/uberfire/ext/plugin/client/perspective/editor/layout/editor/popups/EditScreen.java#L259-L275) and in [PluginNavList](https://github.com/uberfire/uberfire-extensions/blob/087db6a447ae4f90a21b0df4453b9557e6c01447/uberfire-runtime-plugins/uberfire-runtime-plugins-client/src/main/java/org/uberfire/ext/plugin/client/widget/navigator/PluginNavList.java#L147-L165) and [here](https://github.com/uberfire/uberfire-extensions/blob/087db6a447ae4f90a21b0df4453b9557e6c01447/uberfire-runtime-plugins/uberfire-runtime-plugins-client/src/main/java/org/uberfire/ext/plugin/client/widget/navigator/PluginNavList.java#L237-L244).

In both classes there was a bug where if the screen was generated via dynamic screens plugin (static or created on runtime plugins editor) the name is blank because there is no annotation associated with that.



One thing to keep in mind (and maybe we can discuss about this evolution in future) is that there is no way to use ActivityManager to list all avaliable screens because ActivityManager only "activate" a screen after a goTo to this activity (lazy one). So in order to list all the avaliable screens we have to search that dinammically via bean manager.


