### PR TITLE
Add no argument constructors to client-side application-scoped beans …

### DIFF
--- a/uberfire-client-api/src/main/java/org/uberfire/client/workbench/type/impl/ClientTypeRegistryImpl.java
+++ b/uberfire-client-api/src/main/java/org/uberfire/client/workbench/type/impl/ClientTypeRegistryImpl.java
@@ -23,6 +23,11 @@ public class ClientTypeRegistryImpl implements ClientTypeRegistry {
 
     private final SyncBeanManager iocManager;
 
+    // For proxying
+    public ClientTypeRegistryImpl() {
+        iocManager = null;
+    }
+
     @Inject
     public ClientTypeRegistryImpl( final SyncBeanManager iocManager ) {
         this.iocManager = iocManager;

--- a/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/menu/SplashScreenMenuPresenter.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/menu/SplashScreenMenuPresenter.java
@@ -62,6 +62,12 @@ public class SplashScreenMenuPresenter implements IsWidget {
     private final PlaceManager placeManager;
     private final View view;
 
+    // For proxying
+    public SplashScreenMenuPresenter() {
+        placeManager = null;
+        view = null;
+    }
+
     @Inject
     public SplashScreenMenuPresenter(PlaceManager placeManager, View view) {
         this.placeManager = checkNotNull( "placeManager", placeManager );

--- a/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/widgets/common/ErrorPopupPresenter.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/widgets/common/ErrorPopupPresenter.java
@@ -52,6 +52,11 @@ public class ErrorPopupPresenter {
 
     private final View view;
 
+    // For proxying
+    public ErrorPopupPresenter() {
+        this.view = null;
+    }
+
     @Inject
     public ErrorPopupPresenter( View view ) {
         this.view = checkNotNull( "view", view );

--- a/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/widgets/notfound/ActivityNotFoundPresenter.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/widgets/notfound/ActivityNotFoundPresenter.java
@@ -34,6 +34,11 @@ import com.google.gwt.user.client.ui.IsWidget;
 @Named("uf.workbench.activity.notfound")
 public class ActivityNotFoundPresenter extends AbstractPopupActivity {
 
+    // For proxying
+    public ActivityNotFoundPresenter() {
+        super( null, null );
+    }
+
     @Inject
     //Constructor injection for testing
     public ActivityNotFoundPresenter( final PlaceManager placeManager, PopupView popupView ) {

--- a/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/widgets/notifications/NotificationManager.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/widgets/notifications/NotificationManager.java
@@ -121,6 +121,12 @@ public class NotificationManager {
         boolean isShowing( final NotificationEvent event );
     }
 
+    // For proxying
+    public NotificationManager() {
+      this.iocManager = null;
+      this.placeManager = null;
+    }
+
     @Inject
     public NotificationManager( final SyncBeanManager iocManager,
                                 final PlaceManager placeManager ) {


### PR DESCRIPTION
This change helps prepare Uberfire for Errai 4.0, where normal scope beans will have to be proxiable.