### PR TITLE
UF-237: SessionListener for lock cleanup not working on Tomcat7, E(J)WS

### DIFF
--- a/uberfire-backend/uberfire-backend-server/src/main/java/org/uberfire/backend/server/LockCleanupSessionListener.java
+++ b/uberfire-backend/uberfire-backend-server/src/main/java/org/uberfire/backend/server/LockCleanupSessionListener.java
@@ -2,14 +2,13 @@ package org.uberfire.backend.server;
 
 import java.util.Set;
 
-import javax.inject.Inject;
-import javax.inject.Named;
 import javax.servlet.annotation.WebListener;
 import javax.servlet.http.HttpSessionEvent;
 import javax.servlet.http.HttpSessionListener;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.uberfire.backend.server.io.ConfigIOServiceProducer;
 import org.uberfire.backend.server.util.Paths;
 import org.uberfire.backend.vfs.PathFactory;
 import org.uberfire.backend.vfs.impl.LockInfo;
@@ -26,20 +25,15 @@ public class LockCleanupSessionListener implements HttpSessionListener {
 
     private static final Logger logger = LoggerFactory.getLogger( LockCleanupSessionListener.class );
 
-    @Inject
-    @Named("configIO")
-    private IOService ioService;
-
-    @Inject
-    @Named("systemFS")
-    private FileSystem fileSystem;
-
     @Override
     public void sessionCreated( HttpSessionEvent se ) {
     }
 
     @Override
     public void sessionDestroyed( HttpSessionEvent se ) {
+        final ConfigIOServiceProducer ioServiceProducer = ConfigIOServiceProducer.getInstance();
+        final IOService ioService = ioServiceProducer.configIOService();
+        final FileSystem fileSystem = ioServiceProducer.configFileSystem();
 
         @SuppressWarnings("unchecked")
         final Set<LockInfo> locks = (Set<LockInfo>) se.getSession()

--- a/uberfire-backend/uberfire-backend-server/src/main/java/org/uberfire/backend/server/io/ConfigIOServiceProducer.java
+++ b/uberfire-backend/uberfire-backend-server/src/main/java/org/uberfire/backend/server/io/ConfigIOServiceProducer.java
@@ -15,14 +15,21 @@ import org.uberfire.commons.services.cdi.StartupType;
 import org.uberfire.io.IOService;
 import org.uberfire.io.impl.IOServiceNio2WrapperImpl;
 import org.uberfire.io.impl.cluster.IOServiceClusterImpl;
+import org.uberfire.java.nio.file.FileSystem;
 
 @ApplicationScoped
 @Startup(StartupType.BOOTSTRAP)
 public class ConfigIOServiceProducer {
 
+    private static ConfigIOServiceProducer instance;
+
     @Inject
     @Named("clusterServiceFactory")
     private ClusterServiceFactory clusterServiceFactory;
+    
+    @Inject
+    @Named("systemFS")
+    private FileSystem fileSystem;
 
     @Inject
     @IOSecurityAuth
@@ -32,17 +39,33 @@ public class ConfigIOServiceProducer {
 
     @PostConstruct
     public void setup() {
+        instance = this;
         if ( clusterServiceFactory == null ) {
             configIOService = new IOServiceNio2WrapperImpl( "config" );
         } else {
             configIOService = new IOServiceClusterImpl( new IOServiceNio2WrapperImpl( "config" ), clusterServiceFactory, clusterServiceFactory.isAutoStart() );
         }
     }
+    
+    public void destroy() {
+        instance = null;
+    }
 
     @Produces
     @Named("configIO")
     public IOService configIOService() {
         return configIOService;
+    }
+    
+    public FileSystem configFileSystem() {
+        return fileSystem;
+    }
+    
+    public static ConfigIOServiceProducer getInstance() {
+        if (instance == null) {
+            throw new IllegalStateException(ConfigIOServiceProducer.class.getName() + " not initialized on startup");
+        }
+        return instance;
     }
 
 }

--- a/uberfire-backend/uberfire-backend-server/src/test/java/org/uberfire/backend/server/LockCleanupSessionListenerTest.java
+++ b/uberfire-backend/uberfire-backend-server/src/test/java/org/uberfire/backend/server/LockCleanupSessionListenerTest.java
@@ -1,0 +1,86 @@
+package org.uberfire.backend.server;
+
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.times;
+
+import java.util.Collections;
+
+import javax.servlet.http.HttpSession;
+import javax.servlet.http.HttpSessionEvent;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.uberfire.backend.server.io.ConfigIOServiceProducer;
+import org.uberfire.backend.vfs.PathFactory;
+import org.uberfire.backend.vfs.impl.LockInfo;
+import org.uberfire.io.IOService;
+import org.uberfire.java.nio.file.Path;
+
+@RunWith(MockitoJUnitRunner.class)
+public class LockCleanupSessionListenerTest {
+
+    @Mock
+    private HttpSessionEvent evt;
+
+    @Mock
+    private HttpSession session;
+
+    @Mock
+    private IOService ioService;
+
+    @Test(expected = IllegalStateException.class)
+    public void throwExceptionWhenIOProducerNotInitialized() {
+        final LockCleanupSessionListener listener = new LockCleanupSessionListener();
+        listener.sessionDestroyed( evt );
+    }
+
+    @Test
+    public void initWithoutInjection() {
+        final ConfigIOServiceProducer producer = spy( new ConfigIOServiceProducer() );
+        final LockCleanupSessionListener listener = new LockCleanupSessionListener();
+
+        try {
+            when( evt.getSession() ).thenReturn( session );
+            when( session.getAttribute( VFSLockServiceImpl.LOCK_SESSION_ATTRIBUTE_NAME ) ).thenReturn( Collections.emptySet() );
+            when( producer.configIOService() ).thenReturn( ioService );
+
+            producer.setup();
+            listener.sessionDestroyed( evt );
+
+            // Needs to programmatically request FS and IOService from producer instead of using @Inject (see UF-237)
+            verify( producer ).configIOService();
+            verify( producer ).configFileSystem();
+        } finally {
+            producer.destroy();
+        }
+    }
+
+    @Test
+    public void releaseLockAssociatedWithSession() {
+        final ConfigIOServiceProducer producer = spy( new ConfigIOServiceProducer() );
+        final LockCleanupSessionListener listener = spy( new LockCleanupSessionListener() );
+
+        try {
+            final String lockedBy = "christian";
+            final LockInfo lock = new LockInfo( true,lockedBy, PathFactory.newPath( "file", "default://file" ) );
+
+            when( evt.getSession() ).thenReturn( session );
+            when( session.getAttribute( VFSLockServiceImpl.LOCK_SESSION_ATTRIBUTE_NAME ) ).thenReturn( Collections.singleton( lock ) );
+            when( producer.configIOService() ).thenReturn( ioService );
+            when( ioService.readAllString( any( Path.class ) ) ).thenReturn( lockedBy );
+
+            producer.setup();
+            listener.sessionDestroyed( evt );
+
+            verify( ioService, times(1) ).delete( any( Path.class ));
+        } finally {
+            producer.destroy();
+        }
+    }
+
+}


### PR DESCRIPTION
The problem was that dependency injection in @WebListeners
(HttpSessionListeners) is not supported in various containers
(some versions of Tomcat7, E(J)WS and WLS). Now our listener
is no longer relying on @Inject to get to its dependencies.

Luckily all its dependencies are already available after startup so
this was a relatively easy workaround.

This also includes test coverage.

**Needs to be cherry-picked to 0.7.x**