### PR TITLE
UF241: Docks not hiding when different editor selected

### DIFF
--- a/uberfire-workbench/uberfire-workbench-client-views-bs2/src/main/java/org/uberfire/client/views/bs2/listbar/ListBarWidgetImpl.java
+++ b/uberfire-workbench/uberfire-workbench-client-views-bs2/src/main/java/org/uberfire/client/views/bs2/listbar/ListBarWidgetImpl.java
@@ -168,7 +168,7 @@ public class ListBarWidgetImpl
 
     private WorkbenchDragAndDropManager dndManager;
 
-    private final Map<PartDefinition, FlowPanel> partContentView = new HashMap<PartDefinition, FlowPanel>();
+    final Map<PartDefinition, FlowPanel> partContentView = new HashMap<PartDefinition, FlowPanel>();
     private final Map<PartDefinition, Widget> partTitle = new HashMap<PartDefinition, Widget>();
     LinkedHashSet<PartDefinition> parts = new LinkedHashSet<PartDefinition>();
 
@@ -321,7 +321,7 @@ public class ListBarWidgetImpl
         scheduleResize();
     }
 
-    private void updateBreadcrumb( final PartDefinition partDefinition ) {
+    void updateBreadcrumb( final PartDefinition partDefinition ) {
         this.title.clear();
 
         final Widget title = partTitle.get( partDefinition );
@@ -369,7 +369,7 @@ public class ListBarWidgetImpl
                 return true;
             }
             parts.add( currentPart.getK1() );
-            panelManager.onPartHid(currentPart.getK1());
+            panelManager.onPartHidden( currentPart.getK1() );
             currentPart.getK2().getElement().getStyle().setDisplay( NONE );
         }
 
@@ -388,7 +388,7 @@ public class ListBarWidgetImpl
         return true;
     }
 
-    private void setupDropdown() {
+    void setupDropdown() {
         if ( isMultiPart ) {
             dropdownCaret.setRightDropdown( true );
             dropdownCaret.clear();
@@ -399,7 +399,7 @@ public class ListBarWidgetImpl
         }
     }
 
-    private void setupContextMenu() {
+    void setupContextMenu() {
         contextMenu.clear();
         final WorkbenchPartPresenter.View part = (WorkbenchPartPresenter.View) currentPart.getK2().getWidget( 0 );
         if ( part.getPresenter().getMenus() != null && part.getPresenter().getMenus().getItems().size() > 0 ) {

--- a/uberfire-workbench/uberfire-workbench-client-views-bs2/src/test/java/org/uberfire/client/views/bs2/listbar/ListBarWidgetTest.java
+++ b/uberfire-workbench/uberfire-workbench-client-views-bs2/src/test/java/org/uberfire/client/views/bs2/listbar/ListBarWidgetTest.java
@@ -1,11 +1,5 @@
 package org.uberfire.client.views.bs2.listbar;
 
-import java.lang.annotation.Annotation;
-import java.util.Iterator;
-import java.util.LinkedHashSet;
-import java.util.Map;
-import javax.enterprise.inject.Instance;
-
 import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.event.dom.client.FocusHandler;
 import com.google.gwt.user.client.ui.FlowPanel;
@@ -22,11 +16,16 @@ import org.uberfire.client.workbench.widgets.listbar.ListbarPreferences;
 import org.uberfire.commons.data.Pair;
 import org.uberfire.workbench.model.PartDefinition;
 
-import static org.junit.Assert.*;
+import javax.enterprise.inject.Instance;
+import java.lang.annotation.Annotation;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.*;
 
-@RunWith(GwtMockitoTestRunner.class)
+@RunWith( GwtMockitoTestRunner.class )
 public class ListBarWidgetTest {
 
     @InjectMocks
@@ -82,9 +81,6 @@ public class ListBarWidgetTest {
     private PanelManager panelManager;
 
     @Mock
-    private Map<PartDefinition, FlowPanel> partContentView;
-
-    @Mock
     private LinkedHashSet<PartDefinition> parts;
 
     @Before
@@ -103,7 +99,7 @@ public class ListBarWidgetTest {
 
     @Test
     public void clearCallSequence() {
-        // this gets a setVisisble call earlier in the setup process
+        // this gets a setVisible call earlier in the setup process
         reset( widget.menuArea );
 
         widget.clear();
@@ -113,6 +109,43 @@ public class ListBarWidgetTest {
         verify( widget.content ).clear();
         verify( parts ).clear();
         assertTrue( widget.partChooserList == null );
+    }
+
+    @Test
+    public void onSelectPartOnPartHiddenEventIsFired() {
+        ListBarWidgetImpl listBar = getStubListBarWidget();
+
+
+        final PartDefinition selectedPart = mock( PartDefinition.class );
+        final PartDefinition currentPart = mock( PartDefinition.class );
+
+        listBar.panelManager = panelManager;
+        listBar.partContentView.put( selectedPart, new FlowPanel() );
+        listBar.parts.add( selectedPart );
+        listBar.currentPart = Pair.newPair( currentPart, new FlowPanel() );
+        listBar.partContentView.put( currentPart, new FlowPanel() );
+
+
+        listBar.selectPart( selectedPart );
+
+        verify( panelManager ).onPartHidden( currentPart );
+
+    }
+
+    private ListBarWidgetImpl getStubListBarWidget() {
+        return new ListBarWidgetImpl() {
+            @Override
+            void setupContextMenu() {
+            }
+
+            @Override
+            void setupDropdown() {
+            }
+
+            @Override
+            void updateBreadcrumb( PartDefinition partDefinition ) {
+            }
+        };
     }
 
 }

--- a/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/main/java/org/uberfire/client/views/pfly/listbar/ListBarWidgetImpl.java
+++ b/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/main/java/org/uberfire/client/views/pfly/listbar/ListBarWidgetImpl.java
@@ -145,7 +145,7 @@ public class ListBarWidgetImpl
 
     WorkbenchPanelPresenter presenter;
 
-    private final Map<PartDefinition, FlowPanel> partContentView = new HashMap<PartDefinition, FlowPanel>();
+    final Map<PartDefinition, FlowPanel> partContentView = new HashMap<PartDefinition, FlowPanel>();
     LinkedHashSet<PartDefinition> parts = new LinkedHashSet<PartDefinition>();
 
     Pair<PartDefinition, FlowPanel> currentPart;
@@ -300,6 +300,7 @@ public class ListBarWidgetImpl
                 return true;
             }
             parts.add( currentPart.getK1() );
+            panelManager.onPartHidden( currentPart.getK1() );
             currentPart.getK2().getElement().getStyle().setDisplay( NONE );
         }
 
@@ -317,7 +318,7 @@ public class ListBarWidgetImpl
         return true;
     }
 
-    private void setupContextMenu() {
+    void setupContextMenu() {
         contextMenu.clear();
         final WorkbenchPartPresenter.View part = (WorkbenchPartPresenter.View) currentPart.getK2().getWidget( 0 );
         if ( part.getPresenter().getMenus() != null && part.getPresenter().getMenus().getItems().size() > 0 ) {

--- a/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/test/java/org/uberfire/client/views/pfly/PatternFlyTabTests.gwt.xml
+++ b/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/test/java/org/uberfire/client/views/pfly/PatternFlyTabTests.gwt.xml
@@ -7,4 +7,5 @@
 
   <source path='tab'/>
   <source path='mock'/>
+  <source path='listbar'/>
 </module>

--- a/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/test/java/org/uberfire/client/views/pfly/listbar/ListBarWidgetImplTest.java
+++ b/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/test/java/org/uberfire/client/views/pfly/listbar/ListBarWidgetImplTest.java
@@ -1,0 +1,49 @@
+package org.uberfire.client.views.pfly.listbar;
+
+import com.google.gwt.user.client.ui.FlowPanel;
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.uberfire.client.workbench.PanelManager;
+import org.uberfire.commons.data.Pair;
+import org.uberfire.workbench.model.PartDefinition;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+@RunWith( GwtMockitoTestRunner.class )
+public class ListBarWidgetImplTest {
+
+    ListBarWidgetImpl listBar;
+
+    @Before
+    public void setUp() throws Exception {
+        listBar = new ListBarWidgetImpl() {
+            @Override
+            void setupContextMenu() {
+            }
+        };
+    }
+
+    @Test
+    public void onSelectPartOnPartHiddenEventIsFired() {
+
+        final PartDefinition selectedPart = mock( PartDefinition.class );
+        final PartDefinition currentPart = mock( PartDefinition.class );
+
+        listBar.panelManager = mock( PanelManager.class );
+        listBar.partContentView.put( selectedPart, new FlowPanel() );
+        listBar.parts.add( selectedPart );
+        listBar.currentPart = Pair.newPair( currentPart, new FlowPanel() );
+        listBar.partContentView.put( currentPart, new FlowPanel() );
+        listBar.titleDropDown = mock( PartListDropdown.class );
+
+        listBar.selectPart( selectedPart );
+
+        verify( listBar.panelManager ).onPartHidden( currentPart );
+
+    }
+
+
+}

--- a/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/PanelManager.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/PanelManager.java
@@ -180,9 +180,9 @@ public interface PanelManager {
     PanelDefinition getPanelForPlace( PlaceRequest place );
 
     /**
-     * @param the part that has been hid
+     * @param part that has been hidden
      */
-    void onPartHid(PartDefinition part);
+    void onPartHidden( PartDefinition part );
 
     /**
      * @param part the part that has been maximized

--- a/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/PanelManagerImpl.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/PanelManagerImpl.java
@@ -65,7 +65,7 @@ public class PanelManagerImpl implements PanelManager {
     protected Event<PlaceMinimizedEvent> placeMinimizedEventEvent;
 
     @Inject
-    protected Event<PlaceHidEvent> placeHidEvent;
+    protected Event<PlaceHiddenEvent> placeHiddenEvent;
 
     @Inject
     protected SyncBeanManager iocManager;
@@ -286,8 +286,8 @@ public class PanelManagerImpl implements PanelManager {
     }
 
     @Override
-    public void onPartHid( final PartDefinition part ) {
-        placeHidEvent.fire( new PlaceHidEvent( part.getPlace() ) );
+    public void onPartHidden( final PartDefinition part ) {
+        placeHiddenEvent.fire( new PlaceHiddenEvent( part.getPlace() ) );
     }
 
     @Override

--- a/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/events/PlaceHiddenEvent.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/events/PlaceHiddenEvent.java
@@ -20,17 +20,17 @@ package org.uberfire.client.workbench.events;
 import org.uberfire.mvp.PlaceRequest;
 
 /**
- * Fired by the framework each time a workbench editor or screen gets hid.
+ * Fired by the framework each time a workbench editor or screen gets hidden.
  */
-public class PlaceHidEvent extends AbstractPlaceEvent {
+public class PlaceHiddenEvent extends AbstractPlaceEvent {
 
-    public PlaceHidEvent(final PlaceRequest place) {
+    public PlaceHiddenEvent( final PlaceRequest place ) {
         super(place);
     }
 
     @Override
     public String toString() {
-        return "PlaceHidEvent [place=" + getPlace() + "]";
+        return "PlaceHiddenEvent [place=" + getPlace() + "]";
     }
 
 


### PR DESCRIPTION
When switching between files, the newly introduced PlaceHidEvent is not fired, causing docks to stay active when they shouldn't.

Also renamed PlaceHidEvent to PlaceHiddenEvent.

Note, this only affects 0.8.0-SNAPSHOT. 0.7.0 works fine.

https://issues.jboss.org/browse/UF-241