### PR TITLE
BZ1269333: Result of searching assets by Business Central includes duplicate records

### DIFF
--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/main/java/org/uberfire/java/nio/fs/jgit/JGitFileSystemProvider.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/main/java/org/uberfire/java/nio/fs/jgit/JGitFileSystemProvider.java
@@ -138,7 +138,6 @@ import org.uberfire.java.nio.security.FileSystemAuthenticator;
 import org.uberfire.java.nio.security.FileSystemAuthorizer;
 import org.uberfire.java.nio.security.SecuredFileSystemProvider;
 
-import static org.eclipse.jgit.api.ListBranchCommand.ListMode.*;
 import static org.eclipse.jgit.lib.Constants.*;
 import static org.uberfire.commons.validation.PortablePreconditions.*;
 import static org.uberfire.java.nio.base.dotfiles.DotFileUtils.*;
@@ -404,7 +403,11 @@ public class JGitFileSystemProvider implements SecuredFileSystemProvider,
                 try {
                     if ( repoDir.isDirectory() ) {
                         final String name = repoDir.getName().substring( 0, repoDir.getName().indexOf( DOT_GIT_EXT ) );
-                        final JGitFileSystem fs = new JGitFileSystem( this, fullHostNames, newRepository( repoDir, true ), name, ALL, buildCredential( null ) );
+                        //Default to ListMode of null to avoid indexing scanning remote branches. Ideally the ListMode should
+                        //be identical to that used when the original JGitFileSystem was created however that information is not
+                        //persisted. Using a default of null rather than ALL is a safer default as *all* GIT repositories created
+                        //from within the workbench have a ListMode of null.
+                        final JGitFileSystem fs = new JGitFileSystem( this, fullHostNames, newRepository( repoDir, true ), name, null, buildCredential( null ) );
                         LOG.debug( "Running GIT GC on '" + name + "'" );
                         JGitUtil.gc( fs.gitRepo() );
                         LOG.debug( "Registering existing GIT filesystem '" + name + "' at " + repoDir );


### PR DESCRIPTION
See https://bugzilla.redhat.com/show_bug.cgi?id=1269333

The issue was when existing repositories in ```.niogit``` were re-scanned (i.e. after a stop and restart) the ```ListMode``` used by ```GIT``` to retrieve branch information defaulted to ```ALL``` which meant index information for ```origin\master``` and ```master``` was being created.