### PR TITLE
showcase: remove GWT permutations for IE10 and older

### DIFF
--- a/uberfire-showcase/uberfire-client-webapp/src/main/resources/org/uberfire/UberfireShowcaseClient.gwt.xml
+++ b/uberfire-showcase/uberfire-client-webapp/src/main/resources/org/uberfire/UberfireShowcaseClient.gwt.xml
@@ -24,4 +24,7 @@
   <inherits name="org.jboss.errai.bus.ErraiBus" />
   <inherits name="org.jboss.errai.ioc.Container" />
 
+  <!-- We don't need to support IE10 or older -->
+  <!-- There is no "ie11" permutation. IE11 uses the Firefox one (gecko1_8) -->
+  <set-property name="user.agent" value="gecko1_8,safari"/>
 </module>

--- a/uberfire-showcase/uberfire-webapp/src/main/resources/org/uberfire/UberfireShowcase.gwt.xml
+++ b/uberfire-showcase/uberfire-webapp/src/main/resources/org/uberfire/UberfireShowcase.gwt.xml
@@ -19,4 +19,7 @@
   <extend-property name="locale" values="pt_BR"/>
   <extend-property name="locale" values="zh_CN"/>
 
+  <!-- We don't need to support IE10 or older -->
+  <!-- There is no "ie11" permutation. IE11 uses the Firefox one (gecko1_8) -->
+  <set-property name="user.agent" value="gecko1_8,safari"/>
 </module>


### PR DESCRIPTION
IE10 and older IEs are not supported, so no need to build the permutations for them.