### PR TITLE
BZ:1271532: BPM cluster fails to setup due to NPE in uberfire

### DIFF
--- a/uberfire-io/src/test/java/org/uberfire/io/impl/cluster/helix/ClusterServiceHelixTest.java
+++ b/uberfire-io/src/test/java/org/uberfire/io/impl/cluster/helix/ClusterServiceHelixTest.java
@@ -1,0 +1,82 @@
+package org.uberfire.io.impl.cluster.helix;
+
+import org.apache.helix.HelixManager;
+import org.apache.helix.model.ExternalView;
+import org.junit.Before;
+import org.junit.Test;
+import org.uberfire.commons.message.MessageHandlerResolver;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.when;
+
+public class ClusterServiceHelixTest {
+
+
+    ClusterServiceHelix clusterServiceHelix;
+    ExternalView externalView;
+
+    @Test
+    public void getNodeStatusEmptyOrNullShouldReturnOfflineTest() {
+
+        when( externalView.getStateMap( "resourceName_0" )).thenReturn( null );
+        assertEquals( "OFFLINE", clusterServiceHelix.getNodeStatus() );
+
+        Map<String, String> emptyMap = new HashMap<String, String>(  );
+        when( externalView.getStateMap( "resourceName_0" )).thenReturn( emptyMap );
+        assertEquals( "OFFLINE", clusterServiceHelix.getNodeStatus() );
+
+    }
+
+    @Test
+    public void getNodeStatusTest() {
+
+        Map<String, String> valueMap = new HashMap<String, String>(  );
+        valueMap.put( "instanceName" , "LEADER" );
+        when( externalView.getStateMap( "resourceName_0" ) ).thenReturn( valueMap );
+        assertEquals( "LEADER", clusterServiceHelix.getNodeStatus() );
+
+    }
+
+    @Test
+    public void getNodeStatusNullViewTest() {
+        externalView = null;
+        assertEquals( "OFFLINE", clusterServiceHelix.getNodeStatus() );
+    }
+
+
+    @Before
+    public void setup() {
+        externalView = mock( ExternalView.class );
+
+        clusterServiceHelix = new ClusterServiceHelix( "clusterName",
+                "zkAddress",
+                "instanceName",
+                "resourceName",
+                mock( MessageHandlerResolver.class ) ) {
+            @Override
+            HelixManager getZkHelixManager( String clusterName, String zkAddress, String instanceName ) {
+                return mock( HelixManager.class );
+            }
+
+            ;
+
+            @Override
+            void start() {
+            }
+
+            @Override
+            public void addMessageHandlerResolver( MessageHandlerResolver resolver ) {
+            }
+
+            @Override
+            ExternalView getResourceExternalView() {
+                return externalView;
+            }
+        };
+    }
+}


### PR DESCRIPTION
Having a BPM cluster with 2 EAP nodes in a domain, the cluster fails to initialize due to NPE in org.uberfire.io.impl.cluster.helix.ClusterServiceHelix.getNodeStatus(). The first node starts up just fine, but the second node fails to deploy Business Central.

The issue occurs when cluster starts with a clean environment - including DB, .niogit and .index for both nodes,  due to nullview or empty map returned by Helix.
      
        String getNodeStatus() {
        final String partition = resourceName + "_0";
        final ExternalView view = getResourceExternalView();
        if ( clusterIsNotSetYet( view, partition ) ) {
            return "OFFLINE";
        }
        final Map<String, String> stateMap = view.getStateMap( partition );
        return stateMap.get( instanceName );
       }


      private boolean clusterIsNotSetYet( ExternalView view, String partition ) {
        //first start with fresh setup
        if( view==null ){
            return true;
        }
        final Map<String, String> stateMap = view.getStateMap( partition );

        return stateMap == null || stateMap.get( instanceName ) == null;
    }

       
and then the NPE used to happen here : view.getStateMap( partition ) or  stateMap.get( instanceName ) 