### PR TITLE
UF-243: Configurable locking strategy for workbench editors

### DIFF
--- a/uberfire-client-api/src/main/java/org/uberfire/client/annotations/WorkbenchEditor.java
+++ b/uberfire-client-api/src/main/java/org/uberfire/client/annotations/WorkbenchEditor.java
@@ -92,4 +92,18 @@ public @interface WorkbenchEditor {
      * is the trigger to create a new panel, if panel already exists this information is ignored.
      */
     int preferredWidth() default -1;
+    
+    /**
+     * Defines how and if locks are acquired when using this editor. By default, a pessimistic locking 
+     * strategy is used, allowing edits by only one user at a time.
+     */
+    LockingStrategy lockingStrategy() default LockingStrategy.PESSIMISTIC; 
+    
+    /**
+     * Locking strategies define how and if locks are acquired when using editors.
+     */
+    public static enum LockingStrategy {
+        OPTIMISTIC, // No locks are acquired, editor implementations need their own conflict resolution logic (if desired).
+        PESSIMISTIC // Locks are acquired allowing edits by only one user at a time
+    }
 }

--- a/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/mvp/AbstractWorkbenchEditorActivity.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/mvp/AbstractWorkbenchEditorActivity.java
@@ -15,14 +15,17 @@
  */
 package org.uberfire.client.mvp;
 
+import static org.uberfire.client.annotations.WorkbenchEditor.LockingStrategy.PESSIMISTIC;
+
 import javax.inject.Inject;
 
 import org.uberfire.backend.vfs.ObservablePath;
 import org.uberfire.client.annotations.WorkbenchEditor;
+import org.uberfire.client.annotations.WorkbenchEditor.LockingStrategy;
 import org.uberfire.client.mvp.LockTarget.TitleProvider;
 import org.uberfire.mvp.PlaceRequest;
 import org.uberfire.mvp.impl.PathPlaceRequest;
-
+    
 /**
  * Implementation of behaviour common to all workbench editor activities. Concrete implementations are typically not
  * written by hand; rather, they are generated from classes annotated with {@link WorkbenchEditor}.
@@ -30,7 +33,7 @@ import org.uberfire.mvp.impl.PathPlaceRequest;
 public abstract class AbstractWorkbenchEditorActivity extends AbstractWorkbenchActivity implements WorkbenchEditorActivity {
 
     @Inject
-    private LockManager lockManager;
+    protected LockManager lockManager;
     
     protected ObservablePath path;
 
@@ -85,7 +88,10 @@ public abstract class AbstractWorkbenchEditorActivity extends AbstractWorkbenchA
     @Override
     public void onOpen() {
         super.onOpen();
-        lockManager.acquireLockOnDemand();
+        
+        if (getLockingStrategy() == PESSIMISTIC) {
+            lockManager.acquireLockOnDemand();
+        }
     }
 
     @Override
@@ -110,6 +116,15 @@ public abstract class AbstractWorkbenchEditorActivity extends AbstractWorkbenchA
         if ( path != null ) {
             lockManager.onFocus();
         }
+    }
+    
+    /**
+     * Returns the locking strategy for this editor activity, defaulting to
+     * pessimistic. This method is overridden for generated activities returning
+     * the strategy configured at {@link WorkbenchEditor}.
+     */
+    protected LockingStrategy getLockingStrategy() {
+        return LockingStrategy.PESSIMISTIC;
     }
     
 }

--- a/uberfire-workbench/uberfire-workbench-client/src/test/java/org/uberfire/client/mvp/WorkbenchEditorActivityTest.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/test/java/org/uberfire/client/mvp/WorkbenchEditorActivityTest.java
@@ -1,0 +1,98 @@
+package org.uberfire.client.mvp;
+
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.uberfire.client.annotations.WorkbenchEditor.LockingStrategy.OPTIMISTIC;
+import static org.uberfire.client.annotations.WorkbenchEditor.LockingStrategy.PESSIMISTIC;
+
+import java.util.Collection;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.uberfire.client.annotations.WorkbenchEditor.LockingStrategy;
+import org.uberfire.mvp.PlaceRequest;
+
+import com.google.gwt.user.client.ui.IsWidget;
+import com.google.gwtmockito.GwtMockitoTestRunner;
+
+@RunWith(GwtMockitoTestRunner.class)
+public class WorkbenchEditorActivityTest {
+
+    @Mock
+    private LockManager lockManager;
+    
+    @Mock
+    private PlaceRequest place;
+    
+    @Mock
+    private PlaceManager placeManager;
+    
+    private class EditorTestActivity extends AbstractWorkbenchEditorActivity {
+        private LockingStrategy strategy;
+        
+        public EditorTestActivity( LockManager lockManager, PlaceManager placeManager, LockingStrategy strategy  ) {
+            super( placeManager );
+            this.lockManager = lockManager;
+            this.strategy = strategy;
+        }
+
+        @Override
+        public String getIdentifier() {
+            return null;
+        }
+
+        @Override
+        public Collection<String> getRoles() {
+            return null;
+        }
+
+        @Override
+        public String getSignatureId() {
+            return null;
+        }
+
+        @Override
+        public Collection<String> getTraits() {
+            return null;
+        }
+
+        @Override
+        public String getTitle() {
+            return null;
+        }
+
+        @Override
+        public IsWidget getWidget() {
+            return null;
+        }
+
+        @Override
+        protected LockingStrategy getLockingStrategy() {
+            return strategy;
+        }
+        
+    }
+   
+    @Test
+    public void optimisticLockingDoesNotAcquireLocks() {
+        EditorTestActivity activity = new EditorTestActivity (lockManager, placeManager, OPTIMISTIC);
+        
+        activity.onStartup( place );
+        activity.onOpen();
+        
+        verify(lockManager, never()).acquireLockOnDemand();
+    }
+    
+    @Test
+    public void pessimisticLockingAcquiresLocks() {
+        EditorTestActivity activity = new EditorTestActivity (lockManager, placeManager, PESSIMISTIC);
+        
+        activity.onStartup( place );
+        activity.onOpen();
+        
+        verify(lockManager, times(1)).acquireLockOnDemand();
+    }
+
+}

--- a/uberfire-workbench/uberfire-workbench-processors-tests/src/test/java/org/uberfire/annotations/processors/WorkbenchEditorProcessorTest.java
+++ b/uberfire-workbench/uberfire-workbench-processors-tests/src/test/java/org/uberfire/annotations/processors/WorkbenchEditorProcessorTest.java
@@ -102,8 +102,8 @@ public class WorkbenchEditorProcessorTest extends AbstractProcessorTest {
         assertSuccessfulCompilation( diagnostics );
         assertNotNull( result.getActualCode() );
         assertNotNull( result.getExpectedCode() );
-        assertEquals( result.getActualCode(),
-                      result.getExpectedCode() );
+        assertEquals( result.getExpectedCode(),
+                      result.getActualCode() );
     }
 
     @Test
@@ -120,8 +120,8 @@ public class WorkbenchEditorProcessorTest extends AbstractProcessorTest {
         assertSuccessfulCompilation( diagnostics );
         assertNotNull( result.getActualCode() );
         assertNotNull( result.getExpectedCode() );
-        assertEquals( result.getActualCode(),
-                      result.getExpectedCode() );
+        assertEquals( result.getExpectedCode(),
+                      result.getActualCode() );
     }
 
     @Test
@@ -139,8 +139,8 @@ public class WorkbenchEditorProcessorTest extends AbstractProcessorTest {
         assertCompilationMessage( diagnostics, Kind.WARNING, Diagnostic.NOPOS, Diagnostic.NOPOS, "The WorkbenchEditor both extends com.google.gwt.user.client.ui.IsWidget and provides a @WorkbenchPartView annotated method. The annotated method will take precedence." );
         assertNotNull( result.getActualCode() );
         assertNotNull( result.getExpectedCode() );
-        assertEquals( result.getActualCode(),
-                      result.getExpectedCode() );
+        assertEquals( result.getExpectedCode(),
+                      result.getActualCode() );
     }
 
     @Test
@@ -157,8 +157,8 @@ public class WorkbenchEditorProcessorTest extends AbstractProcessorTest {
         assertSuccessfulCompilation( diagnostics );
         assertNotNull( result.getActualCode() );
         assertNotNull( result.getExpectedCode() );
-        assertEquals( result.getActualCode(),
-                      result.getExpectedCode() );
+        assertEquals( result.getExpectedCode(),
+                      result.getActualCode() );
     }
 
     @Test
@@ -175,8 +175,8 @@ public class WorkbenchEditorProcessorTest extends AbstractProcessorTest {
         assertSuccessfulCompilation( diagnostics );
         assertNotNull( result.getActualCode() );
         assertNotNull( result.getExpectedCode() );
-        assertEquals( result.getActualCode(),
-                      result.getExpectedCode() );
+        assertEquals( result.getExpectedCode(),
+                      result.getActualCode() );
     }
 
     @Test
@@ -193,8 +193,8 @@ public class WorkbenchEditorProcessorTest extends AbstractProcessorTest {
         assertSuccessfulCompilation( diagnostics );
         assertNotNull( result.getActualCode() );
         assertNotNull( result.getExpectedCode() );
-        assertEquals( result.getActualCode(),
-                      result.getExpectedCode() );
+        assertEquals( result.getExpectedCode(),
+                      result.getActualCode() );
     }
 
     @Test
@@ -211,8 +211,8 @@ public class WorkbenchEditorProcessorTest extends AbstractProcessorTest {
         assertSuccessfulCompilation( diagnostics );
         assertNotNull( result.getActualCode() );
         assertNotNull( result.getExpectedCode() );
-        assertEquals( result.getActualCode(),
-                      result.getExpectedCode() );
+        assertEquals( result.getExpectedCode(),
+                      result.getActualCode() );
     }
 
     @Test
@@ -229,8 +229,8 @@ public class WorkbenchEditorProcessorTest extends AbstractProcessorTest {
         assertSuccessfulCompilation( diagnostics );
         assertNotNull( result.getActualCode() );
         assertNotNull( result.getExpectedCode() );
-        assertEquals( result.getActualCode(),
-                      result.getExpectedCode() );
+        assertEquals( result.getExpectedCode(),
+                      result.getActualCode() );
     }
 
     @Test
@@ -267,8 +267,8 @@ public class WorkbenchEditorProcessorTest extends AbstractProcessorTest {
         assertCompilationMessage( diagnostics, Kind.WARNING, 27, 17, "There is also an @OnStartup(Path, PlaceRequest) method in this class. That method takes precedence over this one." );
         assertNotNull( result.getActualCode() );
         assertNotNull( result.getExpectedCode() );
-        assertEquals( result.getActualCode(),
-                      result.getExpectedCode() );
+        assertEquals( result.getExpectedCode(),
+                      result.getActualCode() );
     }
 
     @Test
@@ -285,8 +285,8 @@ public class WorkbenchEditorProcessorTest extends AbstractProcessorTest {
         assertSuccessfulCompilation( diagnostics );
         assertNotNull( result.getActualCode() );
         assertNotNull( result.getExpectedCode() );
-        assertEquals( result.getActualCode(),
-                      result.getExpectedCode() );
+        assertEquals( result.getExpectedCode(),
+                      result.getActualCode() );
     }
 
     @Test
@@ -303,8 +303,8 @@ public class WorkbenchEditorProcessorTest extends AbstractProcessorTest {
         assertSuccessfulCompilation( diagnostics );
         assertNotNull( result.getActualCode() );
         assertNotNull( result.getExpectedCode() );
-        assertEquals( result.getActualCode(),
-                      result.getExpectedCode() );
+        assertEquals( result.getExpectedCode(),
+                      result.getActualCode() );
     }
 
     @Test
@@ -321,8 +321,8 @@ public class WorkbenchEditorProcessorTest extends AbstractProcessorTest {
         assertSuccessfulCompilation( diagnostics );
         assertNotNull( result.getActualCode() );
         assertNotNull( result.getExpectedCode() );
-        assertEquals( result.getActualCode(),
-                      result.getExpectedCode() );
+        assertEquals( result.getExpectedCode(),
+                      result.getActualCode() );
     }
 
     @Test
@@ -339,8 +339,8 @@ public class WorkbenchEditorProcessorTest extends AbstractProcessorTest {
         assertSuccessfulCompilation( diagnostics );
         assertNotNull( result.getActualCode() );
         assertNotNull( result.getExpectedCode() );
-        assertEquals( result.getActualCode(),
-                      result.getExpectedCode() );
+        assertEquals( result.getExpectedCode(),
+                      result.getActualCode() );
     }
 
     @Test
@@ -356,7 +356,8 @@ public class WorkbenchEditorProcessorTest extends AbstractProcessorTest {
         assertSuccessfulCompilation( diagnostics );
         assertNotNull( result.getActualCode() );
         assertNotNull( result.getExpectedCode() );
-        assertEquals( result.getActualCode(), result.getExpectedCode() );
+        assertEquals( result.getExpectedCode(), 
+                      result.getActualCode() );
     }
 
     @Test
@@ -383,8 +384,8 @@ public class WorkbenchEditorProcessorTest extends AbstractProcessorTest {
         assertSuccessfulCompilation( diagnostics );
         assertNotNull( result.getActualCode() );
         assertNotNull( result.getExpectedCode() );
-        assertEquals( result.getActualCode(),
-                      result.getExpectedCode() );
+        assertEquals( result.getExpectedCode(),
+                      result.getActualCode() );
     }
 
     public void testWorkbenchEditorMultipleSupportedTypesWithNegativePreferredWidth() throws FileNotFoundException {
@@ -398,8 +399,8 @@ public class WorkbenchEditorProcessorTest extends AbstractProcessorTest {
         assertSuccessfulCompilation( diagnostics );
         assertNotNull( result.getActualCode() );
         assertNotNull( result.getExpectedCode() );
-        assertEquals( result.getActualCode(),
-                      result.getExpectedCode() );
+        assertEquals( result.getExpectedCode(),
+                      result.getActualCode() );
     }
 
     @Test
@@ -414,8 +415,8 @@ public class WorkbenchEditorProcessorTest extends AbstractProcessorTest {
         assertSuccessfulCompilation( diagnostics );
         assertNotNull( result.getActualCode() );
         assertNotNull( result.getExpectedCode() );
-        assertEquals( result.getActualCode(),
-                      result.getExpectedCode() );
+        assertEquals( result.getExpectedCode(),
+                      result.getActualCode() );
     }
 
     @Test
@@ -430,8 +431,8 @@ public class WorkbenchEditorProcessorTest extends AbstractProcessorTest {
         assertSuccessfulCompilation( diagnostics );
         assertNotNull( result.getActualCode() );
         assertNotNull( result.getExpectedCode() );
-        assertEquals( result.getActualCode(),
-                      result.getExpectedCode() );
+        assertEquals( result.getExpectedCode(),
+                      result.getActualCode() );
     }
 
     @Test
@@ -446,8 +447,8 @@ public class WorkbenchEditorProcessorTest extends AbstractProcessorTest {
         assertSuccessfulCompilation( diagnostics );
         assertNotNull( result.getActualCode() );
         assertNotNull( result.getExpectedCode() );
-        assertEquals( result.getActualCode(),
-                      result.getExpectedCode() );
+        assertEquals( result.getExpectedCode(),
+                      result.getActualCode() );
     }
 
     @Test
@@ -462,7 +463,24 @@ public class WorkbenchEditorProcessorTest extends AbstractProcessorTest {
         assertSuccessfulCompilation( diagnostics );
         assertNotNull( result.getActualCode() );
         assertNotNull( result.getExpectedCode() );
-        assertEquals( result.getActualCode(),
-                      result.getExpectedCode() );
+        assertEquals( result.getExpectedCode(),
+                      result.getActualCode() );
+    }
+    
+    @Test
+    public void testEditorWithLockingStrategy() throws FileNotFoundException {
+        final String pathCompilationUnit = "org/uberfire/annotations/processors/WorkbenchEditorTest27";
+        final String pathExpectedResult = "org/uberfire/annotations/processors/expected/WorkbenchEditorTest27.expected";
+
+        result.setExpectedCode( getExpectedSourceCode( pathExpectedResult ) );
+
+        final List<Diagnostic<? extends JavaFileObject>> diagnostics = compile(
+                getProcessorUnderTest(),
+                pathCompilationUnit );
+        assertSuccessfulCompilation( diagnostics );
+        assertNotNull( result.getActualCode() );
+        assertNotNull( result.getExpectedCode() );
+        assertEquals( result.getExpectedCode(), 
+                      result.getActualCode() );
     }
 }

--- a/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/WorkbenchEditorTest27.java
+++ b/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/WorkbenchEditorTest27.java
@@ -1,0 +1,27 @@
+package org.uberfire.annotations.processors;
+
+import com.google.gwt.user.client.ui.IsWidget;
+import com.google.gwt.user.client.ui.SimplePanel;
+
+import org.jboss.errai.ioc.client.api.ActivatedBy;
+import org.uberfire.client.annotations.WorkbenchEditor;
+import org.uberfire.client.annotations.WorkbenchPartTitle;
+import org.uberfire.client.annotations.WorkbenchPartView;
+import static org.uberfire.client.annotations.WorkbenchEditor.LockingStrategy.PESSIMISTIC;
+import org.uberfire.client.mvp.MyTestType;
+import org.uberfire.security.annotations.Roles;
+
+@WorkbenchEditor(identifier = "test27", lockingStrategy = PESSIMISTIC)
+public class WorkbenchEditorTest27 {
+
+    @WorkbenchPartView
+    public IsWidget getView() {
+        return new SimplePanel();
+    }
+
+    @WorkbenchPartTitle
+    public String getTitle() {
+        return "title";
+    }
+
+}

--- a/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/WorkbenchEditorTest8.java
+++ b/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/WorkbenchEditorTest8.java
@@ -4,6 +4,7 @@ import com.google.gwt.user.client.ui.IsWidget;
 import com.google.gwt.user.client.ui.SimplePanel;
 import org.uberfire.backend.vfs.ObservablePath;
 import org.uberfire.client.annotations.WorkbenchEditor;
+import org.uberfire.client.annotations.WorkbenchEditor.LockingStrategy;
 import org.uberfire.client.annotations.WorkbenchPartTitle;
 import org.uberfire.client.annotations.WorkbenchPartView;
 import org.uberfire.client.mvp.MyTestType;
@@ -14,7 +15,7 @@ import org.uberfire.lifecycle.OnMayClose;
 import org.uberfire.lifecycle.OnOpen;
 import org.uberfire.lifecycle.OnStartup;
 
-@WorkbenchEditor(identifier = "test8", supportedTypes = { MyTestType.class })
+@WorkbenchEditor(identifier = "test8", supportedTypes = { MyTestType.class }, lockingStrategy = LockingStrategy.OPTIMISTIC)
 public class WorkbenchEditorTest8 {
 
     @WorkbenchPartView

--- a/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/WorkbenchEditorTest27.expected
+++ b/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/WorkbenchEditorTest27.expected
@@ -24,7 +24,6 @@ import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
 
 import javax.inject.Named;
-import org.uberfire.client.workbench.annotations.AssociatedResources;
 import org.uberfire.client.workbench.annotations.Priority;
 import org.uberfire.client.mvp.AbstractWorkbenchEditorActivity;
 import org.uberfire.client.mvp.PlaceManager;
@@ -40,64 +39,24 @@ import static org.uberfire.client.annotations.WorkbenchEditor.LockingStrategy.*;
 
 @Dependent
 @Generated("org.uberfire.annotations.processors.WorkbenchEditorProcessor")
-@Named("test8")
-@AssociatedResources({
-    org.uberfire.client.mvp.MyTestType.class
-})
-
+@Named("test27")
 @Priority(0)
 /*
  * WARNING! This class is generated. Do not modify.
  */
-public class WorkbenchEditorTest8Activity extends AbstractWorkbenchEditorActivity {
+public class WorkbenchEditorTest27Activity extends AbstractWorkbenchEditorActivity {
 
     private static final Collection<String> ROLES = Collections.emptyList();
 
     private static final Collection<String> TRAITS = Collections.emptyList();
 
     @Inject
-    private WorkbenchEditorTest8 realPresenter;
+    private WorkbenchEditorTest27 realPresenter;
 
     @Inject
     //Constructor injection for testing
-    public WorkbenchEditorTest8Activity(final PlaceManager placeManager) {
+    public WorkbenchEditorTest27Activity(final PlaceManager placeManager) {
         super( placeManager );
-    }
-
-    @Override
-    public void onStartup(final ObservablePath path,
-                        final PlaceRequest place) {
-        super.onStartup( path, place );
-        realPresenter.onStartup( path );
-    }
-
-    @Override
-    public boolean onMayClose() {
-        return realPresenter.onMayClose();
-    }
-
-    @Override
-    public void onClose() {
-        super.onClose();
-        realPresenter.onClose();
-    }
-
-    @Override
-    public void onOpen() {
-        super.onOpen();
-        realPresenter.onOpen();
-    }
-
-    @Override
-    public void onLostFocus() {
-        super.onLostFocus();
-        realPresenter.onLostFocus();
-    }
-
-    @Override
-    public void onFocus() {
-        super.onFocus();
-        realPresenter.onFocus();
     }
 
     @Override
@@ -122,17 +81,17 @@ public class WorkbenchEditorTest8Activity extends AbstractWorkbenchEditorActivit
 
     @Override
     public String getSignatureId() {
-        return "org.uberfire.annotations.processors.WorkbenchEditorTest8Activity";
+        return "org.uberfire.annotations.processors.WorkbenchEditorTest27Activity";
     }
 
     @Override
     public LockingStrategy getLockingStrategy() {
-        return OPTIMISTIC;
+        return PESSIMISTIC;
     }
     
     @Override
     public String getIdentifier() {
-        return "test8";
+        return "test27";
     }
 
 }

--- a/uberfire-workbench/uberfire-workbench-processors/src/main/java/org/uberfire/annotations/processors/EditorActivityGenerator.java
+++ b/uberfire-workbench/uberfire-workbench-processors/src/main/java/org/uberfire/annotations/processors/EditorActivityGenerator.java
@@ -67,6 +67,7 @@ public class EditorActivityGenerator extends AbstractGenerator {
         Integer priority = 0;
         Collection<String> associatedResources = null;
         String identifier = null;
+        String lockingStrategy = null;
         Integer preferredHeight = null;
         Integer preferredWidth = null;
 
@@ -90,6 +91,8 @@ public class EditorActivityGenerator extends AbstractGenerator {
                         if ( _preferredWidth > 0 ) {
                             preferredWidth = _preferredWidth;
                         }
+                    } else if ( "lockingStrategy".equals( entry.getKey().getSimpleName().toString() ) ) {
+                        lockingStrategy = aval.getValue().toString();
                     }
                 }
                 break;
@@ -170,6 +173,7 @@ public class EditorActivityGenerator extends AbstractGenerator {
             messager.printMessage( Kind.NOTE, "Package name: " + packageName );
             messager.printMessage( Kind.NOTE, "Class name: " + className );
             messager.printMessage( Kind.NOTE, "Identifier: " + identifier );
+            messager.printMessage( Kind.NOTE, "Locking strategy: " + lockingStrategy );
             messager.printMessage( Kind.NOTE, "Owning Perspective Identifier: " + owningPlace );
             messager.printMessage( Kind.NOTE, "getContextIdMethodName: " + getContextIdMethodName );
             messager.printMessage( Kind.NOTE, "Priority: " + priority );
@@ -220,6 +224,8 @@ public class EditorActivityGenerator extends AbstractGenerator {
                   className );
         root.put( "identifier",
                   identifier );
+        root.put( "lockingStrategy",
+                  lockingStrategy );
         root.put( "owningPlace",
                   owningPlace );
         root.put( "getContextIdMethodName",

--- a/uberfire-workbench/uberfire-workbench-processors/src/main/resources/org/uberfire/annotations/processors/templates/activityEditor.ftl
+++ b/uberfire-workbench/uberfire-workbench-processors/src/main/resources/org/uberfire/annotations/processors/templates/activityEditor.ftl
@@ -61,6 +61,11 @@ import com.google.gwt.user.client.ui.IsWidget;
 import org.jboss.errai.ioc.client.api.ActivatedBy;
 
 </#if>
+<#if lockingStrategy??>
+import org.uberfire.client.annotations.WorkbenchEditor.LockingStrategy;
+import static org.uberfire.client.annotations.WorkbenchEditor.LockingStrategy.*;
+
+</#if>
 @Dependent
 @Generated("org.uberfire.annotations.processors.WorkbenchEditorProcessor")
 @Named("${identifier}")
@@ -274,6 +279,13 @@ public class ${className} extends AbstractWorkbenchEditorActivity {
         return "${packageName}.${className}";
     }
 
+    <#if lockingStrategy??>
+    @Override
+    public LockingStrategy getLockingStrategy() {
+        return ${lockingStrategy};
+    }
+    
+    </#if>    
     @Override
     public String getIdentifier() {
         return "${identifier}";


### PR DESCRIPTION
It's now possible to use the lockingStrategy attribute
on @WorkbenchEditor to configure optimistic and pessimistic
locking on a per-editor basis. This allows developers to
turn off pessimistic locking and provide their own
locking solution.