### PR TITLE
 Included selection when adding menus on WorkbenchMenuBar

### DIFF
--- a/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/widgets/menu/WorkbenchMenuBarPresenter.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/widgets/menu/WorkbenchMenuBarPresenter.java
@@ -23,6 +23,7 @@ import javax.enterprise.event.Observes;
 import javax.inject.Inject;
 
 import com.google.gwt.user.client.ui.IsWidget;
+import org.uberfire.client.mvp.PerspectiveManager;
 import org.uberfire.client.workbench.events.PerspectiveChange;
 import org.uberfire.client.workbench.events.PlaceMaximizedEvent;
 import org.uberfire.client.workbench.events.PlaceMinimizedEvent;
@@ -45,6 +46,9 @@ public class WorkbenchMenuBarPresenter implements WorkbenchMenuBar {
 
     private boolean useExpandedMode = true;
     private boolean expanded = true;
+
+    @Inject
+    private PerspectiveManager perspectiveManager;
 
     public interface View
             extends
@@ -97,7 +101,11 @@ public class WorkbenchMenuBarPresenter implements WorkbenchMenuBar {
             menus.accept( new BaseMenuVisitor() {
                 @Override
                 public void visit( final MenuItemPerspective menuItemPerspective ) {
-                    perspectiveMenus.put( menuItemPerspective.getPlaceRequest(), menuItemPerspective );
+                    final PlaceRequest placeRequest = menuItemPerspective.getPlaceRequest();
+                    perspectiveMenus.put( placeRequest, menuItemPerspective );
+                    if( perspectiveManager.getCurrentPerspective() != null && placeRequest.equals( perspectiveManager.getCurrentPerspective().getPlace() ) ){
+                        view.selectMenu( menuItemPerspective );
+                    }
                 }
             } );
         }

--- a/uberfire-workbench/uberfire-workbench-client/src/test/java/org/uberfire/client/workbench/widgets/menu/WorkbenchMenuBarPresenterTest.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/test/java/org/uberfire/client/workbench/widgets/menu/WorkbenchMenuBarPresenterTest.java
@@ -1,0 +1,73 @@
+/*
+ *
+ *  * Copyright 2015 JBoss Inc
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ *  * use this file except in compliance with the License. You may obtain a copy of
+ *  * the License at
+ *  *
+ *  * http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  * License for the specific language governing permissions and limitations under
+ *  * the License.
+ *
+ */
+
+package org.uberfire.client.workbench.widgets.menu;
+
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.uberfire.client.mvp.PerspectiveActivity;
+import org.uberfire.client.mvp.PerspectiveManager;
+import org.uberfire.mvp.PlaceRequest;
+import org.uberfire.mvp.impl.DefaultPlaceRequest;
+import org.uberfire.workbench.model.menu.MenuFactory;
+import org.uberfire.workbench.model.menu.Menus;
+
+import static org.mockito.Mockito.*;
+
+/**
+ * Created by Cristiano Nicolai.
+ */
+@RunWith( GwtMockitoTestRunner.class )
+public class WorkbenchMenuBarPresenterTest {
+
+    @Mock
+    private PerspectiveManager perspectiveManager;
+
+    @Mock
+    private WorkbenchMenuBarPresenter.View view;
+
+    @InjectMocks
+    private WorkbenchMenuBarPresenter presenter;
+
+    @Test
+    public void testAddCurrentPerspective(){
+        final String perspectiveId = "perspectiveId";
+        final Menus menus = MenuFactory.newSimpleItem( "test" ).perspective( perspectiveId ).endMenu().build();
+        final PlaceRequest placeRequest = new DefaultPlaceRequest( perspectiveId );
+        final PerspectiveActivity perspectiveActivity = mock( PerspectiveActivity.class );
+        when( perspectiveActivity.getPlace() ).thenReturn( placeRequest );
+        when( perspectiveManager.getCurrentPerspective() ).thenReturn( perspectiveActivity );
+        presenter.addMenus( menus );
+        verify( view ).selectMenu( menus.getItems().get( 0 ) );
+    }
+
+    @Test
+    public void testAddPerspective(){
+        final String perspectiveId = "perspectiveId";
+        final Menus menus = MenuFactory.newSimpleItem( "test" ).perspective( perspectiveId ).endMenu().build();
+        final PlaceRequest placeRequest = new DefaultPlaceRequest( "anyId" );
+        final PerspectiveActivity perspectiveActivity = mock( PerspectiveActivity.class );
+        when( perspectiveActivity.getPlace() ).thenReturn( placeRequest );
+        when( perspectiveManager.getCurrentPerspective() ).thenReturn( perspectiveActivity );
+        presenter.addMenus( menus );
+        verify( view, never() ).selectMenu( menus.getItems().get( 0 ) );
+    }
+}


### PR DESCRIPTION
 This fix is needed because in some cases, perspective change event is fired before menus is added.