### PR TITLE
[URGENT] Fix for cluster issue BZ-1283953

### DIFF
--- a/uberfire-backend/uberfire-backend-server/src/main/java/org/uberfire/backend/server/security/FileSystemResourceAdaptor.java
+++ b/uberfire-backend/uberfire-backend-server/src/main/java/org/uberfire/backend/server/security/FileSystemResourceAdaptor.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2015 JBoss, by Red Hat, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.uberfire.backend.server.security;
 
 import java.util.Collection;
@@ -11,8 +27,8 @@ public class FileSystemResourceAdaptor implements RuntimeContentResource {
 
     private final FileSystem fileSystem;
 
-    public FileSystemResourceAdaptor( FileSystem fileSystem ) {
-        this.fileSystem = fileSystem;
+    public FileSystemResourceAdaptor( final FileSystem fileSystem ) {
+        this.fileSystem = fileSystem.getRootDirectories().iterator().next().getFileSystem();
     }
 
     public FileSystem getFileSystem() {

--- a/uberfire-backend/uberfire-backend-server/src/test/java/org/uberfire/backend/server/security/FileSystemResourceAdaptorTest.java
+++ b/uberfire-backend/uberfire-backend-server/src/test/java/org/uberfire/backend/server/security/FileSystemResourceAdaptorTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2015 JBoss, by Red Hat, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.backend.server.security;
+
+import java.net.URI;
+import java.util.Arrays;
+
+import org.junit.Test;
+import org.uberfire.java.nio.base.FileSystemId;
+import org.uberfire.java.nio.file.FileSystem;
+import org.uberfire.java.nio.file.Path;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * TODO: update me
+ */
+public class FileSystemResourceAdaptorTest {
+
+    @Test
+    public void testFileSystemToCheckProxyIssuesWithExtraInterfaces() {
+        final FileSystem mockedFS = mock( FileSystem.class );
+        final FileSystem mockedFSId = mock( FileSystem.class, withSettings().extraInterfaces( FileSystemId.class ) );
+
+        final Path rootPath = mock( Path.class );
+
+        when( mockedFS.getRootDirectories() ).thenReturn( Arrays.asList( rootPath ) );
+        when( mockedFSId.getRootDirectories() ).thenReturn( Arrays.asList( rootPath ) );
+
+        when( rootPath.getFileSystem() ).thenReturn( mockedFSId );
+        when( rootPath.toUri() ).thenReturn( URI.create( "jgit://myrepo" ) );
+
+        when( ( (FileSystemId) mockedFSId ).id() ).thenReturn( "my-fsid" );
+
+        {
+            final FileSystemResourceAdaptor fileSystemResourceAdaptor = new FileSystemResourceAdaptor( mockedFS );
+            assertEquals( mockedFSId, fileSystemResourceAdaptor.getFileSystem() );
+            assertEquals( "my-fsid", fileSystemResourceAdaptor.getSignatureId() );
+        }
+    }
+}

--- a/uberfire-backend/uberfire-backend-server/src/test/java/org/uberfire/backend/server/security/IOServiceSecuritySetupTest.java
+++ b/uberfire-backend/uberfire-backend-server/src/test/java/org/uberfire/backend/server/security/IOServiceSecuritySetupTest.java
@@ -1,5 +1,7 @@
 package org.uberfire.backend.server.security;
 
+import java.util.Arrays;
+
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
@@ -14,7 +16,9 @@ import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
+import org.uberfire.java.nio.base.FileSystemId;
 import org.uberfire.java.nio.file.FileSystem;
+import org.uberfire.java.nio.file.Path;
 import org.uberfire.java.nio.security.FileSystemAuthenticator;
 import org.uberfire.java.nio.security.FileSystemAuthorizer;
 import org.uberfire.java.nio.security.FileSystemUser;
@@ -59,7 +63,16 @@ public class IOServiceSecuritySetupTest {
         FileSystemUser user = mockFsp.authenticator.authenticate( "fake", "fake" );
         assertEquals( MockAuthenticationService.FAKE_USER.getIdentifier(),
                       user.getName() );
-        assertTrue( mockFsp.authorizer.authorize( mock( FileSystem.class ),
+
+        final FileSystem mockfs = mock( FileSystem.class );
+        final FileSystem mockedFSId = mock( FileSystem.class, withSettings().extraInterfaces( FileSystemId.class ) );
+        final Path rootPath = mock( Path.class );
+        when( mockfs.getRootDirectories() ).thenReturn( Arrays.asList( rootPath ) );
+        when( mockedFSId.getRootDirectories() ).thenReturn( Arrays.asList( rootPath ) );
+        when( rootPath.getFileSystem() ).thenReturn( mockedFSId );
+
+
+        assertTrue( mockFsp.authorizer.authorize( mockfs,
                                                   user ) );
     }
 
@@ -95,6 +108,13 @@ public class IOServiceSecuritySetupTest {
         FileSystemAuthorizer installedAuthorizer = MockSecuredFilesystemProvider.LATEST_INSTANCE.authorizer;
         FileSystemAuthenticator installedAuthenticator = MockSecuredFilesystemProvider.LATEST_INSTANCE.authenticator;
         FileSystem mockfs = mock( FileSystem.class );
+
+        final FileSystem mockedFSId = mock( FileSystem.class, withSettings().extraInterfaces( FileSystemId.class ) );
+        final Path rootPath = mock( Path.class );
+        when( mockfs.getRootDirectories() ).thenReturn( Arrays.asList( rootPath ) );
+        when( mockedFSId.getRootDirectories() ).thenReturn( Arrays.asList( rootPath ) );
+        when( rootPath.getFileSystem() ).thenReturn( mockedFSId );
+
         FileSystemUser fileSystemUser = installedAuthenticator.authenticate( "fake", "fake" );
 
         installedAuthorizer.authorize( mockfs, fileSystemUser );

--- a/uberfire-io/src/main/java/org/uberfire/io/impl/cluster/FileSystemSyncLock.java
+++ b/uberfire-io/src/main/java/org/uberfire/io/impl/cluster/FileSystemSyncLock.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2015 JBoss, by Red Hat, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.uberfire.io.impl.cluster;
 
 import java.util.HashMap;
@@ -18,7 +34,8 @@ public class FileSystemSyncLock<V> extends LockExecuteNotifyAsyncReleaseTemplate
     private final String uri;
 
     public FileSystemSyncLock( final String serviceId,
-                               final FileSystem fileSystem ) {
+                               final FileSystem _fileSystem ) {
+        final FileSystem fileSystem = _fileSystem.getRootDirectories().iterator().next().getFileSystem();
         this.serviceId = serviceId;
         this.scheme = fileSystem.getRootDirectories().iterator().next().toUri().getScheme();
         this.id = ( (FileSystemId) fileSystem ).id();

--- a/uberfire-io/src/main/java/org/uberfire/io/impl/cluster/FileSystemSyncNonLock.java
+++ b/uberfire-io/src/main/java/org/uberfire/io/impl/cluster/FileSystemSyncNonLock.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2015 JBoss, by Red Hat, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.uberfire.io.impl.cluster;
 
 import java.util.HashMap;
@@ -20,7 +36,8 @@ public class FileSystemSyncNonLock<V> {
     private final String uri;
 
     public FileSystemSyncNonLock( final String serviceId,
-                                  final FileSystem fileSystem ) {
+                                  final FileSystem _fileSystem ) {
+        final FileSystem fileSystem = _fileSystem.getRootDirectories().iterator().next().getFileSystem();
         this.serviceId = serviceId;
         this.scheme = fileSystem.getRootDirectories().iterator().next().toUri().getScheme();
         this.id = ( (FileSystemId) fileSystem ).id();

--- a/uberfire-io/src/test/java/org/uberfire/io/impl/cluster/FileSystemSyncTest.java
+++ b/uberfire-io/src/test/java/org/uberfire/io/impl/cluster/FileSystemSyncTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2015 JBoss, by Red Hat, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.io.impl.cluster;
+
+import java.net.URI;
+import java.util.Arrays;
+import java.util.Map;
+
+import org.junit.Test;
+import org.uberfire.java.nio.base.FileSystemId;
+import org.uberfire.java.nio.file.FileSystem;
+import org.uberfire.java.nio.file.Path;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+public class FileSystemSyncTest {
+
+    @Test
+    public void testFileSystemToCheckProxyIssuesWithExtraInterfaces() {
+        final FileSystem mockedFS = mock( FileSystem.class );
+        final FileSystem mockedFSId = mock( FileSystem.class, withSettings().extraInterfaces( FileSystemId.class ) );
+
+        final Path rootPath = mock( Path.class );
+
+        when( mockedFS.getRootDirectories() ).thenReturn( Arrays.asList( rootPath ) );
+        when( mockedFSId.getRootDirectories() ).thenReturn( Arrays.asList( rootPath ) );
+
+        when( rootPath.getFileSystem() ).thenReturn( mockedFSId );
+        when( rootPath.toUri() ).thenReturn( URI.create( "jgit://myrepo" ) );
+
+        when( ( (FileSystemId) mockedFSId ).id() ).thenReturn( "my-fsid" );
+
+        {
+            final FileSystemSyncLock<String> fileSystemSyncLock = new FileSystemSyncLock<String>( "serviceId", mockedFS );
+            final Map<String, String> content = fileSystemSyncLock.buildContent();
+
+            assertEquals( "my-fsid", content.get( "fs_id" ) );
+        }
+        {
+            final FileSystemSyncNonLock<String> fileSystemSyncNonLock = new FileSystemSyncNonLock<String>( "serviceId", mockedFS );
+            final Map<String, String> content = fileSystemSyncNonLock.buildContent();
+
+            assertEquals( "my-fsid", content.get( "fs_id" ) );
+        }
+
+    }
+
+}

--- a/uberfire-io/src/test/java/org/uberfire/io/impl/cluster/IOServiceClusterImplTest.java
+++ b/uberfire-io/src/test/java/org/uberfire/io/impl/cluster/IOServiceClusterImplTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2015 JBoss, by Red Hat, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.io.impl.cluster;
+
+import java.net.URI;
+import java.util.Arrays;
+
+import org.junit.Test;
+import org.uberfire.commons.cluster.ClusterService;
+import org.uberfire.io.impl.IOServiceLockable;
+import org.uberfire.io.lock.BatchLockControl;
+import org.uberfire.java.nio.base.FileSystemId;
+import org.uberfire.java.nio.file.FileSystem;
+import org.uberfire.java.nio.file.Option;
+import org.uberfire.java.nio.file.Path;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+public class IOServiceClusterImplTest {
+
+    @Test
+    public void testFileSystemToCheckProxyIssuesWithExtraInterfaces() {
+        final FileSystem mockedFS = mock( FileSystem.class );
+        final FileSystem mockedFSId = mock( FileSystem.class, withSettings().extraInterfaces( FileSystemId.class ) );
+
+        final Path rootPath = mock( Path.class );
+
+        when( mockedFS.getRootDirectories() ).thenReturn( Arrays.asList( rootPath ) );
+        when( mockedFSId.getRootDirectories() ).thenReturn( Arrays.asList( rootPath ) );
+
+        when( rootPath.getFileSystem() ).thenReturn( mockedFSId );
+        when( rootPath.toUri() ).thenReturn( URI.create( "jgit://myrepo" ) );
+
+        when( ( (FileSystemId) mockedFSId ).id() ).thenReturn( "my-fsid" );
+
+        final ClusterService clusterService = mock( ClusterService.class );
+        final IOServiceLockable serviceLockable = mock( IOServiceLockable.class );
+        final BatchLockControl batchLockControl = mock( BatchLockControl.class );
+
+        when( serviceLockable.getFileSystems() ).thenReturn( Arrays.asList( mockedFSId, mockedFS ) );
+        when( batchLockControl.getHoldCount() ).thenReturn( 0 );
+        when( serviceLockable.getLockControl() ).thenReturn( batchLockControl );
+
+        {
+            final IOServiceClusterImpl ioServiceCluster = new TestWrapper( clusterService, serviceLockable );
+
+            assertEquals( 0, ioServiceCluster.batchFileSystems.size() );
+
+            ioServiceCluster.startBatch( mockedFS );
+
+            assertEquals( 1, ioServiceCluster.batchFileSystems.size() );
+
+            assertTrue( ioServiceCluster.batchFileSystems.contains( ( (FileSystemId) mockedFSId ).id() ) );
+
+            ioServiceCluster.endBatch();
+
+            verify( serviceLockable, times( 1 ) ).endBatch();
+
+            assertEquals( 0, ioServiceCluster.batchFileSystems.size() );
+
+            verify( clusterService, times( 1 ) ).unlock();
+        }
+
+        {
+            final IOServiceClusterImpl ioServiceCluster = new TestWrapper( clusterService, serviceLockable );
+
+            assertEquals( 0, ioServiceCluster.batchFileSystems.size() );
+
+            ioServiceCluster.startBatch( new FileSystem[]{ mockedFS }, mock( Option.class ) );
+
+            assertEquals( 1, ioServiceCluster.batchFileSystems.size() );
+
+            assertTrue( ioServiceCluster.batchFileSystems.contains( ( (FileSystemId) mockedFSId ).id() ) );
+
+            ioServiceCluster.endBatch();
+
+            verify( serviceLockable, times( 2 ) ).endBatch();
+
+            assertEquals( 0, ioServiceCluster.batchFileSystems.size() );
+
+            verify( clusterService, times( 2 ) ).unlock();
+        }
+
+        {
+            final IOServiceClusterImpl ioServiceCluster = new TestWrapper( clusterService, serviceLockable );
+
+            assertEquals( 0, ioServiceCluster.batchFileSystems.size() );
+
+            ioServiceCluster.startBatch( mockedFS, mock( Option.class ) );
+
+            assertEquals( 1, ioServiceCluster.batchFileSystems.size() );
+
+            assertTrue( ioServiceCluster.batchFileSystems.contains( ( (FileSystemId) mockedFSId ).id() ) );
+
+            ioServiceCluster.endBatch();
+
+            verify( serviceLockable, times( 3 ) ).endBatch();
+
+            assertEquals( 0, ioServiceCluster.batchFileSystems.size() );
+
+            verify( clusterService, times( 3 ) ).unlock();
+        }
+    }
+
+    private class TestWrapper extends IOServiceClusterImpl {
+
+        public TestWrapper( final ClusterService clusterService,
+                            final IOServiceLockable service ) {
+            this.clusterService = clusterService;
+            this.service = service;
+        }
+    }
+}


### PR DESCRIPTION
BZ-1283953: Cluster failing to cleanup the global lock properly. After investigating, it was noticed that some FileSystem ("system") were proxyed, and the CDI proxy doesn't include other possible interfaces other than that been injected... so when tested instance of FileSystemId it always failed.
So.. in order to avoid such issue, the solution is to avoid use directly the file system and resolve it using the fs.getRootDirs().interator().next().getFileSystem(); with this we assure that we have access the real FileSystem instance.

Additional PR:
https://github.com/droolsjbpm/guvnor/pull/199