### PR TITLE
(0.7.x) BZ1283953: Cluster failing to cleanup the global lock properly. Fix for uberfire-extensions IOServiceSecuritySetupTest.

### DIFF
--- a/uberfire-backend/uberfire-backend-server/src/main/java/org/uberfire/backend/server/security/FileSystemResourceAdaptor.java
+++ b/uberfire-backend/uberfire-backend-server/src/main/java/org/uberfire/backend/server/security/FileSystemResourceAdaptor.java
@@ -28,7 +28,11 @@ public class FileSystemResourceAdaptor implements RuntimeContentResource {
     private final FileSystem fileSystem;
 
     public FileSystemResourceAdaptor( final FileSystem fileSystem ) {
-        this.fileSystem = fileSystem.getRootDirectories().iterator().next().getFileSystem();
+        if ( fileSystem == null ) {
+            this.fileSystem = null;
+        } else {
+            this.fileSystem = fileSystem.getRootDirectories().iterator().next().getFileSystem();
+        }
     }
 
     public FileSystem getFileSystem() {
@@ -45,7 +49,6 @@ public class FileSystemResourceAdaptor implements RuntimeContentResource {
 
     @Override
     public Collection<String> getGroups() {
-
         return Collections.emptyList();
     }
 

--- a/uberfire-backend/uberfire-backend-server/src/test/resources/META-INF/services/org.uberfire.java.nio.file.spi.FileSystemProvider
+++ b/uberfire-backend/uberfire-backend-server/src/test/resources/META-INF/services/org.uberfire.java.nio.file.spi.FileSystemProvider
@@ -1,1 +1,2 @@
 org.uberfire.backend.server.security.MockSecuredFilesystemProvider
+org.uberfire.java.nio.fs.file.SimpleFileSystemProvider


### PR DESCRIPTION
See https://github.com/uberfire/uberfire/pull/228

This is the corollary for 0.7.x