### PR TITLE
Upgrade mocking deps to fix test on JDK8

### DIFF
--- a/uberfire-api/pom.xml
+++ b/uberfire-api/pom.xml
@@ -47,6 +47,12 @@
       <groupId>org.jboss.errai</groupId>
       <artifactId>errai-security-server</artifactId>
     </dependency>
+    <!-- Needed as replacement for the javassist:javassist which is excluded from errai-security-server -->
+    <dependency>
+      <groupId>org.javassist</groupId>
+      <artifactId>javassist</artifactId>
+      <scope>runtime</scope>
+    </dependency>
 
     <dependency>
       <groupId>org.jboss.errai</groupId>

--- a/uberfire-parent-with-dependencies/pom.xml
+++ b/uberfire-parent-with-dependencies/pom.xml
@@ -76,14 +76,14 @@
 
     <version.org.hibernate.javax.persistence.hibernate-jpa-2.0-api>1.0.1.Final</version.org.hibernate.javax.persistence.hibernate-jpa-2.0-api>
     <version.org.jasypt>1.9.0</version.org.jasypt>
-    <version.org.javassist>3.15.0-GA</version.org.javassist>
+    <version.org.javassist>3.18.1-GA</version.org.javassist>
     <version.org.scannotation>1.0.3</version.org.scannotation>
 
     <version.junit>4.11</version.junit>
-    <version.org.mockito>1.9.0</version.org.mockito>
+    <version.org.mockito>1.10.19</version.org.mockito>
     <version.org.easytesting.fest>2.0M6</version.org.easytesting.fest>
     <version.org.hamcrest>1.3</version.org.hamcrest>
-    <version.org.powermock.mockito>1.4.12</version.org.powermock.mockito>
+    <version.org.powermock.mockito>1.6.3</version.org.powermock.mockito>
 
     <version.org.apache.lucene>4.0.0</version.org.apache.lucene>
     <version.org.apache.helix>0.6.5</version.org.apache.helix>
@@ -102,7 +102,7 @@
     <version.org.patternfly>2.1.0</version.org.patternfly>
 
     <osgi.snapshot.qualifier>${maven.build.timestamp}</osgi.snapshot.qualifier>
-    <version.com.google.gwt.gwtmockito>1.1.4</version.com.google.gwt.gwtmockito>
+    <version.com.google.gwt.gwtmockito>1.1.5</version.com.google.gwt.gwtmockito>
   </properties>
 
   <!-- IMPORTANT: Do not declare any build configuration here! Declare it in uberfire-parent-metadata. -->
@@ -481,6 +481,14 @@
         <groupId>org.jboss.errai</groupId>
         <artifactId>errai-security-server</artifactId>
         <version>${version.org.jboss.errai}</version>
+        <exclusions>
+          <!-- Old javassist groupId. Uses same class names as the new one so we need to exclude this artifact in all
+               places. -->
+          <exclusion>
+            <groupId>javassist</groupId>
+            <artifactId>javassist</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
 
       <dependency>
@@ -735,6 +743,14 @@
         <groupId>org.scannotation</groupId>
         <artifactId>scannotation</artifactId>
         <version>${version.org.scannotation}</version>
+        <exclusions>
+          <!-- Uses old javassist groupId so Maven is not able to exclude this itself. All UF modules have to use
+               org.javassist:javassist instead of this one. -->
+          <exclusion>
+            <groupId>javassist</groupId>
+            <artifactId>javassist</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
 
 

--- a/uberfire-showcase/showcase-distribution-wars/pom.xml
+++ b/uberfire-showcase/showcase-distribution-wars/pom.xml
@@ -172,11 +172,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.scannotation</groupId>
-      <artifactId>scannotation</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>org.jboss.classfilewriter</groupId>
       <artifactId>jboss-classfilewriter</artifactId>
     </dependency>

--- a/uberfire-testing-utils/pom.xml
+++ b/uberfire-testing-utils/pom.xml
@@ -46,6 +46,18 @@
     <dependency>
       <groupId>org.jboss.errai</groupId>
       <artifactId>errai-security-server</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>javassist</groupId>
+          <artifactId>javassist</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <!-- Needed as replacement for the above javassist:javassist exclusion from errai-security-server -->
+    <dependency>
+      <groupId>org.javassist</groupId>
+      <artifactId>javassist</artifactId>
+      <scope>runtime</scope>
     </dependency>
 
     <dependency>

--- a/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/PanelManagerImpl.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/PanelManagerImpl.java
@@ -62,32 +62,27 @@ import static org.uberfire.commons.validation.PortablePreconditions.checkNotNull
 @ApplicationScoped
 public class PanelManagerImpl implements PanelManager {
 
-    @Inject
     protected Event<PlaceGainFocusEvent> placeGainFocusEvent;
 
-    @Inject
     protected Event<PlaceLostFocusEvent> placeLostFocusEvent;
 
-    @Inject
     protected Event<PanelFocusEvent> panelFocusEvent;
 
-    @Inject
     protected Event<SelectPlaceEvent> selectPlaceEvent;
 
-    @Inject
-    protected Event<PlaceMaximizedEvent> placeMaximizedEventEvent;
+    protected Event<PlaceMaximizedEvent> placeMaximizedEvent;
 
-    @Inject
-    protected Event<PlaceMinimizedEvent> placeMinimizedEventEvent;
+    protected Event<PlaceMinimizedEvent> placeMinimizedEvent;
 
-    @Inject
     protected Event<PlaceHiddenEvent> placeHiddenEvent;
 
-    @Inject
     protected SyncBeanManager iocManager;
 
-    @Inject
     protected Instance<PlaceManager> placeManager;
+
+    LayoutSelection layoutSelection;
+
+    private BeanFactory beanFactory;
 
     /**
      * Description that the current root panel was created from. Presently, this is a mutable data structure and the
@@ -108,12 +103,6 @@ public class PanelManagerImpl implements PanelManager {
 
     protected PartDefinition activePart = null;
 
-    @Inject
-    LayoutSelection layoutSelection;
-
-    @Inject
-    private BeanFactory beanFactory;
-
     /**
      * Registration for the native preview handler that watches for ^M events and maximizes/restores the current panel.
      */
@@ -123,6 +112,32 @@ public class PanelManagerImpl implements PanelManager {
      * The currently maximized panel. Set to null when a panel is not maximized.
      */
     private WorkbenchPanelPresenter maximizedPanel = null;
+
+    @Inject
+    public PanelManagerImpl(
+            Event<PlaceGainFocusEvent> placeGainFocusEvent,
+            Event<PlaceLostFocusEvent> placeLostFocusEvent,
+            Event<PanelFocusEvent> panelFocusEvent,
+            Event<SelectPlaceEvent> selectPlaceEvent,
+            Event<PlaceMaximizedEvent> placeMaximizedEvent,
+            Event<PlaceMinimizedEvent> placeMinimizedEventEvent,
+            Event<PlaceHiddenEvent> placeHiddenEvent,
+            SyncBeanManager iocManager,
+            Instance<PlaceManager> placeManager,
+            LayoutSelection layoutSelection,
+            BeanFactory beanFactory) {
+        this.placeGainFocusEvent = placeGainFocusEvent;
+        this.placeLostFocusEvent = placeLostFocusEvent;
+        this.panelFocusEvent = panelFocusEvent;
+        this.selectPlaceEvent = selectPlaceEvent;
+        this.placeMaximizedEvent = placeMaximizedEvent;
+        this.placeMinimizedEvent = placeMinimizedEventEvent;
+        this.placeHiddenEvent = placeHiddenEvent;
+        this.iocManager = iocManager;
+        this.placeManager = placeManager;
+        this.layoutSelection = layoutSelection;
+        this.beanFactory = beanFactory;
+    }
 
     @PostConstruct
     private void setup() {
@@ -293,12 +308,12 @@ public class PanelManagerImpl implements PanelManager {
 
     @Override
     public void onPartMaximized( final PartDefinition part ) {
-        placeMaximizedEventEvent.fire( new PlaceMaximizedEvent( part.getPlace() ) );
+        placeMaximizedEvent.fire( new PlaceMaximizedEvent( part.getPlace() ) );
     }
 
     @Override
     public void onPartMinimized( final PartDefinition part ) {
-        placeMinimizedEventEvent.fire( new PlaceMinimizedEvent( part.getPlace() ) );
+        placeMinimizedEvent.fire( new PlaceMinimizedEvent( part.getPlace() ) );
     }
 
     @Override

--- a/uberfire-workbench/uberfire-workbench-client/src/test/java/org/uberfire/client/workbench/PanelManagerTest.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/test/java/org/uberfire/client/workbench/PanelManagerTest.java
@@ -28,7 +28,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Answers;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
@@ -36,7 +35,10 @@ import org.uberfire.client.mvp.PerspectiveActivity;
 import org.uberfire.client.mvp.UIPart;
 import org.uberfire.client.workbench.events.PanelFocusEvent;
 import org.uberfire.client.workbench.events.PlaceGainFocusEvent;
+import org.uberfire.client.workbench.events.PlaceHiddenEvent;
 import org.uberfire.client.workbench.events.PlaceLostFocusEvent;
+import org.uberfire.client.workbench.events.PlaceMaximizedEvent;
+import org.uberfire.client.workbench.events.PlaceMinimizedEvent;
 import org.uberfire.client.workbench.events.SelectPlaceEvent;
 import org.uberfire.client.workbench.panels.WorkbenchPanelPresenter;
 import org.uberfire.client.workbench.panels.WorkbenchPanelView;
@@ -67,11 +69,13 @@ public class PanelManagerTest {
     @Mock StubPlaceLostFocusEvent placeLostFocusEvent;
     @Mock StubSelectPlaceEvent selectPlaceEvent;
     @Mock StubPanelFocusEvent panelFocusEvent;
+    @Mock StubPlaceMaximizedEvent placeMaximizedEvent;
+    @Mock StubPlaceMinimizedEvent placeMinimizedEvent;
+    @Mock StubPlaceHiddenEvent placeHidEvent;
     @Mock SimpleWorkbenchPanelPresenter workbenchPanelPresenter;
     @Mock(answer=Answers.RETURNS_DEEP_STUBS) LayoutSelection layoutSelection;
 
-    @InjectMocks
-    PanelManagerImpl panelManager;
+    private PanelManagerImpl panelManager;
 
     /**
      * This is the part presenter that will be returned by the mock BeanFactory in response to any newWorkbenchPart()
@@ -118,6 +122,19 @@ public class PanelManagerTest {
         } );
 
         PerspectiveActivity testPerspectiveActivity = mock( PerspectiveActivity.class );
+
+        panelManager = new PanelManagerImpl(
+                placeGainFocusEvent,
+                placeLostFocusEvent,
+                panelFocusEvent,
+                selectPlaceEvent,
+                placeMaximizedEvent,
+                placeMinimizedEvent,
+                placeHidEvent,
+                null,
+                null,
+                layoutSelection,
+                beanFactory);
         panelManager.setRoot( testPerspectiveActivity, testPerspectiveDef.getRoot() );
     }
 
@@ -305,4 +322,7 @@ public class PanelManagerTest {
     static class StubPlaceLostFocusEvent extends StubEventSource<PlaceLostFocusEvent> {}
     static class StubSelectPlaceEvent extends StubEventSource<SelectPlaceEvent> {}
     static class StubPanelFocusEvent extends StubEventSource<PanelFocusEvent> {}
+    static class StubPlaceMaximizedEvent extends StubEventSource<PlaceMaximizedEvent> {}
+    static class StubPlaceMinimizedEvent extends StubEventSource<PlaceMinimizedEvent> {}
+    static class StubPlaceHiddenEvent extends StubEventSource<PlaceHiddenEvent> {}
 }


### PR DESCRIPTION
 * fixes failing test DisposableShutdownServiceTest
 * PanelManagerImpl moved from field injection
   to constructor injection so that @InjectMocks
   could be removed (was causing issues)
* few minor fixes related to exclusion of old javassist dep

There are still three tests failing on JDK8 (`TabPanelWithDropdownsTest`), but they were failing even before these changes and I am currently not sure how to fix them. We need to take a loot at them later.

I tried local build with JDK7 and everything works as expected (no failures).