### PR TITLE
CallerProxy - Return primitive default value in case of exception

### DIFF
--- a/uberfire-testing-utils/src/main/java/org/uberfire/mocks/CallerProxy.java
+++ b/uberfire-testing-utils/src/main/java/org/uberfire/mocks/CallerProxy.java
@@ -18,6 +18,7 @@ package org.uberfire.mocks;
 
 import java.lang.reflect.Method;
 
+import com.google.common.base.Defaults;
 import org.jboss.errai.common.client.api.ErrorCallback;
 import org.jboss.errai.common.client.api.RemoteCallback;
 
@@ -54,7 +55,11 @@ public class CallerProxy implements java.lang.reflect.InvocationHandler {
             if ( errorCallBack != null ) {
                 errorCallBack.error( result, e );
             }
-            return result;
+            if( m.getReturnType().isPrimitive() ) {
+                return Defaults.defaultValue( m.getReturnType() );
+            } else {
+                return result;
+            }
         }
         if ( successCallBack != null ) {
             successCallBack.callback( result );

--- a/uberfire-testing-utils/src/test/java/org/uberfire/mocks/CallerMockTest.java
+++ b/uberfire-testing-utils/src/test/java/org/uberfire/mocks/CallerMockTest.java
@@ -18,17 +18,17 @@ package org.uberfire.mocks;
 
 import javax.inject.Inject;
 
-import com.google.gwtmockito.GwtMockitoTestRunner;
 import org.jboss.errai.common.client.api.Caller;
 import org.jboss.errai.common.client.api.ErrorCallback;
 import org.jboss.errai.common.client.api.RemoteCallback;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
 
 import static org.mockito.Mockito.*;
 
-@RunWith(GwtMockitoTestRunner.class)
+@RunWith( MockitoJUnitRunner.class )
 public class CallerMockTest {
 
     SampleTarget sampleTarget;
@@ -90,6 +90,21 @@ public class CallerMockTest {
     }
 
     @Test
+    public void callerSampleCallBackPrimitiveTypeTest() throws SampleException {
+        when( sampleTarget.targetPrimitiveType() ).thenThrow( SampleException.class );
+
+        callerMock = new CallerMock<SampleTarget>( sampleTarget );
+        callerSample = new CallerSampleClient( callerMock, successCallBack, errorCallBack );
+
+        callerSample.targetPrimitiveType();
+
+        verify( sampleTarget ).targetPrimitiveType();
+        verify( errorCallBack ).error( anyString(), any( SampleException.class ) );
+        verify( successCallBack, never() ).callback( anyString() );
+
+    }
+
+    @Test
     public void callerSampleCallBackErrorbyRunTimeExceptionTest() {
         SampleTarget target = new SampleTarget() {
             @Override
@@ -100,6 +115,11 @@ public class CallerMockTest {
             @Override
             public String targetCallWithCheckedException() throws SampleException {
                 return null;
+            }
+
+            @Override
+            public long targetPrimitiveType() {
+                return 0;
             }
         };
 
@@ -149,6 +169,10 @@ public class CallerMockTest {
             caller.call( successCallBack, errorCallBack ).targetCallWithCheckedException();
         }
 
+        public long targetPrimitiveType() {
+            return caller.call( successCallBack, errorCallBack ).targetPrimitiveType();
+        }
+
     }
 
     private class SampleException extends Exception {
@@ -157,9 +181,11 @@ public class CallerMockTest {
 
     private interface SampleTarget {
 
-        public String targetCall();
+        String targetCall();
 
-        public String targetCallWithCheckedException() throws SampleException;
+        String targetCallWithCheckedException() throws SampleException;
+
+        long targetPrimitiveType();
 
     }
 


### PR DESCRIPTION
 This is to avoid a NullPointerException on Proxy instance when casting the returned null value into the primitive return type.