### PR TITLE
BZ-1287511: Fixes for master

### DIFF
--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/main/java/org/uberfire/java/nio/fs/jgit/JGitFileSystem.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/main/java/org/uberfire/java/nio/fs/jgit/JGitFileSystem.java
@@ -87,7 +87,7 @@ public class JGitFileSystem implements FileSystem,
 
     private FileSystemState state = FileSystemState.NORMAL;
     private CommitInfo batchCommitInfo = null;
-    private boolean hadCommitOnBatchState = false;
+    private Map<Path, Boolean> hadCommitOnBatchState = new ConcurrentHashMap<Path, Boolean>();
 
     private final Lock lock = new Lock();
 
@@ -507,12 +507,21 @@ public class JGitFileSystem implements FileSystem,
         this.batchCommitInfo = buildCommitInfo( defaultMessage, op );
     }
 
-    public void setHadCommitOnBatchState( boolean hadCommitOnBatchState ) {
-        this.hadCommitOnBatchState = hadCommitOnBatchState;
+    public void setHadCommitOnBatchState( final Path path,
+                                          final boolean hadCommitOnBatchState ) {
+        final Path root = checkNotNull( "path", path ).getRoot();
+        this.hadCommitOnBatchState.put( root.getRoot(), hadCommitOnBatchState );
     }
 
-    public boolean isHadCommitOnBatchState() {
-        return hadCommitOnBatchState;
+    public void setHadCommitOnBatchState( final boolean value ) {
+        for ( Map.Entry<Path, Boolean> entry : hadCommitOnBatchState.entrySet() ) {
+            entry.setValue( value );
+        }
+    }
+
+    public boolean isHadCommitOnBatchState( final Path path ) {
+        final Path root = checkNotNull( "path", path ).getRoot();
+        return hadCommitOnBatchState.containsKey( root ) ? hadCommitOnBatchState.get( root ) : false;
     }
 
     public void setBatchCommitInfo( CommitInfo batchCommitInfo ) {

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/main/java/org/uberfire/java/nio/fs/jgit/JGitFileSystemProvider.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/main/java/org/uberfire/java/nio/fs/jgit/JGitFileSystemProvider.java
@@ -1980,14 +1980,17 @@ public class JGitFileSystemProvider implements SecuredFileSystemProvider,
             for ( Map.Entry<JGitFileSystem, Map<String, NotificationModel>> jGitFileSystemMapEntry : oldHeadsOfPendingDiffs.entrySet() ) {
                 for ( Map.Entry<String, NotificationModel> branchNameNotificationModelEntry : jGitFileSystemMapEntry.getValue().entrySet() ) {
                     final ObjectId newHead = JGitUtil.getTreeRefObjectId( jGitFileSystemMapEntry.getKey().gitRepo().getRepository(), branchNameNotificationModelEntry.getKey() );
-
-                    notifyDiffs( jGitFileSystemMapEntry.getKey(),
-                                 branchNameNotificationModelEntry.getKey(),
-                                 branchNameNotificationModelEntry.getValue().getSessionId(),
-                                 branchNameNotificationModelEntry.getValue().getUserName(),
-                                 branchNameNotificationModelEntry.getValue().getMessage(),
-                                 branchNameNotificationModelEntry.getValue().getOriginalHead(),
-                                 newHead );
+                    try {
+                        notifyDiffs( jGitFileSystemMapEntry.getKey(),
+                                     branchNameNotificationModelEntry.getKey(),
+                                     branchNameNotificationModelEntry.getValue().getSessionId(),
+                                     branchNameNotificationModelEntry.getValue().getUserName(),
+                                     branchNameNotificationModelEntry.getValue().getMessage(),
+                                     branchNameNotificationModelEntry.getValue().getOriginalHead(),
+                                     newHead );
+                    } catch ( final Exception ex ) {
+                        LOG.error( String.format( "Couldn't produce diff notification for repository `%s` branch `%s`.", jGitFileSystemMapEntry.getKey().toString(), branchNameNotificationModelEntry.getKey() ), ex );
+                    }
                 }
             }
 
@@ -2003,13 +2006,13 @@ public class JGitFileSystemProvider implements SecuredFileSystemProvider,
         }
     }
 
-    private void notifyDiffs( final JGitFileSystem fs,
-                              final String _tree,
-                              final String sessionId,
-                              final String userName,
-                              final String message,
-                              final ObjectId oldHead,
-                              final ObjectId newHead ) {
+    void notifyDiffs( final JGitFileSystem fs,
+                      final String _tree,
+                      final String sessionId,
+                      final String userName,
+                      final String message,
+                      final ObjectId oldHead,
+                      final ObjectId newHead ) {
 
         final String tree;
         if ( _tree.startsWith( "refs/" ) ) {


### PR DESCRIPTION
The fix is splitted in 2 commits on purpose.

1st commit avoids empty amends (basically avoid recreate history for batch on branches that didn't have a commit)
2nd commit avoids block the cleanup of historic notification if excaption happens during notification (a good case is the missing tree reported by BZ)

important note: was barely impossible to reproduce the Missing tree error. A quicl google search shows that people that has faced such issue had hard time (to not say couldn't) reproduce it.