### PR TITLE
Override org.jboss.xnio deps to fix deployment on WildFly 8

### DIFF
--- a/uberfire-parent-with-dependencies/pom.xml
+++ b/uberfire-parent-with-dependencies/pom.xml
@@ -50,6 +50,7 @@
     <version.org.jboss.weld.weld>2.0.5.Final</version.org.jboss.weld.weld>
     <version.org.jboss.weld.weld-api>2.0.SP1</version.org.jboss.weld.weld-api>
     <version.org.jboss.classfilewriter.jboss-classfilewriter>1.0.4.Final</version.org.jboss.classfilewriter.jboss-classfilewriter>
+    <version.org.jboss.xnio>3.2.0.Final</version.org.jboss.xnio>
     <version.org.owasp.encoder>1.1.1</version.org.owasp.encoder>
     <version.org.patternfly>2.1.0</version.org.patternfly>
     <version.org.picketlink>2.6.0.Final</version.org.picketlink>
@@ -252,6 +253,18 @@
         <groupId>org.picketlink</groupId>
         <artifactId>picketlink-tomcat7-single</artifactId>
         <version>${version.org.picketlink}</version>
+      </dependency>
+
+      <!-- Overrides to fix apps on WildFly 8 (e.g. gwt:run) -->
+      <dependency>
+        <groupId>org.jboss.xnio</groupId>
+        <artifactId>xnio-api</artifactId>
+        <version>${version.org.jboss.xnio}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jboss.xnio</groupId>
+        <artifactId>xnio-nio</artifactId>
+        <version>${version.org.jboss.xnio}</version>
       </dependency>
 
     </dependencies>


### PR DESCRIPTION
Needed after the upgrade to IP BOM 6.0.0.CR31