### PR TITLE
Remove forgotten uberfire-workbench-client-views-bs2 references

### DIFF
--- a/uberfire-bom/pom.xml
+++ b/uberfire-bom/pom.xml
@@ -164,17 +164,6 @@
       </dependency>
       <dependency>
         <groupId>org.uberfire</groupId>
-        <artifactId>uberfire-workbench-client-views-bs2</artifactId>
-        <version>${project.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.uberfire</groupId>
-        <artifactId>uberfire-workbench-client-views-bs2</artifactId>
-        <version>${project.version}</version>
-        <classifier>sources</classifier>
-      </dependency>
-      <dependency>
-        <groupId>org.uberfire</groupId>
         <artifactId>uberfire-workbench-client-views-patternfly</artifactId>
         <version>${project.version}</version>
       </dependency>

--- a/uberfire-distro/pom.xml
+++ b/uberfire-distro/pom.xml
@@ -122,15 +122,6 @@
     </dependency>
     <dependency>
       <groupId>org.uberfire</groupId>
-      <artifactId>uberfire-workbench-client-views-bs2</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.uberfire</groupId>
-      <artifactId>uberfire-workbench-client-views-bs2</artifactId>
-      <classifier>sources</classifier>
-    </dependency>
-    <dependency>
-      <groupId>org.uberfire</groupId>
       <artifactId>uberfire-workbench-client-views-patternfly</artifactId>
     </dependency>
     <dependency>

--- a/uberfire-showcase/uberfire-client-webapp/pom.xml
+++ b/uberfire-showcase/uberfire-client-webapp/pom.xml
@@ -40,13 +40,13 @@
 
     <dependency>
       <groupId>org.uberfire</groupId>
-      <artifactId>uberfire-workbench-client-views-bs2</artifactId>
+      <artifactId>uberfire-workbench-processors</artifactId>
       <scope>provided</scope>
     </dependency>
 
     <dependency>
-      <groupId>org.uberfire</groupId>
-      <artifactId>uberfire-workbench-processors</artifactId>
+      <groupId>com.github.gwtbootstrap</groupId>
+      <artifactId>gwt-bootstrap</artifactId>
       <scope>provided</scope>
     </dependency>
     
@@ -97,7 +97,6 @@
             <compileSourcesArtifact>org.uberfire:uberfire-client-api</compileSourcesArtifact>
             <compileSourcesArtifact>org.uberfire:uberfire-workbench-client</compileSourcesArtifact>
             <compileSourcesArtifact>org.uberfire:uberfire-workbench-client-backend</compileSourcesArtifact>
-            <compileSourcesArtifact>org.uberfire:uberfire-workbench-client-views-bs2</compileSourcesArtifact>
           </compileSourcesArtifacts>
         </configuration>
       </plugin>


### PR DESCRIPTION
This is quick&dirty fix as it basically just makes sure the stuff compiles. I am not exactly sure what will happen to the application after removing the -bs2 dependency. It seems the proper fix would be to migrate all the stuff BS2 stuff to BS3/Patternfly, but looks very complicated for me...

@mbiarnes this should remove all the references to -views-bs2 module + fix the compilation error you saw (just added the gwt-bootsrap dependency).

