### PR TITLE
Adding back version for m2e lifecylce-mapping plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -330,6 +330,7 @@
         <plugin>
           <groupId>org.eclipse.m2e</groupId>
           <artifactId>lifecycle-mapping</artifactId>
+          <version>1.0.0</version>
           <configuration>
             <lifecycleMappingMetadata>
               <pluginExecutions>


### PR DESCRIPTION
- Removing it causes lots of NPEs (in maven paring logic) and
prevented Eclipse from building the project correctly.