### PR TITLE
Exclude log4j and commons-logging where needed + add enforcer rule to…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,6 +78,30 @@
     <pluginManagement>
       <plugins>
         <plugin>
+          <artifactId>maven-enforcer-plugin</artifactId>
+          <executions>
+            <execution>
+              <id>ban-unwanted-logging-deps</id>
+              <goals>
+                <goal>enforce</goal>
+              </goals>
+              <phase>validate</phase>
+              <configuration>
+                <rules>
+                  <bannedDependencies>
+                    <excludes>
+                      <!-- In case of transitive dependency, exclude it and use jcl-over-slf4j instead -->
+                      <exclude>commons-logging:commons-log*</exclude>
+                      <!-- In case of transitive dependency, exclude it and use log4j-over-slf4j instead -->
+                      <exclude>log4j:log4j</exclude>
+                    </excludes>
+                  </bannedDependencies>
+                </rules>
+              </configuration>
+            </execution>
+          </executions>
+        </plugin>
+        <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>build-helper-maven-plugin</artifactId>
           <executions>

--- a/uberfire-io/pom.xml
+++ b/uberfire-io/pom.xml
@@ -50,6 +50,19 @@
     <dependency>
       <groupId>org.apache.helix</groupId>
       <artifactId>helix-core</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>log4j</groupId>
+          <artifactId>log4j</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <!-- Replacement for log4j:log4j excluded from helix-core -->
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>log4j-over-slf4j</artifactId>
+      <scope>runtime</scope>
+
     </dependency>
     <dependency>
       <groupId>commons-io</groupId>

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/pom.xml
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/pom.xml
@@ -55,6 +55,18 @@
     <dependency>
       <groupId>org.eclipse.jgit</groupId>
       <artifactId>org.eclipse.jgit</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>commons-logging</groupId>
+          <artifactId>commons-logging</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <!-- Needed as replacement for commons-logging which is excluded from org.eclipse.jgit -->
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>jcl-over-slf4j</artifactId>
+      <scope>runtime</scope>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
… ban unwnated logging deps

 * both commons-logging and log4j should not be used. UF depends on SLF4J for logging,
   so all other logging frameworks need to excluded and replaced by the appropriate
   SLF4J logging bridges (e.g. jcl-over-slf4j and log4j-over-slf4j)

 * the enforcer rule makes sure that we catch these violations early, before they
   are even introduced. Solution is to exclude these unwanted (transitive) deps and
   depend explicitely on the logging bridge