### PR TITLE
GUVNOR-2328: Asset Editor height doesn't count with the added top tabs

### DIFF
--- a/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/main/java/org/uberfire/client/views/pfly/listbar/ListBarWidgetImpl.java
+++ b/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/main/java/org/uberfire/client/views/pfly/listbar/ListBarWidgetImpl.java
@@ -278,6 +278,7 @@ public class ListBarWidgetImpl
 
         header.setVisible( true );
 
+        resizePanelBody();
         scheduleResize();
     }
 
@@ -350,11 +351,13 @@ public class ListBarWidgetImpl
             content.remove( view );
         }
 
-        if( currentPart == null ){
+        if ( currentPart == null ) {
             header.setVisible( false );
         }
 
+        resizePanelBody();
         scheduleResize();
+
         return removed;
     }
 
@@ -469,7 +472,7 @@ public class ListBarWidgetImpl
                 }
 
                 return makeDropDownMenuButton( groups.getCaption(),
-                        widgetList );
+                                               widgetList );
 
             } else {
                 final List<Widget> widgetList = new ArrayList<Widget>();
@@ -485,7 +488,7 @@ public class ListBarWidgetImpl
                 }
 
                 return makeDropDownMenuButton( groups.getCaption(),
-                        widgetList );
+                                               widgetList );
             }
 
         } else if ( item instanceof MenuCustom ) {
@@ -520,6 +523,14 @@ public class ListBarWidgetImpl
                 onResize();
             }
         } );
+    }
+
+    private void resizePanelBody() {
+        //When an Item is added to the PanelHeader recalculate the PanelBody size.
+        //This cannot be performed in either the @PostConstruct or onAttach() methods as at
+        //these times the PanelHeader may not have any content and hence have no size.
+        content.getElement().getStyle().setProperty( "height",
+                                                     "calc(100% - " + header.getOffsetHeight() + "px)" );
     }
 
     /**

--- a/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/main/java/org/uberfire/client/views/pfly/tab/TabPanelWithDropdowns.java
+++ b/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/main/java/org/uberfire/client/views/pfly/tab/TabPanelWithDropdowns.java
@@ -166,6 +166,7 @@ public class TabPanelWithDropdowns extends Composite {
         activatableWidgets.add( tab.getTabWidget() );
         tabBar.add( tab.getTabWidget() );
         tabContent.add( tab.getContentPane() );
+        resizeTabContent();
     }
 
     /**
@@ -181,7 +182,16 @@ public class TabPanelWithDropdowns extends Composite {
         tabContent.remove( tab.getContentPane() );
         activatableWidgets.remove( tab.getTabWidget() );
         allContentTabs.remove( tab );
+        resizeTabContent();
         return removed;
+    }
+
+    private void resizeTabContent() {
+        //When an Item is added to the TabBar recalculate the TabContent size.
+        //This cannot be performed in either the @PostConstruct or onAttach() methods as at
+        //these times the TabBar may not have any content and hence have no size.
+        tabContent.getElement().getStyle().setProperty( "height",
+                                                        "calc(100% - " + tabBar.getOffsetHeight() + "px)" );
     }
 
     /**


### PR DESCRIPTION
See https://issues.jboss.org/browse/GUVNOR-2328

The cause is that the "tab content" region's size is set to 100% which is the size of the ```DIV``` containing both the "tab header" and "tab content" regions. This fix ensures the "tab content" size is 100% less the height of the "tab header".