### PR TITLE
Upgrade to Errai 4.0.0-SNAPSHOT, GWT 2.8.0-beta1, and Java 8.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
     <!-- IMPORTANT: Do not declare any external dependencies versions here! Declare them in uberfire-parent-with-dependencies. -->
     <uberfire.version>${project.version}</uberfire.version>
     <!-- Exception as it is needed for gwt-maven-plugin version-->
-    <version.com.google.gwt>2.7.0</version.com.google.gwt>
+    <version.com.google.gwt>2.8.0-beta1</version.com.google.gwt>
     <!-- Override version 2.5.4 coming from jboss-parent:19 as it forks executions, which is a bug.
          See https://issues.apache.org/jira/browse/FELIX-4882 for more details. -->
     <version.bundle.plugin>3.0.1</version.bundle.plugin>
@@ -60,6 +60,8 @@
     <osgi.snapshot.qualifier>${maven.build.timestamp}</osgi.snapshot.qualifier>
     <!-- TODO fix all the modules to have all direct dependencies specified, then remove this property -->
     <illegaltransitivereportonly>true</illegaltransitivereportonly>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
   </properties>
 
   <scm>
@@ -122,6 +124,7 @@
                       <ignoreClass>javax.inject.Named</ignoreClass>
                       <ignoreClass>javax.inject.Scope</ignoreClass>
                       <ignoreClass>javax.inject.Qualifier</ignoreClass>
+                      <ignoreClass>javax.inject.Singleton</ignoreClass>
                       <ignoreClass>javax.enterprise.*</ignoreClass>
                       <!-- Classes from gwt-user duplicated in errai-uibinder -->
                       <ignoreClass>com.google.gwt.uibinder.rebind.UiBinderWriter</ignoreClass>
@@ -224,6 +227,8 @@
             <maxmem>512m</maxmem>
             <showDeprecation>true</showDeprecation>
             <showWarnings>true</showWarnings>
+            <source>${maven.compiler.source}</source>
+            <target>${maven.compiler.target}</target>
           </configuration>
         </plugin>
         <plugin>
@@ -266,7 +271,7 @@
             <excludes>
               <exclude>**/*IntegrationTest.java</exclude>
             </excludes>
-            <argLine>-Xmx1024m -XX:MaxPermSize=128m -Dfile.encoding=UTF-8 ${jacocoArgs}</argLine>
+            <argLine>-Xmx1024m -Dfile.encoding=UTF-8 ${jacocoArgs}</argLine>
           </configuration>
         </plugin>
 
@@ -285,7 +290,7 @@
             <includes>
               <include>**/*IntegrationTest.java</include>
             </includes>
-            <argLine>-Xmx1024m -XX:MaxPermSize=128m -Dfile.encoding=UTF-8</argLine>
+            <argLine>-Xmx1024m -Dfile.encoding=UTF-8</argLine>
           </configuration>
         </plugin>
 

--- a/uberfire-api/src/main/java/org/uberfire/backend/vfs/impl/ObservablePathImpl.java
+++ b/uberfire-api/src/main/java/org/uberfire/backend/vfs/impl/ObservablePathImpl.java
@@ -18,9 +18,9 @@ package org.uberfire.backend.vfs.impl;
 
 import java.util.ArrayList;
 import java.util.List;
+
 import javax.enterprise.context.Dependent;
 import javax.enterprise.event.Observes;
-import javax.enterprise.inject.Alternative;
 import javax.inject.Inject;
 
 import org.jboss.errai.common.client.api.annotations.Portable;
@@ -43,7 +43,6 @@ import org.uberfire.workbench.events.ResourceUpdatedEvent;
 
 @Portable
 @Dependent
-@Alternative
 public class ObservablePathImpl implements ObservablePath,
                                            IsVersioned {
 

--- a/uberfire-api/src/main/java/org/uberfire/workbench/type/AnyResourceTypeDefinition.java
+++ b/uberfire-api/src/main/java/org/uberfire/workbench/type/AnyResourceTypeDefinition.java
@@ -16,11 +16,8 @@
 
 package org.uberfire.workbench.type;
 
-import javax.enterprise.context.ApplicationScoped;
-
 import org.uberfire.backend.vfs.Path;
 
-@ApplicationScoped
 public class AnyResourceTypeDefinition implements ResourceTypeDefinition {
 
     @Override

--- a/uberfire-api/src/main/java/org/uberfire/workbench/type/DotResourceTypeDefinition.java
+++ b/uberfire-api/src/main/java/org/uberfire/workbench/type/DotResourceTypeDefinition.java
@@ -16,11 +16,8 @@
 
 package org.uberfire.workbench.type;
 
-import javax.enterprise.context.ApplicationScoped;
-
 import org.uberfire.backend.vfs.Path;
 
-@ApplicationScoped
 public class DotResourceTypeDefinition implements ResourceTypeDefinition {
 
     @Override

--- a/uberfire-api/src/main/java/org/uberfire/workbench/type/TextResourceTypeDefinition.java
+++ b/uberfire-api/src/main/java/org/uberfire/workbench/type/TextResourceTypeDefinition.java
@@ -16,11 +16,8 @@
 
 package org.uberfire.workbench.type;
 
-import javax.enterprise.context.ApplicationScoped;
-
 import org.uberfire.backend.vfs.Path;
 
-@ApplicationScoped
 public class TextResourceTypeDefinition implements ResourceTypeDefinition {
 
     @Override

--- a/uberfire-archetype/uberfire-project-archetype/src/main/resources/archetype-resources/__rootArtifactId__-parent-with-dependencies/pom.xml
+++ b/uberfire-archetype/uberfire-project-archetype/src/main/resources/archetype-resources/__rootArtifactId__-parent-with-dependencies/pom.xml
@@ -48,7 +48,7 @@
 
     <version.org.mvel>2.1.8.Final</version.org.mvel>
 
-    <version.com.google.gwt>2.7.0</version.com.google.gwt>
+    <version.com.google.gwt>2.8.0-beta1</version.com.google.gwt>
     <version.org.gwtbootstrap3>0.9.1</version.org.gwtbootstrap3>
     <version.com.allen-sauer.gwt.dnd>3.3.3</version.com.allen-sauer.gwt.dnd>
     <version.com.google.guava>17.0</version.com.google.guava>
@@ -438,7 +438,7 @@
 
       <dependency>
         <groupId>org.jboss.errai</groupId>
-        <artifactId>errai-weld-integration</artifactId>
+        <artifactId>errai-cdi-server</artifactId>
         <version>\${version.org.jboss.errai}</version>
       </dependency>
 

--- a/uberfire-archetype/uberfire-project-archetype/src/main/resources/archetype-resources/__rootArtifactId__-showcase/__rootArtifactId__-webapp/pom.xml
+++ b/uberfire-archetype/uberfire-project-archetype/src/main/resources/archetype-resources/__rootArtifactId__-showcase/__rootArtifactId__-webapp/pom.xml
@@ -170,7 +170,7 @@
 
     <dependency>
       <groupId>org.jboss.errai</groupId>
-      <artifactId>errai-weld-integration</artifactId>
+      <artifactId>errai-cdi-server</artifactId>
     </dependency>
 
     <dependency>
@@ -263,7 +263,7 @@
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>gwt-maven-plugin</artifactId>
         <configuration>
-          <extraJvmArgs>-Xmx712m -XX:CompileThreshold=7000 -XX:MaxPermSize=512M -Derrai.jboss.home=${errai.jboss.home}</extraJvmArgs>
+          <extraJvmArgs>-Xmx712m -XX:CompileThreshold=7000 -Derrai.jboss.home=${errai.jboss.home}</extraJvmArgs>
           <strict>true</strict>
           <logLevel>INFO</logLevel>
           <noServer>false</noServer>

--- a/uberfire-archetype/uberfire-project-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/uberfire-archetype/uberfire-project-archetype/src/main/resources/archetype-resources/pom.xml
@@ -25,8 +25,8 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <!-- maven-compiler-plugin -->
-    <maven.compiler.target>1.6</maven.compiler.target>
-    <maven.compiler.source>1.6</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>1.8</maven.compiler.source>
 
     <!--
         Options to override the compiler arguments directly on the compiler arument line to separate between what
@@ -109,7 +109,7 @@
             <excludes>
               <exclude>**/*IntegrationTest.java</exclude>
             </excludes>
-            <argLine>-Xmx1024m -XX:MaxPermSize=128m</argLine>
+            <argLine>-Xmx1024m</argLine>
           </configuration>
         </plugin>
 
@@ -128,7 +128,7 @@
             <includes>
               <include>**/*IntegrationTest.java</include>
             </includes>
-            <argLine>-Xmx1024m -XX:MaxPermSize=128m</argLine>
+            <argLine>-Xmx1024m</argLine>
           </configuration>
         </plugin>
 

--- a/uberfire-backend/uberfire-backend-server/src/test/java/org/uberfire/backend/server/io/DisposableShutdownServiceTest.java
+++ b/uberfire-backend/uberfire-backend-server/src/test/java/org/uberfire/backend/server/io/DisposableShutdownServiceTest.java
@@ -35,8 +35,9 @@ import org.uberfire.java.nio.file.spi.FileSystemProvider;
 import org.uberfire.java.nio.fs.jgit.JGitFileSystemProvider;
 
 import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
+import static org.mockito.Mockito.*;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({ PriorityDisposableRegistry.class,

--- a/uberfire-client-api/src/main/java/org/uberfire/client/workbench/type/impl/ClientTypeRegistryImpl.java
+++ b/uberfire-client-api/src/main/java/org/uberfire/client/workbench/type/impl/ClientTypeRegistryImpl.java
@@ -16,21 +16,23 @@
 
 package org.uberfire.client.workbench.type.impl;
 
+import static java.util.Collections.sort;
+import static java.util.Collections.unmodifiableList;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
+
 import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
-import org.jboss.errai.ioc.client.container.IOCBeanDef;
+import org.jboss.errai.ioc.client.container.SyncBeanDef;
 import org.jboss.errai.ioc.client.container.SyncBeanManager;
 import org.uberfire.backend.vfs.Path;
 import org.uberfire.client.workbench.type.ClientResourceType;
 import org.uberfire.client.workbench.type.ClientTypeRegistry;
-
-import static java.util.Collections.*;
 
 @ApplicationScoped
 public class ClientTypeRegistryImpl implements ClientTypeRegistry {
@@ -46,9 +48,9 @@ public class ClientTypeRegistryImpl implements ClientTypeRegistry {
 
     @PostConstruct
     public void init() {
-        final Collection<IOCBeanDef<ClientResourceType>> availableTypes = iocManager.lookupBeans( ClientResourceType.class );
+        final Collection<SyncBeanDef<ClientResourceType>> availableTypes = iocManager.lookupBeans( ClientResourceType.class );
 
-        for ( final IOCBeanDef<ClientResourceType> availableType : availableTypes ) {
+        for ( final SyncBeanDef<ClientResourceType> availableType : availableTypes ) {
             localResourceTypes.add( availableType.getInstance() );
         }
 

--- a/uberfire-js/src/main/java/org/uberfire/client/exporter/PerspectiveJSExporter.java
+++ b/uberfire-js/src/main/java/org/uberfire/client/exporter/PerspectiveJSExporter.java
@@ -16,13 +16,16 @@
 
 package org.uberfire.client.exporter;
 
-import static org.jboss.errai.ioc.client.QualifierUtil.*;
+import static org.jboss.errai.ioc.client.QualifierUtil.DEFAULT_QUALIFIERS;
+
+import java.lang.annotation.Annotation;
+import java.util.Arrays;
+import java.util.HashSet;
 
 import javax.enterprise.context.ApplicationScoped;
 
 import org.jboss.errai.ioc.client.container.IOC;
 import org.jboss.errai.ioc.client.container.SyncBeanManager;
-import org.jboss.errai.ioc.client.container.SyncBeanManagerImpl;
 import org.uberfire.client.mvp.ActivityBeansCache;
 import org.uberfire.client.mvp.PerspectiveActivity;
 import org.uberfire.client.perspective.JSNativePerspective;
@@ -55,7 +58,12 @@ public class PerspectiveJSExporter implements UberfireJSExporter {
 
             final JSWorkbenchPerspectiveActivity activity = new JSWorkbenchPerspectiveActivity( newNativePerspective );
 
-            ( (SyncBeanManagerImpl) beanManager ).addBean( (Class) PerspectiveActivity.class, JSWorkbenchPerspectiveActivity.class, null, activity, DEFAULT_QUALIFIERS, newNativePerspective.getId(), true, null );
+            beanManager.registerBean( new SingletonBeanDef<PerspectiveActivity, JSWorkbenchPerspectiveActivity>( activity,
+                                                                  PerspectiveActivity.class,
+                                                                  new HashSet<Annotation>( Arrays.asList( DEFAULT_QUALIFIERS ) ),
+                                                                  newNativePerspective.getId(),
+                                                                  true,
+                                                                  true ) );
 
             activityBeansCache.addNewPerspectiveActivity( beanManager.lookupBeans( newNativePerspective.getId() ).iterator().next() );
         }

--- a/uberfire-js/src/main/java/org/uberfire/client/exporter/PluginJSExporter.java
+++ b/uberfire-js/src/main/java/org/uberfire/client/exporter/PluginJSExporter.java
@@ -16,12 +16,17 @@
 
 package org.uberfire.client.exporter;
 
+import static org.jboss.errai.ioc.client.QualifierUtil.DEFAULT_QUALIFIERS;
+
+import java.lang.annotation.Annotation;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
 import javax.enterprise.context.ApplicationScoped;
 
-import com.google.gwt.core.client.JavaScriptObject;
 import org.jboss.errai.ioc.client.container.IOC;
 import org.jboss.errai.ioc.client.container.SyncBeanManager;
-import org.jboss.errai.ioc.client.container.SyncBeanManagerImpl;
 import org.uberfire.client.mvp.Activity;
 import org.uberfire.client.mvp.ActivityBeansCache;
 import org.uberfire.client.mvp.PlaceManager;
@@ -30,7 +35,7 @@ import org.uberfire.client.plugin.JSNativePlugin;
 import org.uberfire.client.screen.JSNativeScreen;
 import org.uberfire.client.screen.JSWorkbenchScreenActivity;
 
-import static org.jboss.errai.ioc.client.QualifierUtil.*;
+import com.google.gwt.core.client.JavaScriptObject;
 
 @ApplicationScoped
 public class PluginJSExporter implements UberfireJSExporter {
@@ -56,9 +61,17 @@ public class PluginJSExporter implements UberfireJSExporter {
 
             final JSWorkbenchScreenActivity activity = new JSWorkbenchScreenActivity( newNativePlugin, beanManager.lookupBean( PlaceManager.class ).getInstance() );
 
-            ( (SyncBeanManagerImpl) beanManager ).addBean( (Class) Activity.class, JSWorkbenchScreenActivity.class, null, activity, DEFAULT_QUALIFIERS, newNativePlugin.getId(), true, null );
-            ( (SyncBeanManagerImpl) beanManager ).addBean( (Class) WorkbenchScreenActivity.class, JSWorkbenchScreenActivity.class, null, activity, DEFAULT_QUALIFIERS, newNativePlugin.getId(), true, null );
-            ( (SyncBeanManagerImpl) beanManager ).addBean( (Class) JSWorkbenchScreenActivity.class, JSWorkbenchScreenActivity.class, null, activity, DEFAULT_QUALIFIERS, newNativePlugin.getId(), true, null );
+            final Set<Annotation> qualifiers = new HashSet<Annotation>( Arrays.asList( DEFAULT_QUALIFIERS ));
+            final SingletonBeanDef<JSWorkbenchScreenActivity, JSWorkbenchScreenActivity> beanDef =
+                    new SingletonBeanDef<JSWorkbenchScreenActivity, JSWorkbenchScreenActivity>( activity,
+                                                                                                JSWorkbenchScreenActivity.class,
+                                                                                                qualifiers,
+                                                                                                newNativePlugin.getId(),
+                                                                                                true,
+                                                                                                true );
+            beanManager.registerBean( beanDef );
+            beanManager.registerBeanTypeAlias( beanDef, WorkbenchScreenActivity.class );
+            beanManager.registerBeanTypeAlias( beanDef, Activity.class );
 
             activityBeansCache.addNewScreenActivity( beanManager.lookupBeans( newNativePlugin.getId() ).iterator().next() );
         }

--- a/uberfire-js/src/main/java/org/uberfire/client/exporter/SingletonBeanDef.java
+++ b/uberfire-js/src/main/java/org/uberfire/client/exporter/SingletonBeanDef.java
@@ -1,0 +1,91 @@
+package org.uberfire.client.exporter;
+
+import java.lang.annotation.Annotation;
+import java.util.Collections;
+import java.util.Set;
+
+import javax.inject.Singleton;
+
+import org.jboss.errai.ioc.client.QualifierUtil;
+import org.jboss.errai.ioc.client.container.SyncBeanDef;
+
+public class SingletonBeanDef<T, B extends T>
+    implements
+    SyncBeanDef<T> {
+
+    private final B instance;
+    private final Class<T> type;
+    private final Set<Annotation> qualifiers;
+    private final String name;
+    private final boolean concrete;
+    private final boolean activated;
+
+    public SingletonBeanDef( final B instance,
+                             final Class<T> type,
+                             final Set<Annotation> qualifiers,
+                             final String name,
+                             final boolean concrete,
+                             final boolean activated ) {
+        this.instance = instance;
+        this.type = type;
+        this.qualifiers = qualifiers;
+        this.name = name;
+        this.concrete = concrete;
+        this.activated = activated;
+    }
+
+    @Override
+    public Class<T> getType() {
+        return type;
+    }
+
+    @Override
+    public Class< ? > getBeanClass() {
+        return instance.getClass();
+    }
+
+    @Override
+    public Class< ? extends Annotation> getScope() {
+        return Singleton.class;
+    }
+
+    @Override
+    public T getInstance() {
+        return instance;
+    }
+
+    @Override
+    public T newInstance() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Set<Annotation> getQualifiers() {
+        if (qualifiers == null) {
+            return Collections.emptySet();
+        } else {
+            return qualifiers;
+        }
+    }
+
+    @Override
+    public boolean matches( final Set<Annotation> annotations ) {
+        return QualifierUtil.matches( annotations, getQualifiers() );
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public boolean isConcrete() {
+        return concrete;
+    }
+
+    @Override
+    public boolean isActivated() {
+        return activated;
+    }
+
+}

--- a/uberfire-js/src/main/java/org/uberfire/client/exporter/SplashScreenJSExporter.java
+++ b/uberfire-js/src/main/java/org/uberfire/client/exporter/SplashScreenJSExporter.java
@@ -16,12 +16,17 @@
 
 package org.uberfire.client.exporter;
 
+import static org.jboss.errai.ioc.client.QualifierUtil.DEFAULT_QUALIFIERS;
+
+import java.lang.annotation.Annotation;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
 import javax.enterprise.context.ApplicationScoped;
 
-import com.google.gwt.core.client.JavaScriptObject;
 import org.jboss.errai.ioc.client.container.IOC;
 import org.jboss.errai.ioc.client.container.SyncBeanManager;
-import org.jboss.errai.ioc.client.container.SyncBeanManagerImpl;
 import org.uberfire.client.mvp.Activity;
 import org.uberfire.client.mvp.ActivityBeansCache;
 import org.uberfire.client.mvp.SplashScreenActivity;
@@ -29,7 +34,7 @@ import org.uberfire.client.splash.JSNativeSplashScreen;
 import org.uberfire.client.splash.JSSplashScreenActivity;
 import org.uberfire.client.workbench.widgets.splash.SplashView;
 
-import static org.jboss.errai.ioc.client.QualifierUtil.*;
+import com.google.gwt.core.client.JavaScriptObject;
 
 @ApplicationScoped
 public class SplashScreenJSExporter implements UberfireJSExporter {
@@ -57,10 +62,17 @@ public class SplashScreenJSExporter implements UberfireJSExporter {
 
             final JSSplashScreenActivity activity = new JSSplashScreenActivity( newNativePlugin,
                                                                                 splashView );
-
-            ( (SyncBeanManagerImpl) beanManager ).addBean( (Class) Activity.class, JSSplashScreenActivity.class, null, activity, DEFAULT_QUALIFIERS, newNativePlugin.getId(), true, null );
-            ( (SyncBeanManagerImpl) beanManager ).addBean( (Class) SplashScreenActivity.class, JSSplashScreenActivity.class, null, activity, DEFAULT_QUALIFIERS, newNativePlugin.getId(), true, null );
-            ( (SyncBeanManagerImpl) beanManager ).addBean( (Class) JSSplashScreenActivity.class, JSSplashScreenActivity.class, null, activity, DEFAULT_QUALIFIERS, newNativePlugin.getId(), true, null );
+            final Set<Annotation> qualifiers = new HashSet<Annotation>( Arrays.asList( DEFAULT_QUALIFIERS ) );
+            final SingletonBeanDef<JSSplashScreenActivity, JSSplashScreenActivity> beanDef =
+                    new SingletonBeanDef<JSSplashScreenActivity, JSSplashScreenActivity>( activity,
+                                                                                          JSSplashScreenActivity.class,
+                                                                                          qualifiers,
+                                                                                          newNativePlugin.getId(),
+                                                                                          true,
+                                                                                          true );
+            beanManager.registerBean( beanDef );
+            beanManager.registerBeanTypeAlias( beanDef, SplashScreenActivity.class );
+            beanManager.registerBeanTypeAlias( beanDef, Activity.class );
 
             activityBeansCache.addNewSplashScreenActivity( beanManager.lookupBeans( newNativePlugin.getId() ).iterator().next() );
         }

--- a/uberfire-js/src/main/java/org/uberfire/client/exporter/UberfireJSAPIExporter.java
+++ b/uberfire-js/src/main/java/org/uberfire/client/exporter/UberfireJSAPIExporter.java
@@ -17,19 +17,19 @@
 package org.uberfire.client.exporter;
 
 import java.util.Collection;
-import javax.enterprise.context.ApplicationScoped;
 
 import org.jboss.errai.ioc.client.api.AfterInitialization;
+import org.jboss.errai.ioc.client.api.EntryPoint;
 import org.jboss.errai.ioc.client.container.IOC;
-import org.jboss.errai.ioc.client.container.IOCBeanDef;
+import org.jboss.errai.ioc.client.container.SyncBeanDef;
 
-@ApplicationScoped
+@EntryPoint
 public class UberfireJSAPIExporter {
 
     @AfterInitialization
     public void export() {
-        Collection<IOCBeanDef<UberfireJSExporter>> jsAPIs = IOC.getBeanManager().lookupBeans( UberfireJSExporter.class );
-        for ( IOCBeanDef<UberfireJSExporter> bean : jsAPIs ) {
+        Collection<SyncBeanDef<UberfireJSExporter>> jsAPIs = IOC.getBeanManager().lookupBeans( UberfireJSExporter.class );
+        for ( SyncBeanDef<UberfireJSExporter> bean : jsAPIs ) {
             UberfireJSExporter jsAPI = bean.getInstance();
             jsAPI.export();
         }

--- a/uberfire-nio2-backport/uberfire-nio2-api/src/test/java/org/uberfire/java/nio/file/FilesTest.java
+++ b/uberfire-nio2-backport/uberfire-nio2-api/src/test/java/org/uberfire/java/nio/file/FilesTest.java
@@ -16,6 +16,9 @@
 
 package org.uberfire.java.nio.file;
 
+import static org.fest.assertions.api.Assertions.assertThat;
+import static org.fest.assertions.api.Assertions.fail;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -32,8 +35,6 @@ import org.uberfire.java.nio.file.attribute.BasicFileAttributeView;
 import org.uberfire.java.nio.file.attribute.BasicFileAttributes;
 import org.uberfire.java.nio.fs.file.BaseSimpleFileStore;
 import org.uberfire.java.nio.fs.jgit.JGitFileStore;
-
-import static org.fest.assertions.api.Assertions.*;
 
 public class FilesTest extends AbstractBaseTest {
 
@@ -597,7 +598,7 @@ public class FilesTest extends AbstractBaseTest {
 
         final BasicFileAttributeView view = Files.getFileAttributeView( path, BasicFileAttributeView.class );
         assertThat( view ).isNotNull();
-        assertThat( view.readAttributes() ).isNotNull();
+        assertThat( (Object) view.readAttributes() ).isNotNull();
         assertThat( view.readAttributes().isRegularFile() ).isTrue();
         assertThat( view.readAttributes().isDirectory() ).isFalse();
         assertThat( view.readAttributes().isSymbolicLink() ).isFalse();
@@ -611,7 +612,7 @@ public class FilesTest extends AbstractBaseTest {
 
         final BasicFileAttributeView view = Files.getFileAttributeView( path, BasicFileAttributeView.class );
         assertThat( view ).isNotNull();
-        assertThat( view.readAttributes() ).isNotNull();
+        assertThat( (Object) view.readAttributes() ).isNotNull();
         assertThat( view.readAttributes().isRegularFile() ).isTrue();
         assertThat( view.readAttributes().isDirectory() ).isFalse();
         assertThat( view.readAttributes().isSymbolicLink() ).isFalse();

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-fs/src/test/java/org/uberfire/java/nio/fs/file/SimpleFileSystemProviderAttrsRelatedTest.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-fs/src/test/java/org/uberfire/java/nio/fs/file/SimpleFileSystemProviderAttrsRelatedTest.java
@@ -16,6 +16,12 @@
 
 package org.uberfire.java.nio.fs.file;
 
+import static org.fest.assertions.api.Assertions.assertThat;
+import static org.fest.assertions.api.Assertions.fail;
+import static org.uberfire.java.nio.file.AccessMode.EXECUTE;
+import static org.uberfire.java.nio.file.AccessMode.READ;
+import static org.uberfire.java.nio.file.AccessMode.WRITE;
+
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
@@ -28,10 +34,6 @@ import org.uberfire.java.nio.file.NoSuchFileException;
 import org.uberfire.java.nio.file.Path;
 import org.uberfire.java.nio.file.attribute.BasicFileAttributeView;
 import org.uberfire.java.nio.file.attribute.BasicFileAttributes;
-import org.uberfire.java.nio.fs.file.SimpleFileSystemProvider;
-
-import static org.fest.assertions.api.Assertions.*;
-import static org.uberfire.java.nio.file.AccessMode.*;
 
 public class SimpleFileSystemProviderAttrsRelatedTest {
 
@@ -191,7 +193,7 @@ public class SimpleFileSystemProviderAttrsRelatedTest {
 
         final BasicFileAttributeView view = fsProvider.getFileAttributeView( path, BasicFileAttributeView.class );
         assertThat( view ).isNotNull();
-        assertThat( view.readAttributes() ).isNotNull();
+        assertThat( (Object) view.readAttributes() ).isNotNull();
         assertThat( view.readAttributes().isRegularFile() ).isTrue();
         assertThat( view.readAttributes().isDirectory() ).isFalse();
         assertThat( view.readAttributes().isSymbolicLink() ).isFalse();
@@ -208,7 +210,7 @@ public class SimpleFileSystemProviderAttrsRelatedTest {
 
         final BasicFileAttributeView view = fsProvider.getFileAttributeView( path, BasicFileAttributeView.class );
         assertThat( view ).isNotNull();
-        assertThat( view.readAttributes() ).isNotNull();
+        assertThat( (Object) view.readAttributes() ).isNotNull();
         assertThat( view.readAttributes().isRegularFile() ).isTrue();
         assertThat( view.readAttributes().isDirectory() ).isFalse();
         assertThat( view.readAttributes().isSymbolicLink() ).isFalse();

--- a/uberfire-parent-with-dependencies/pom.xml
+++ b/uberfire-parent-with-dependencies/pom.xml
@@ -42,7 +42,7 @@
 
     <version.com.allen-sauer.gwt.dnd>3.3.3</version.com.allen-sauer.gwt.dnd>
     <version.org.apache.lucene>4.0.0</version.org.apache.lucene>
-    <version.org.jboss.errai>3.2.2-SNAPSHOT</version.org.jboss.errai>
+    <version.org.jboss.errai>4.0.0-SNAPSHOT</version.org.jboss.errai>
     <version.org.jboss.errai.cdi10-compatible>3.0.6.Final</version.org.jboss.errai.cdi10-compatible>
     <version.org.jboss.weld.weld>2.0.5.Final</version.org.jboss.weld.weld>
     <version.org.jboss.weld.weld-api>2.0.SP1</version.org.jboss.weld.weld-api>
@@ -87,6 +87,110 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+
+      <dependency>
+        <groupId>org.jboss.errai</groupId>
+        <artifactId>errai-javax-enterprise</artifactId>
+        <version>${version.org.jboss.errai}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.jboss.errai</groupId>
+        <artifactId>errai-jaxrs-client</artifactId>
+        <version>${version.org.jboss.errai}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.jboss.errai</groupId>
+        <artifactId>errai-jaxrs-client</artifactId>
+        <type>test-jar</type>
+        <version>${version.org.jboss.errai}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.jboss.errai</groupId>
+        <artifactId>errai-jaxrs-provider</artifactId>
+        <version>${version.org.jboss.errai}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.jboss.errai</groupId>
+        <artifactId>errai-jboss-as-support</artifactId>
+        <version>${version.org.jboss.errai}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.jboss.errai</groupId>
+        <artifactId>errai-jpa-client</artifactId>
+        <version>${version.org.jboss.errai}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.jboss.errai</groupId>
+        <artifactId>errai-jpa-datasync</artifactId>
+        <version>${version.org.jboss.errai}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.jboss.errai</groupId>
+        <artifactId>errai-js</artifactId>
+        <version>${version.org.jboss.errai}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.jboss.errai</groupId>
+        <artifactId>errai-marshalling</artifactId>
+        <version>${version.org.jboss.errai}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.jboss.errai</groupId>
+        <artifactId>errai-navigation</artifactId>
+        <version>${version.org.jboss.errai}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.jboss.errai</groupId>
+        <artifactId>errai-otec</artifactId>
+        <version>${version.org.jboss.errai}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.jboss.errai</groupId>
+        <artifactId>errai-tools</artifactId>
+        <version>${version.org.jboss.errai}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.jboss.errai</groupId>
+        <artifactId>errai-ui</artifactId>
+        <version>${version.org.jboss.errai}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.jboss.errai</groupId>
+        <artifactId>errai-uibinder</artifactId>
+        <version>${version.org.jboss.errai}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.jboss.errai</groupId>
+        <artifactId>errai-validation</artifactId>
+        <version>${version.org.jboss.errai}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.jboss.errai</groupId>
+        <artifactId>errai-cdi-server</artifactId>
+        <version>${version.org.jboss.errai}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.jboss.errai</groupId>
+        <artifactId>errai-security-server</artifactId>
+        <version>${version.org.jboss.errai}</version>
+      </dependency>
+
       <dependency>
         <groupId>org.jboss.errai</groupId>
         <artifactId>errai-security-client</artifactId>

--- a/uberfire-security/uberfire-security-api/src/main/java/org/uberfire/security/impl/authz/RuntimeAuthorizationManager.java
+++ b/uberfire-security/uberfire-security-api/src/main/java/org/uberfire/security/impl/authz/RuntimeAuthorizationManager.java
@@ -20,7 +20,6 @@ import static org.uberfire.commons.validation.PortablePreconditions.*;
 import static org.uberfire.security.authz.AuthorizationResult.*;
 
 import javax.enterprise.context.ApplicationScoped;
-import javax.enterprise.inject.Alternative;
 
 import org.jboss.errai.security.shared.api.identity.User;
 import org.jboss.errai.security.shared.exception.UnauthorizedException;
@@ -30,7 +29,6 @@ import org.uberfire.security.authz.AuthorizationResult;
 import org.uberfire.security.authz.ProfileDecisionManager;
 
 @ApplicationScoped
-@Alternative
 public class RuntimeAuthorizationManager implements AuthorizationManager {
 
     private final RuntimeResourceManager resourceManager = new RuntimeResourceManager();

--- a/uberfire-showcase/uberfire-client-webapp/pom.xml
+++ b/uberfire-showcase/uberfire-client-webapp/pom.xml
@@ -85,7 +85,7 @@
           <logLevel>INFO</logLevel>
           <strict>true</strict>
           <runTarget>index.html</runTarget>
-          <extraJvmArgs>-Xmx712m -XX:CompileThreshold=7000 -XX:MaxPermSize=512M</extraJvmArgs>
+          <extraJvmArgs>-Xmx712m -XX:CompileThreshold=7000</extraJvmArgs>
           <compileSourcesArtifacts>
             <compileSourcesArtifact>org.uberfire:uberfire-commons</compileSourcesArtifact>
             <compileSourcesArtifact>org.uberfire:uberfire-nio2-model</compileSourcesArtifact>

--- a/uberfire-showcase/uberfire-client-webapp/src/main/java/org/uberfire/client/ExampleDeclarativePerspective.java
+++ b/uberfire-showcase/uberfire-client-webapp/src/main/java/org/uberfire/client/ExampleDeclarativePerspective.java
@@ -17,7 +17,6 @@
 package org.uberfire.client;
 
 import javax.annotation.PostConstruct;
-import javax.inject.Inject;
 
 import org.uberfire.client.annotations.WorkbenchPanel;
 import org.uberfire.client.annotations.WorkbenchPerspective;
@@ -28,9 +27,8 @@ import com.google.gwt.user.client.ui.FlowPanel;
 @WorkbenchPerspective( identifier = "ExampleDeclarativePerspective", isTransient = true )
 public class ExampleDeclarativePerspective extends FlowPanel {
 
-    @Inject
     @WorkbenchPanel( parts = "HomeScreen" )
-    FlowPanel theOnlyPanel;
+    FlowPanel theOnlyPanel = new FlowPanel();
 
     @PostConstruct
     void doLayout() {

--- a/uberfire-showcase/uberfire-client-webapp/src/main/java/org/uberfire/client/HomePerspective.java
+++ b/uberfire-showcase/uberfire-client-webapp/src/main/java/org/uberfire/client/HomePerspective.java
@@ -16,8 +16,6 @@
 
 package org.uberfire.client;
 
-import javax.enterprise.context.ApplicationScoped;
-
 import org.jboss.errai.ui.shared.api.annotations.DataField;
 import org.jboss.errai.ui.shared.api.annotations.Templated;
 import org.uberfire.client.annotations.WorkbenchPanel;
@@ -25,7 +23,6 @@ import org.uberfire.client.annotations.WorkbenchPerspective;
 
 import com.google.gwt.user.client.ui.Composite;
 
-@ApplicationScoped
 @WorkbenchPerspective(identifier = "HomePerspective",
                       isDefault = true)
 @Templated

--- a/uberfire-showcase/uberfire-client-webapp/src/main/java/org/uberfire/client/ShowcaseEntryPoint.java
+++ b/uberfire-showcase/uberfire-client-webapp/src/main/java/org/uberfire/client/ShowcaseEntryPoint.java
@@ -15,7 +15,7 @@
  */
 package org.uberfire.client;
 
-import static org.uberfire.workbench.model.menu.MenuFactory.*;
+import static org.uberfire.workbench.model.menu.MenuFactory.newTopLevelMenu;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -34,6 +34,7 @@ import org.jboss.errai.bus.client.api.ClientMessageBus;
 import org.jboss.errai.ioc.client.api.EntryPoint;
 import org.jboss.errai.ioc.client.container.IOC;
 import org.jboss.errai.ioc.client.container.IOCBeanDef;
+import org.jboss.errai.ioc.client.container.SyncBeanDef;
 import org.jboss.errai.ioc.client.container.SyncBeanManager;
 import org.uberfire.client.mvp.ActivityManager;
 import org.uberfire.client.mvp.PerspectiveActivity;
@@ -177,11 +178,11 @@ public class ShowcaseEntryPoint {
 
     private PerspectiveActivity getDefaultPerspectiveActivity() {
         PerspectiveActivity defaultPerspective = null;
-        final Collection<IOCBeanDef<PerspectiveActivity>> perspectives = manager.lookupBeans( PerspectiveActivity.class );
-        final Iterator<IOCBeanDef<PerspectiveActivity>> perspectivesIterator = perspectives.iterator();
+        final Collection<SyncBeanDef<PerspectiveActivity>> perspectives = manager.lookupBeans( PerspectiveActivity.class );
+        final Iterator<SyncBeanDef<PerspectiveActivity>> perspectivesIterator = perspectives.iterator();
 
         while ( perspectivesIterator.hasNext() ) {
-            final IOCBeanDef<PerspectiveActivity> perspective = perspectivesIterator.next();
+            final SyncBeanDef<PerspectiveActivity> perspective = perspectivesIterator.next();
             final PerspectiveActivity instance = perspective.getInstance();
             if ( instance.isDefault() ) {
                 defaultPerspective = instance;

--- a/uberfire-showcase/uberfire-client-webapp/src/main/java/org/uberfire/client/TwitterBootstrapPerspective.java
+++ b/uberfire-showcase/uberfire-client-webapp/src/main/java/org/uberfire/client/TwitterBootstrapPerspective.java
@@ -16,8 +16,6 @@
 
 package org.uberfire.client;
 
-import javax.inject.Inject;
-
 import org.jboss.errai.ui.shared.api.annotations.DataField;
 import org.jboss.errai.ui.shared.api.annotations.Templated;
 import org.uberfire.client.annotations.WorkbenchPanel;
@@ -33,22 +31,19 @@ import com.google.gwt.user.client.ui.FlowPanel;
 @WorkbenchPerspective(identifier = "TwitterBootstrapPerspective")
 public class TwitterBootstrapPerspective extends Composite {
 
-    @Inject
     @DataField
     @WorkbenchPanel(panelType = MultiTabWorkbenchPanelPresenter.class,
                     parts = "MoodScreen")
-    FlowPanel tabPanel;
+    FlowPanel tabPanel = new FlowPanel();
 
-    @Inject
     @DataField
     @WorkbenchPanel(panelType = MultiListWorkbenchPanelPresenter.class,
                     parts = "HelloWorldScreen")
-    FlowPanel listPanel;
+    FlowPanel listPanel = new FlowPanel();
 
-    @Inject
     @DataField
     @WorkbenchPanel(panelType = SimpleDnDWorkbenchPanelPresenter.class,
                     parts = "HomeScreen")
-    FlowPanel simplePanel;
+    FlowPanel simplePanel = new FlowPanel();
 
 }

--- a/uberfire-showcase/uberfire-webapp/pom.xml
+++ b/uberfire-showcase/uberfire-webapp/pom.xml
@@ -104,12 +104,6 @@
 
     <dependency>
       <groupId>org.jboss.errai</groupId>
-      <artifactId>errai-uibinder</artifactId>
-      <scope>provided</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.jboss.errai</groupId>
       <artifactId>errai-security-server</artifactId>
       <exclusions>
         <exclusion>
@@ -154,7 +148,7 @@
 
     <dependency>
       <groupId>org.jboss.errai</groupId>
-      <artifactId>errai-weld-integration</artifactId>
+      <artifactId>errai-cdi-server</artifactId>
     </dependency>
 
     <dependency>
@@ -256,7 +250,7 @@
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>gwt-maven-plugin</artifactId>
         <configuration>
-          <extraJvmArgs>-Xmx712m -XX:CompileThreshold=7000 -XX:MaxPermSize=512M -Derrai.jboss.home=${errai.jboss.home}</extraJvmArgs>
+          <extraJvmArgs>-Xmx2G -XX:CompileThreshold=7000 -Derrai.jboss.home=${errai.jboss.home}</extraJvmArgs>
           <strict>true</strict>
           <logLevel>INFO</logLevel>
           <noServer>false</noServer>

--- a/uberfire-showcase/uberfire-webapp/src/main/java/org/uberfire/client/ShowcaseEntryPoint.java
+++ b/uberfire-showcase/uberfire-webapp/src/main/java/org/uberfire/client/ShowcaseEntryPoint.java
@@ -15,6 +15,9 @@
  */
 package org.uberfire.client;
 
+import static org.uberfire.workbench.model.menu.MenuFactory.newTopLevelCustomMenu;
+import static org.uberfire.workbench.model.menu.MenuFactory.newTopLevelMenu;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -22,24 +25,18 @@ import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
+
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.event.Observes;
 import javax.enterprise.inject.Produces;
 import javax.inject.Inject;
 
-import com.google.common.collect.Sets;
-import com.google.gwt.animation.client.Animation;
-import com.google.gwt.dom.client.Element;
-import com.google.gwt.dom.client.Style;
-import com.google.gwt.user.client.Window;
-import com.google.gwt.user.client.ui.Image;
-import com.google.gwt.user.client.ui.RootPanel;
-import com.google.gwt.user.client.ui.Widget;
 import org.jboss.errai.common.client.api.Caller;
 import org.jboss.errai.ioc.client.api.AfterInitialization;
 import org.jboss.errai.ioc.client.api.EntryPoint;
 import org.jboss.errai.ioc.client.container.IOC;
 import org.jboss.errai.ioc.client.container.IOCBeanDef;
+import org.jboss.errai.ioc.client.container.SyncBeanDef;
 import org.jboss.errai.ioc.client.container.SyncBeanManager;
 import org.jboss.errai.security.shared.api.Role;
 import org.jboss.errai.security.shared.api.identity.User;
@@ -65,6 +62,15 @@ import org.uberfire.workbench.model.menu.MenuItem;
 import org.uberfire.workbench.model.menu.Menus;
 
 import static org.uberfire.workbench.model.menu.MenuFactory.*;
+
+import com.google.common.collect.Sets;
+import com.google.gwt.animation.client.Animation;
+import com.google.gwt.dom.client.Element;
+import com.google.gwt.dom.client.Style;
+import com.google.gwt.user.client.Window;
+import com.google.gwt.user.client.ui.Image;
+import com.google.gwt.user.client.ui.RootPanel;
+import com.google.gwt.user.client.ui.Widget;
 
 /**
  * GWT's Entry-point for Uberfire-showcase
@@ -221,11 +227,11 @@ public class ShowcaseEntryPoint {
 
     private PerspectiveActivity getDefaultPerspectiveActivity() {
         PerspectiveActivity defaultPerspective = null;
-        final Collection<IOCBeanDef<PerspectiveActivity>> perspectives = manager.lookupBeans( PerspectiveActivity.class );
-        final Iterator<IOCBeanDef<PerspectiveActivity>> perspectivesIterator = perspectives.iterator();
+        final Collection<SyncBeanDef<PerspectiveActivity>> perspectives = manager.lookupBeans( PerspectiveActivity.class );
+        final Iterator<SyncBeanDef<PerspectiveActivity>> perspectivesIterator = perspectives.iterator();
 
         while ( perspectivesIterator.hasNext() ) {
-            final IOCBeanDef<PerspectiveActivity> perspective = perspectivesIterator.next();
+            final SyncBeanDef<PerspectiveActivity> perspective = perspectivesIterator.next();
             final PerspectiveActivity instance = perspective.getInstance();
             if ( instance.isDefault() ) {
                 defaultPerspective = instance;

--- a/uberfire-workbench/uberfire-workbench-client-tests/pom.xml
+++ b/uberfire-workbench/uberfire-workbench-client-tests/pom.xml
@@ -112,7 +112,7 @@
           <runTarget>index.html</runTarget>
 
           <!-- do not insert line breaks in this string; it breaks Windows compatibility -->
-          <extraJvmArgs>-Xmx1g -Xms756m -XX:MaxPermSize=256m</extraJvmArgs>
+          <extraJvmArgs>-Xmx1g -Xms756m</extraJvmArgs>
 
         </configuration>
         <executions>

--- a/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/main/java/org/uberfire/client/views/pfly/dnd/CompassWidgetImpl.java
+++ b/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/main/java/org/uberfire/client/views/pfly/dnd/CompassWidgetImpl.java
@@ -81,7 +81,7 @@ public class CompassWidgetImpl implements CompassWidget {
     private CompassPosition dropTargetPosition = CompassPosition.NONE;
 
     @PostConstruct
-    void init() {
+    private void init() {
         popup = uiBinder.createAndBindUi( this );
 
         //Setup drop indicator

--- a/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/main/java/org/uberfire/client/views/pfly/multipage/MultiPageEditorImpl.java
+++ b/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/main/java/org/uberfire/client/views/pfly/multipage/MultiPageEditorImpl.java
@@ -21,6 +21,8 @@ import javax.inject.Inject;
 
 import com.google.gwt.user.client.ui.IsWidget;
 import com.google.gwt.user.client.ui.Widget;
+
+import org.uberfire.client.workbench.widgets.multipage.Multiple;
 import org.uberfire.client.workbench.widgets.multipage.MultiPageEditor;
 import org.uberfire.client.workbench.widgets.multipage.MultiPageEditorView;
 import org.uberfire.client.workbench.widgets.multipage.Page;
@@ -28,7 +30,7 @@ import org.uberfire.client.workbench.widgets.multipage.Page;
 @Dependent
 public class MultiPageEditorImpl implements MultiPageEditor {
 
-    @Inject
+    @Inject @Multiple
     private MultiPageEditorViewImpl view;
 
     public void addPage( final Page page ) {

--- a/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/main/java/org/uberfire/client/views/pfly/multipage/MultiPageEditorViewImpl.java
+++ b/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/main/java/org/uberfire/client/views/pfly/multipage/MultiPageEditorViewImpl.java
@@ -24,10 +24,12 @@ import org.gwtbootstrap3.client.shared.event.TabShownEvent;
 import org.gwtbootstrap3.client.shared.event.TabShownHandler;
 import org.uberfire.client.views.pfly.tab.ResizeTabPanel;
 import org.uberfire.client.views.pfly.tab.TabPanelEntry;
+import org.uberfire.client.workbench.widgets.multipage.Multiple;
 import org.uberfire.client.workbench.widgets.multipage.MultiPageEditorView;
 import org.uberfire.client.workbench.widgets.multipage.Page;
 
 @Dependent
+@Multiple
 public class MultiPageEditorViewImpl extends ResizeTabPanel implements MultiPageEditorView {
 
     @Override

--- a/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/main/java/org/uberfire/client/views/pfly/tab/Resize.java
+++ b/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/main/java/org/uberfire/client/views/pfly/tab/Resize.java
@@ -1,0 +1,13 @@
+package org.uberfire.client.views.pfly.tab;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+
+import javax.inject.Qualifier;
+
+@Qualifier
+@Retention(RUNTIME)
+public @interface Resize {
+
+}

--- a/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/main/java/org/uberfire/client/views/pfly/tab/ResizeTabPanel.java
+++ b/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/main/java/org/uberfire/client/views/pfly/tab/ResizeTabPanel.java
@@ -26,6 +26,7 @@ import org.uberfire.client.resources.WorkbenchResources;
 import org.uberfire.client.util.Layouts;
 
 @Dependent
+@Resize
 public class ResizeTabPanel extends TabPanelWithDropdowns implements RequiresResize, ProvidesResize {
 
     @Override

--- a/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/main/java/org/uberfire/client/views/pfly/tab/UberTabPanel.java
+++ b/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/main/java/org/uberfire/client/views/pfly/tab/UberTabPanel.java
@@ -16,27 +16,18 @@
 
 package org.uberfire.client.views.pfly.tab;
 
+import static org.uberfire.commons.validation.PortablePreconditions.checkNotNull;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+
 import javax.annotation.PostConstruct;
 import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
 
-import com.google.gwt.event.dom.client.ClickEvent;
-import com.google.gwt.event.dom.client.ClickHandler;
-import com.google.gwt.event.logical.shared.BeforeSelectionEvent;
-import com.google.gwt.event.logical.shared.BeforeSelectionHandler;
-import com.google.gwt.event.logical.shared.SelectionEvent;
-import com.google.gwt.event.logical.shared.SelectionHandler;
-import com.google.gwt.event.shared.HandlerRegistration;
-import com.google.gwt.user.client.ui.Button;
-import com.google.gwt.user.client.ui.IsWidget;
-import com.google.gwt.user.client.ui.RequiresResize;
-import com.google.gwt.user.client.ui.ResizeComposite;
-import com.google.gwt.user.client.ui.Widget;
 import org.gwtbootstrap3.client.shared.event.TabShowEvent;
 import org.gwtbootstrap3.client.shared.event.TabShowHandler;
 import org.gwtbootstrap3.client.shared.event.TabShownEvent;
@@ -52,7 +43,18 @@ import org.uberfire.client.workbench.widgets.dnd.WorkbenchDragAndDropManager;
 import org.uberfire.mvp.Command;
 import org.uberfire.workbench.model.PartDefinition;
 
-import static org.uberfire.commons.validation.PortablePreconditions.*;
+import com.google.gwt.event.dom.client.ClickEvent;
+import com.google.gwt.event.dom.client.ClickHandler;
+import com.google.gwt.event.logical.shared.BeforeSelectionEvent;
+import com.google.gwt.event.logical.shared.BeforeSelectionHandler;
+import com.google.gwt.event.logical.shared.SelectionEvent;
+import com.google.gwt.event.logical.shared.SelectionHandler;
+import com.google.gwt.event.shared.HandlerRegistration;
+import com.google.gwt.user.client.ui.Button;
+import com.google.gwt.user.client.ui.IsWidget;
+import com.google.gwt.user.client.ui.RequiresResize;
+import com.google.gwt.user.client.ui.ResizeComposite;
+import com.google.gwt.user.client.ui.Widget;
 
 /**
  * A wrapper around {@link TabPanelWithDropdowns} that adds the following capabilities:
@@ -89,7 +91,7 @@ public class UberTabPanel extends ResizeComposite implements MultiPartWidget, Cl
     WorkbenchDragAndDropManager dndManager;
 
     @Inject
-    public UberTabPanel( final PlaceManager panelManager, final ResizeTabPanel tabPanel ) {
+    public UberTabPanel( final PlaceManager panelManager, final @Resize ResizeTabPanel tabPanel ) {
         this.panelManager = checkNotNull( "panelManager", panelManager );
         this.tabPanel = checkNotNull( "tabPanel", tabPanel );
     }

--- a/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/main/java/org/uberfire/client/views/pfly/toolbar/WorkbenchToolBarView.java
+++ b/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/main/java/org/uberfire/client/views/pfly/toolbar/WorkbenchToolBarView.java
@@ -18,6 +18,8 @@ package org.uberfire.client.views.pfly.toolbar;
 import java.util.HashMap;
 import java.util.Map;
 
+import javax.enterprise.context.Dependent;
+
 import org.gwtbootstrap3.client.ui.Button;
 import org.gwtbootstrap3.client.ui.ButtonGroup;
 import org.gwtbootstrap3.client.ui.ButtonToolBar;
@@ -48,6 +50,7 @@ import com.google.gwt.user.client.ui.SimplePanel;
 /**
  * The Tool Bar widget
  */
+@Dependent
 public class WorkbenchToolBarView extends Composite
         implements
         WorkbenchToolBarPresenter.View {

--- a/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/test/java/org/uberfire/client/views/pfly/mock/MockPartView.java
+++ b/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/test/java/org/uberfire/client/views/pfly/mock/MockPartView.java
@@ -16,14 +16,15 @@
 
 package org.uberfire.client.views.pfly.mock;
 
-import org.jboss.errai.ioc.client.api.TestMock;
+import javax.enterprise.inject.Alternative;
+
 import org.uberfire.client.workbench.part.WorkbenchPartPresenter;
 import org.uberfire.client.workbench.part.WorkbenchPartPresenter.View;
 
 import com.google.gwt.user.client.ui.IsWidget;
 import com.google.gwt.user.client.ui.Widget;
 
-@TestMock
+@Alternative
 public class MockPartView implements View {
 
     @Override

--- a/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/test/java/org/uberfire/client/views/pfly/mock/MockPlaceManager.java
+++ b/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/test/java/org/uberfire/client/views/pfly/mock/MockPlaceManager.java
@@ -18,8 +18,8 @@ package org.uberfire.client.views.pfly.mock;
 
 import java.util.Collection;
 
-import com.google.gwt.user.client.ui.HasWidgets;
-import org.jboss.errai.ioc.client.api.TestMock;
+import javax.enterprise.inject.Alternative;
+
 import org.uberfire.backend.vfs.Path;
 import org.uberfire.client.mvp.Activity;
 import org.uberfire.client.mvp.PlaceManager;
@@ -30,7 +30,9 @@ import org.uberfire.mvp.PlaceRequest;
 import org.uberfire.workbench.model.PanelDefinition;
 import org.uberfire.workbench.model.PartDefinition;
 
-@TestMock
+import com.google.gwt.user.client.ui.HasWidgets;
+
+@Alternative
 public class MockPlaceManager implements PlaceManager {
 
     @Override

--- a/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/test/resources/ErraiApp.properties
+++ b/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/test/resources/ErraiApp.properties
@@ -1,0 +1,4 @@
+errai.ioc.enabled.alternatives=org.uberfire.client.views.pfly.mock.MockPartView \
+                               org.uberfire.client.views.pfly.mock.MockPlaceManager \
+                               org.uberfire.security.impl.authz.RuntimeAuthorizationManager \
+                               org.uberfire.client.workbench.WorkbenchServicesProxyClientImpl

--- a/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/menu/SplashScreenMenuPresenter.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/menu/SplashScreenMenuPresenter.java
@@ -78,6 +78,12 @@ public class SplashScreenMenuPresenter implements IsWidget {
     private final PlaceManager placeManager;
     private final View view;
 
+    // For proxying
+    protected SplashScreenMenuPresenter() {
+        this.placeManager = null;
+        this.view = null;
+    }
+
     @Inject
     public SplashScreenMenuPresenter(PlaceManager placeManager, View view) {
         this.placeManager = checkNotNull( "placeManager", placeManager );
@@ -85,7 +91,8 @@ public class SplashScreenMenuPresenter implements IsWidget {
         view.init( this );
     }
 
-    void onNewSplashScreen( @Observes NewSplashScreenActiveEvent event ) {
+    @SuppressWarnings( "unused" )
+    private void onNewSplashScreen( @Observes NewSplashScreenActiveEvent event ) {
         List<SplashScreenListEntry> splashScreens = new ArrayList<SplashScreenListEntry>();
         for ( final SplashScreenActivity activity : placeManager.getActiveSplashScreens() ) {
             splashScreens.add( new SplashScreenListEntry( activity.getTitle(),

--- a/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/mvp/AbstractPopupActivity.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/mvp/AbstractPopupActivity.java
@@ -48,7 +48,7 @@ public abstract class AbstractPopupActivity extends AbstractActivity implements 
      */
     protected AbstractPopupActivity( final PlaceManager placeManager, final PopupView popupView ) {
         super( placeManager );
-        popup = checkNotNull( "popupView", popupView );
+        popup = popupView;
     }
 
     @Override

--- a/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/mvp/AbstractSplashScreenActivity.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/mvp/AbstractSplashScreenActivity.java
@@ -15,20 +15,19 @@
  */
 package org.uberfire.client.mvp;
 
-import static org.uberfire.commons.validation.PortablePreconditions.*;
-
 import javax.annotation.PostConstruct;
 import javax.inject.Inject;
 
-import com.google.gwt.event.logical.shared.CloseEvent;
-import com.google.gwt.event.logical.shared.CloseHandler;
-import com.google.gwt.user.client.ui.IsWidget;
 import org.uberfire.client.annotations.WorkbenchSplashScreen;
 import org.uberfire.client.workbench.WorkbenchServicesProxy;
 import org.uberfire.client.workbench.widgets.splash.SplashView;
 import org.uberfire.mvp.ParameterizedCommand;
 import org.uberfire.mvp.PlaceRequest;
 import org.uberfire.workbench.model.SplashScreenFilter;
+
+import com.google.gwt.event.logical.shared.CloseEvent;
+import com.google.gwt.event.logical.shared.CloseHandler;
+import com.google.gwt.user.client.ui.IsWidget;
 
 /**
  * Implementation of behaviour common to all splash screen activities. Concrete implementations are typically not written by
@@ -48,7 +47,7 @@ public abstract class AbstractSplashScreenActivity extends AbstractActivity impl
     public AbstractSplashScreenActivity( final PlaceManager placeManager,
                                          final SplashView splash ) {
         super( placeManager );
-        this.splash = checkNotNull( "splash", splash );
+        this.splash = splash;
     }
 
     @PostConstruct

--- a/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/mvp/ActivityManagerImpl.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/mvp/ActivityManagerImpl.java
@@ -16,7 +16,24 @@
 
 package org.uberfire.client.mvp;
 
+import static java.util.Collections.emptyList;
+import static java.util.Collections.emptySet;
+import static java.util.Collections.singleton;
+import static java.util.Collections.singletonList;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.IdentityHashMap;
+import java.util.Map;
+import java.util.Set;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.context.Dependent;
+import javax.inject.Inject;
+
 import org.jboss.errai.ioc.client.container.IOCBeanDef;
+import org.jboss.errai.ioc.client.container.SyncBeanDef;
 import org.jboss.errai.ioc.client.container.SyncBeanManager;
 import org.jboss.errai.security.shared.api.identity.User;
 import org.uberfire.backend.vfs.Path;
@@ -24,13 +41,6 @@ import org.uberfire.client.mvp.ActivityLifecycleError.LifecyclePhase;
 import org.uberfire.mvp.PlaceRequest;
 import org.uberfire.mvp.impl.PathPlaceRequest;
 import org.uberfire.security.authz.AuthorizationManager;
-
-import javax.enterprise.context.ApplicationScoped;
-import javax.enterprise.context.Dependent;
-import javax.inject.Inject;
-import java.util.*;
-
-import static java.util.Collections.*;
 
 @ApplicationScoped
 public class ActivityManagerImpl implements ActivityManager {
@@ -84,7 +94,7 @@ public class ActivityManagerImpl implements ActivityManager {
     @Override
     public Set<Activity> getActivities( final PlaceRequest placeRequest ) {
 
-        final Collection<IOCBeanDef<Activity>> beans;
+        final Collection<SyncBeanDef<Activity>> beans;
         if ( placeRequest instanceof PathPlaceRequest ) {
             beans = resolveByPath( (PathPlaceRequest) placeRequest );
         } else {
@@ -194,10 +204,10 @@ public class ActivityManagerImpl implements ActivityManager {
         return beanDef.getScope();
     }
 
-    private <T extends Activity> Set<T> secure( final Collection<IOCBeanDef<T>> activityBeans ) {
+    private <T extends Activity> Set<T> secure( final Collection<SyncBeanDef<T>> activityBeans ) {
         final Set<T> activities = new HashSet<T>( activityBeans.size() );
 
-        for ( final IOCBeanDef<T> activityBean : activityBeans ) {
+        for ( final SyncBeanDef<T> activityBean : activityBeans ) {
             if ( !activityBean.isActivated() ) {
                 continue;
             }
@@ -269,23 +279,23 @@ public class ActivityManagerImpl implements ActivityManager {
      * @param identifier the place ID. Null is permitted, but always resolves to an empty collection.
      * @return an unmodifiable collection with zero or one item, depending on if the resolution was successful.
      */
-    private Collection<IOCBeanDef<Activity>> resolveById( final String identifier ) {
+    private Collection<SyncBeanDef<Activity>> resolveById( final String identifier ) {
         if ( identifier == null ) {
             return emptyList();
         }
 
-        IOCBeanDef<Activity> beanDefActivity = activityBeansCache.getActivity( identifier );
+        SyncBeanDef<Activity> beanDefActivity = activityBeansCache.getActivity( identifier );
         if ( beanDefActivity == null ) {
             return emptyList();
         }
         return singletonList( beanDefActivity );
     }
 
-    private Set<IOCBeanDef<Activity>> resolveByPath( final PathPlaceRequest place ) {
+    private Set<SyncBeanDef<Activity>> resolveByPath( final PathPlaceRequest place ) {
         if ( place == null ) {
             return emptySet();
         }
-        final IOCBeanDef<Activity> result = activityBeansCache.getActivity( place.getIdentifier() );
+        final SyncBeanDef<Activity> result = activityBeansCache.getActivity( place.getIdentifier() );
 
         if ( result != null ) {
             return singleton( result );
@@ -294,7 +304,7 @@ public class ActivityManagerImpl implements ActivityManager {
         return asSet( activityBeansCache.getActivity( place.getPath() ) );
     }
 
-    private Set<IOCBeanDef<Activity>> asSet( final IOCBeanDef<Activity> activity ) {
+    private Set<SyncBeanDef<Activity>> asSet( final SyncBeanDef<Activity> activity ) {
         if ( activity == null ) {
             return emptySet();
         }

--- a/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/mvp/PlaceManagerImpl.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/mvp/PlaceManagerImpl.java
@@ -133,7 +133,7 @@ public class PlaceManagerImpl
         workbenchLayout = layoutSelection.get();
     }
 
-    PlaceHistoryHandler getPlaceHistoryHandler() {
+    private PlaceHistoryHandler getPlaceHistoryHandler() {
         return placeHistoryHandler;
     }
 
@@ -829,7 +829,7 @@ public class PlaceManagerImpl
 
     @Produces
     @ApplicationScoped
-    EventBus produceEventBus() {
+    private EventBus produceEventBus() {
         if ( tempBus == null ) {
             tempBus = new SimpleEventBus();
         }

--- a/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/DefaultBeanFactory.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/DefaultBeanFactory.java
@@ -20,7 +20,7 @@ import java.util.Collection;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
-import org.jboss.errai.ioc.client.container.IOCBeanDef;
+import org.jboss.errai.ioc.client.container.SyncBeanDef;
 import org.jboss.errai.ioc.client.container.SyncBeanManager;
 import org.uberfire.client.mvp.PerspectiveActivity;
 import org.uberfire.client.mvp.TemplatedActivity;
@@ -70,8 +70,8 @@ implements BeanFactory {
 
     @Override
     public WorkbenchPanelPresenter newWorkbenchPanel( final PanelDefinition definition ) {
-        Collection<IOCBeanDef<WorkbenchPanelPresenter>> beans = iocManager.lookupBeans( WorkbenchPanelPresenter.class );
-        for ( IOCBeanDef<WorkbenchPanelPresenter> bean : beans ) {
+        Collection<SyncBeanDef<WorkbenchPanelPresenter>> beans = iocManager.lookupBeans( WorkbenchPanelPresenter.class );
+        for ( SyncBeanDef<WorkbenchPanelPresenter> bean : beans ) {
             if ( bean.getBeanClass().getName().equals( definition.getPanelType() ) ) {
                 final WorkbenchPanelPresenter panel = bean.getInstance();
                 panel.setDefinition( definition );

--- a/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/LayoutSelection.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/LayoutSelection.java
@@ -18,10 +18,11 @@ package org.uberfire.client.workbench;
 
 import java.lang.annotation.Annotation;
 import java.util.Collection;
+
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
-import org.jboss.errai.ioc.client.container.IOCBeanDef;
+import org.jboss.errai.ioc.client.container.SyncBeanDef;
 import org.jboss.errai.ioc.client.container.SyncBeanManager;
 
 /**
@@ -46,9 +47,9 @@ public class LayoutSelection {
         //FIXME: this alternatives process doesn't work
         WorkbenchLayout layout = null;
 
-        Collection<IOCBeanDef<WorkbenchLayout>> beanDefs = iocManager.lookupBeans( WorkbenchLayout.class, altLayout );
+        Collection<SyncBeanDef<WorkbenchLayout>> beanDefs = iocManager.lookupBeans( WorkbenchLayout.class, altLayout );
         if ( beanDefs.size() > 0 ) {
-            IOCBeanDef<WorkbenchLayout> alt = beanDefs.iterator().next();
+            SyncBeanDef<WorkbenchLayout> alt = beanDefs.iterator().next();
             layout = alt.getInstance();
         } else {
             layout = iocManager.lookupBean( WorkbenchLayout.class ).getInstance();

--- a/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/Workbench.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/Workbench.java
@@ -15,11 +15,7 @@
  */
 package org.uberfire.client.workbench;
 
-import static java.util.Collections.*;
-
-import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -35,7 +31,7 @@ import org.jboss.errai.bus.client.api.ClientMessageBus;
 import org.jboss.errai.bus.client.framework.ClientMessageBusImpl;
 import org.jboss.errai.ioc.client.api.AfterInitialization;
 import org.jboss.errai.ioc.client.api.EntryPoint;
-import org.jboss.errai.ioc.client.container.IOCBeanDef;
+import org.jboss.errai.ioc.client.container.SyncBeanDef;
 import org.jboss.errai.ioc.client.container.SyncBeanManager;
 import org.jboss.errai.security.shared.api.identity.User;
 import org.uberfire.backend.vfs.Path;
@@ -286,9 +282,9 @@ public class Workbench {
 
     private PerspectiveActivity getDefaultPerspectiveActivity() {
         PerspectiveActivity defaultPerspective = null;
-        final Collection<IOCBeanDef<PerspectiveActivity>> perspectives = iocManager.lookupBeans(PerspectiveActivity.class);
+        final Collection<SyncBeanDef<PerspectiveActivity>> perspectives = iocManager.lookupBeans(PerspectiveActivity.class);
 
-        for ( final IOCBeanDef<PerspectiveActivity> perspective : perspectives ) {
+        for ( final SyncBeanDef<PerspectiveActivity> perspective : perspectives ) {
             final PerspectiveActivity instance = perspective.getInstance();
             if ( instance.isDefault() ) {
                 defaultPerspective = instance;

--- a/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/WorkbenchLayoutImpl.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/WorkbenchLayoutImpl.java
@@ -30,7 +30,7 @@ import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
-import org.jboss.errai.ioc.client.container.IOCBeanDef;
+import org.jboss.errai.ioc.client.container.SyncBeanDef;
 import org.jboss.errai.ioc.client.container.SyncBeanManager;
 import org.uberfire.client.util.Layouts;
 import org.uberfire.client.workbench.docks.UberfireDocks;
@@ -124,7 +124,7 @@ public class WorkbenchLayoutImpl implements WorkbenchLayout {
         public int getClientWidth() {
             return clientWidth;
         }
-        
+
     }
 
     private static final int MAXIMIZED_PANEL_Z_INDEX = 100;
@@ -236,7 +236,7 @@ public class WorkbenchLayoutImpl implements WorkbenchLayout {
 
     private void setupDocks() {
         try {
-            IOCBeanDef<UberfireDocks> uberfireDocksIOCBeanDef = iocManager.lookupBean(UberfireDocks.class);
+            SyncBeanDef<UberfireDocks> uberfireDocksIOCBeanDef = iocManager.lookupBean(UberfireDocks.class);
             UberfireDocks instance = uberfireDocksIOCBeanDef.getInstance();
             final Command resizeCommand = new Command() {
 
@@ -450,9 +450,9 @@ public class WorkbenchLayoutImpl implements WorkbenchLayout {
     private <T extends OrderableIsWidget> List<T> discoverMarginWidgets(boolean isStandaloneMode,
                                                                         Set<String> headersToKeep,
                                                                         Class<T> marginType) {
-        final Collection<IOCBeanDef<T>> headerBeans = iocManager.lookupBeans(marginType);
+        final Collection<SyncBeanDef<T>> headerBeans = iocManager.lookupBeans(marginType);
         final List<T> instances = new ArrayList<T>();
-        for (final IOCBeanDef<T> headerBean : headerBeans) {
+        for (final SyncBeanDef<T> headerBean : headerBeans) {
             if (!headerBean.isActivated()) {
                 continue;
             }

--- a/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/panels/impl/AbstractDockingWorkbenchPanelView.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/panels/impl/AbstractDockingWorkbenchPanelView.java
@@ -79,8 +79,7 @@ extends AbstractWorkbenchPanelView<P> implements DockingWorkbenchPanelView<P> {
      * The topmost widget (closest to DOM root) that this panel view manages. Contains either partViewContainer itself
      * (when there are no child panels) or a splitter (when there is at least one child panel).
      */
-    @Inject
-    private SimpleLayoutPanel topLevelWidget;
+    private SimpleLayoutPanel topLevelWidget = new SimpleLayoutPanel();
 
     @Inject
     private ResizeFlowPanel partViewContainer;

--- a/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/panels/impl/AbstractWorkbenchPanelPresenter.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/panels/impl/AbstractWorkbenchPanelPresenter.java
@@ -15,8 +15,9 @@
  */
 package org.uberfire.client.workbench.panels.impl;
 
-import static org.uberfire.debug.Debug.*;
+import static org.uberfire.debug.Debug.objectId;
 
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -30,7 +31,6 @@ import org.uberfire.workbench.model.PanelDefinition;
 import org.uberfire.workbench.model.PartDefinition;
 import org.uberfire.workbench.model.Position;
 
-import com.google.common.collect.ImmutableMap;
 import com.google.gwt.user.client.ui.IsWidget;
 
 /**
@@ -157,7 +157,7 @@ public abstract class AbstractWorkbenchPanelPresenter<P extends AbstractWorkbenc
 
     @Override
     public Map<Position, WorkbenchPanelPresenter> getPanels() {
-        return ImmutableMap.copyOf( childPanels );
+        return Collections.unmodifiableMap( childPanels );
     }
 
     protected Position positionOf( WorkbenchPanelPresenter child ) {

--- a/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/pmgr/nswe/part/WorkbenchPartView.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/pmgr/nswe/part/WorkbenchPartView.java
@@ -15,6 +15,8 @@
  */
 package org.uberfire.client.workbench.pmgr.nswe.part;
 
+import javax.enterprise.context.Dependent;
+
 import org.uberfire.client.util.Layouts;
 import org.uberfire.client.workbench.part.WorkbenchPartPresenter;
 
@@ -25,6 +27,7 @@ import com.google.gwt.user.client.ui.SimpleLayoutPanel;
 /**
  * A Workbench panel part.
  */
+@Dependent
 public class WorkbenchPartView
 extends SimpleLayoutPanel
 implements WorkbenchPartPresenter.View {

--- a/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/widgets/common/ErrorPopupPresenter.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/widgets/common/ErrorPopupPresenter.java
@@ -54,7 +54,7 @@ public class ErrorPopupPresenter {
 
     @Inject
     public ErrorPopupPresenter( View view ) {
-        this.view = checkNotNull( "view", view );
+        this.view = view;
     }
 
     /**

--- a/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/widgets/menu/PartContextMenusPresenter.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/widgets/menu/PartContextMenusPresenter.java
@@ -20,13 +20,14 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.event.Observes;
 import javax.inject.Inject;
 
-import com.google.gwt.user.client.ui.IsWidget;
 import org.uberfire.client.mvp.Activity;
 import org.uberfire.client.mvp.PlaceManager;
 import org.uberfire.client.mvp.WorkbenchActivity;
 import org.uberfire.client.workbench.events.PlaceGainFocusEvent;
 import org.uberfire.mvp.PlaceRequest;
 import org.uberfire.workbench.model.menu.Menus;
+
+import com.google.gwt.user.client.ui.IsWidget;
 
 @ApplicationScoped
 public class PartContextMenusPresenter {
@@ -48,7 +49,8 @@ public class PartContextMenusPresenter {
 
     private PlaceRequest activePlace = null;
 
-    void onWorkbenchPartOnFocus( @Observes PlaceGainFocusEvent event ) {
+    @SuppressWarnings( "unused" )
+    private void onWorkbenchPartOnFocus( @Observes PlaceGainFocusEvent event ) {
         final Activity activity = placeManager.getActivity( event.getPlace() );
         if ( activity == null ) {
             return;

--- a/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/widgets/multipage/Multiple.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/widgets/multipage/Multiple.java
@@ -1,0 +1,13 @@
+package org.uberfire.client.workbench.widgets.multipage;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+
+import javax.inject.Qualifier;
+
+@Qualifier
+@Retention(RUNTIME)
+public @interface Multiple {
+
+}

--- a/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/widgets/notifications/NotificationManager.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/widgets/notifications/NotificationManager.java
@@ -22,11 +22,7 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.event.Observes;
 import javax.inject.Inject;
 
-import com.google.gwt.user.client.Command;
-import com.google.gwt.user.client.ui.IsWidget;
-import com.google.gwt.user.client.ui.RootPanel;
-
-import org.jboss.errai.ioc.client.container.IOCBeanDef;
+import org.jboss.errai.ioc.client.container.SyncBeanDef;
 import org.jboss.errai.ioc.client.container.SyncBeanManager;
 import org.uberfire.client.mvp.Activity;
 import org.uberfire.client.mvp.PlaceManager;
@@ -37,6 +33,10 @@ import org.uberfire.commons.validation.PortablePreconditions;
 import org.uberfire.mvp.PlaceRequest;
 import org.uberfire.mvp.impl.DefaultPlaceRequest;
 import org.uberfire.workbench.events.NotificationEvent;
+
+import com.google.gwt.user.client.Command;
+import com.google.gwt.user.client.ui.IsWidget;
+import com.google.gwt.user.client.ui.RootPanel;
 
 /**
  * Observes all notification events, and coordinates their display and removal.
@@ -68,12 +68,12 @@ public class NotificationManager {
          *          The container relative to which Notifications will be shown. Must not be null.
          */
         void setContainer( final IsWidget container );
-        
+
         /**
          * Configures the initial vertical spacing for the first notifications
          * (see {@link NotificationEvent#getInitialTopOffset()}). A default value is
          * used if this method is never invoked.
-         * 
+         *
          * @param spacing
          *            the vertical spacing in number of pixels
          */
@@ -105,7 +105,7 @@ public class NotificationManager {
          *          The handle for the active notification that should be hidden.
          */
         void hide( final NotificationPopupHandle popup );
-        
+
         /**
          * Hides all active notifications.
          */
@@ -124,10 +124,8 @@ public class NotificationManager {
     @Inject
     public NotificationManager( final SyncBeanManager iocManager,
                                 final PlaceManager placeManager ) {
-        this.iocManager = PortablePreconditions.checkNotNull( "iocManager",
-                                                              iocManager );
-        this.placeManager = PortablePreconditions.checkNotNull( "placeManager",
-                                                                placeManager );
+        this.iocManager = iocManager;
+        this.placeManager = placeManager;
     }
 
     private class HideNotificationCommand implements Command {
@@ -176,7 +174,7 @@ public class NotificationManager {
         //Lookup, or create, a View specific to the container
         View notificationsContainerView = notificationsContainerViewMap.get( placeRequest );
         if ( notificationsContainerView == null ) {
-            final IOCBeanDef<View> containerViewBeanDef = iocManager.lookupBean( View.class );
+            final SyncBeanDef<View> containerViewBeanDef = iocManager.lookupBean( View.class );
             if ( containerViewBeanDef != null ) {
                 notificationsContainerView = containerViewBeanDef.getInstance();
                 notificationsContainerView.setContainer( notificationsContainer );
@@ -206,13 +204,13 @@ public class NotificationManager {
         if ( placeRequest == null ) {
             return;
         }
-        
+
         final View view = notificationsContainerViewMap.remove( placeRequest );
         if ( view != null ) {
             view.hideAll();
         }
     }
-    
+
     public void onPlaceLostFocus( @Observes final PlaceLostFocusEvent event ) {
         final View view = notificationsContainerViewMap.get( event.getPlace() );
         if ( view != null ) {

--- a/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/widgets/toolbar/WorkbenchToolBarPresenter.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/widgets/toolbar/WorkbenchToolBarPresenter.java
@@ -160,7 +160,8 @@ public class WorkbenchToolBarPresenter {
     /**
 	 * Removes the toolbar items of a WorkbenchPart when that part is closed.
 	 */
-    void onWorkbenchPartClose( @Observes ClosePlaceEvent event ) {
+    @SuppressWarnings( "unused" )
+    private void onWorkbenchPartClose( @Observes ClosePlaceEvent event ) {
     	removeItemsFor(event.getPlace());
     }
 
@@ -169,7 +170,8 @@ public class WorkbenchToolBarPresenter {
 	 * <p>
 	 * TODO(UF-6): change this to observe PlaceOpenedEvent when such an event exists.
 	 */
-    void onWorkbenchPartOnFocus( @Observes PlaceGainFocusEvent event ) {
+    @SuppressWarnings( "unused" )
+    private void onWorkbenchPartOnFocus( @Observes PlaceGainFocusEvent event ) {
         if ( !workbenchContextItems.containsKey(event.getPlace()) ) {
             addItemsFor(event.getPlace());
         }

--- a/uberfire-workbench/uberfire-workbench-client/src/test/java/org/uberfire/client/mvp/ActivityBeansCacheActivatedByTest.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/test/java/org/uberfire/client/mvp/ActivityBeansCacheActivatedByTest.java
@@ -16,8 +16,11 @@
 
 package org.uberfire.client.mvp;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.lang.annotation.Annotation;
 import java.util.ArrayList;
@@ -25,7 +28,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
-import org.jboss.errai.ioc.client.container.IOCBeanDef;
+import org.jboss.errai.ioc.client.container.SyncBeanDef;
 import org.jboss.errai.ioc.client.container.SyncBeanManager;
 import org.junit.Before;
 import org.junit.Test;
@@ -54,14 +57,14 @@ public class ActivityBeansCacheActivatedByTest {
     SyncBeanManager iocManager;
 
     private ActiveSplashScreenActivity activeSplashScreenActivity;
-    private IOCBeanDef activeSplashScreenActivityBean;
-    private IOCBeanDef nonActiveSplashScreenActivityBean;
+    private SyncBeanDef activeSplashScreenActivityBean;
+    private SyncBeanDef nonActiveSplashScreenActivityBean;
     private ActiveRegularActivity activeRegularActivity;
-    private IOCBeanDef activeRegularActivityBean;
-    private IOCBeanDef nonActiveRegularActivityBean;
+    private SyncBeanDef activeRegularActivityBean;
+    private SyncBeanDef nonActiveRegularActivityBean;
     private ActiveResourceActivity activeResourceActivity;
-    private IOCBeanDef activeResourceActivityBean;
-    private IOCBeanDef nonActiveResourceActivityBean;
+    private SyncBeanDef activeResourceActivityBean;
+    private SyncBeanDef nonActiveResourceActivityBean;
 
     @Before
     @SuppressWarnings("unchecked")
@@ -82,12 +85,12 @@ public class ActivityBeansCacheActivatedByTest {
 
         nonActiveResourceActivityBean = mockResourceActivityBean( NonActiveResourceActivity.class, null );
 
-        Collection<IOCBeanDef<SplashScreenActivity>> splashScreenBeans = new ArrayList<IOCBeanDef<SplashScreenActivity>>();
+        Collection<SyncBeanDef<SplashScreenActivity>> splashScreenBeans = new ArrayList<SyncBeanDef<SplashScreenActivity>>();
         splashScreenBeans.add( activeSplashScreenActivityBean );
         splashScreenBeans.add( nonActiveSplashScreenActivityBean );
 
         // all activity beans, including splash screens
-        Collection<IOCBeanDef<Activity>> allActivityBeans = new ArrayList<IOCBeanDef<Activity>>();
+        Collection<SyncBeanDef<Activity>> allActivityBeans = new ArrayList<SyncBeanDef<Activity>>();
         allActivityBeans.add( activeSplashScreenActivityBean );
         allActivityBeans.add( nonActiveSplashScreenActivityBean );
         allActivityBeans.add( activeRegularActivityBean );
@@ -158,8 +161,8 @@ public class ActivityBeansCacheActivatedByTest {
     };
 
     @SuppressWarnings("unchecked")
-    private <T> IOCBeanDef mockRegularBean(Class<T> type, T instance) {
-        IOCBeanDef<T> beanDef = mock( IOCBeanDef.class );
+    private <T> SyncBeanDef mockRegularBean(Class<T> type, T instance) {
+        SyncBeanDef<T> beanDef = mock( SyncBeanDef.class );
         when( iocManager.lookupBean( type ) ).thenReturn( beanDef );
         when( beanDef.getInstance() ).thenReturn( instance );
         when( beanDef.getBeanClass() ).thenReturn( (Class) type );
@@ -168,14 +171,14 @@ public class ActivityBeansCacheActivatedByTest {
         return beanDef;
     }
 
-    private <T extends SplashScreenActivity> IOCBeanDef mockSplashScreenActivityBean(Class<T> type, T instance) {
-        IOCBeanDef beanDef = mockRegularBean( type, instance );
+    private <T extends SplashScreenActivity> SyncBeanDef mockSplashScreenActivityBean(Class<T> type, T instance) {
+        SyncBeanDef beanDef = mockRegularBean( type, instance );
         when( beanDef.getQualifiers() ).thenReturn( Collections.singleton( IS_SPLASH_SCREEN ) );
         return beanDef;
     }
 
-    private <T extends Activity> IOCBeanDef mockResourceActivityBean(Class<T> type, T instance) {
-        IOCBeanDef beanDef = mockRegularBean( type, instance );
+    private <T extends Activity> SyncBeanDef mockResourceActivityBean(Class<T> type, T instance) {
+        SyncBeanDef beanDef = mockRegularBean( type, instance );
         when( beanDef.getQualifiers() ).thenReturn( Collections.singleton( ASSOCIATED_RESOURCES ) );
         return beanDef;
     }

--- a/uberfire-workbench/uberfire-workbench-client/src/test/java/org/uberfire/client/mvp/ActivityBeansCacheUnitTestWrapper.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/test/java/org/uberfire/client/mvp/ActivityBeansCacheUnitTestWrapper.java
@@ -16,7 +16,8 @@
 
 package org.uberfire.client.mvp;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.lang.annotation.Annotation;
 import java.util.ArrayList;
@@ -26,8 +27,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import org.jboss.errai.ioc.client.container.IOCBeanDef;
-import org.jboss.errai.ioc.client.container.IOCDependentBean;
+import org.jboss.errai.ioc.client.container.SyncBeanDef;
 import org.uberfire.client.workbench.type.ClientResourceType;
 import org.uberfire.commons.data.Pair;
 
@@ -35,15 +35,15 @@ import org.uberfire.commons.data.Pair;
 public class ActivityBeansCacheUnitTestWrapper extends ActivityBeansCache {
 
     private String idMock;
-    private IOCBeanDef mockDef;
+    private SyncBeanDef mockDef;
     private SplashScreenActivity splashScreenActivity;
-    private Collection<IOCBeanDef<Activity>> availableActivities = new HashSet<IOCBeanDef<Activity>>();
+    private Collection<SyncBeanDef<Activity>> availableActivities = new HashSet<SyncBeanDef<Activity>>();
     private List<ActivityAndMetaInfo> activitiesAndMetaInfo = new ArrayList<ActivityAndMetaInfo>();
     private  Pair<Integer, List<Class<? extends ClientResourceType>>> metaInfo;
     private boolean mockSplashcreen = true;
 
     public ActivityBeansCacheUnitTestWrapper() {
-        mockDef = mock( IOCDependentBean.class );
+        mockDef = mock( SyncBeanDef.class );
         idMock = "mockDef1";
         when( mockDef.getName() ).thenReturn( idMock );
         when( mockDef.getBeanClass() ).thenReturn( this.getClass() );
@@ -67,15 +67,12 @@ public class ActivityBeansCacheUnitTestWrapper extends ActivityBeansCache {
         activitiesAndMetaInfo.add( new ActivityAndMetaInfo( null, priority2, new ArrayList() ) );
     }
 
-    Collection<IOCBeanDef<Activity>> getAvailableActivities() {
+    @Override
+    Collection<SyncBeanDef<Activity>> getAvailableActivities() {
         return availableActivities;
     }
 
-    IOCBeanDef<Activity> reLookupBean( IOCBeanDef<Activity> baseBean ) {
-        return mockDef;
-    }
-
-    public IOCBeanDef getMockDef() {
+    public SyncBeanDef getMockDef() {
         return mockDef;
     }
 
@@ -88,7 +85,7 @@ public class ActivityBeansCacheUnitTestWrapper extends ActivityBeansCache {
     }
 
     public void duplicateActivity() {
-        IOCBeanDef duplicateMockDef = mock( IOCDependentBean.class );
+        SyncBeanDef duplicateMockDef = mock( SyncBeanDef.class );
         when( duplicateMockDef.getName() ).thenReturn( idMock );
         availableActivities.add( duplicateMockDef );
     }
@@ -100,7 +97,8 @@ public class ActivityBeansCacheUnitTestWrapper extends ActivityBeansCache {
         return super.getResourceActivities();
     }
 
-    Pair<Integer, List<Class<? extends ClientResourceType>>> generateActivityMetaInfo( IOCBeanDef<Activity> activityBean ) {
+    @Override
+    Pair<Integer, List<Class<? extends ClientResourceType>>> generateActivityMetaInfo( SyncBeanDef<Activity> activityBean ) {
         return metaInfo;
     }
 

--- a/uberfire-workbench/uberfire-workbench-client/src/test/java/org/uberfire/client/mvp/ActivityBeansInfoTest.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/test/java/org/uberfire/client/mvp/ActivityBeansInfoTest.java
@@ -16,24 +16,22 @@
 
 package org.uberfire.client.mvp;
 
-import org.jboss.errai.ioc.client.container.CreationalContext;
-import org.jboss.errai.ioc.client.container.IOCBeanDef;
-import org.jboss.errai.ioc.client.container.SyncBeanManager;
-import org.junit.Before;
-import org.junit.Test;
-import org.mockito.Mock;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
-import javax.inject.Named;
 import java.lang.annotation.Annotation;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
 
-import static org.junit.Assert.*;
-import static org.mockito.Matchers.anyObject;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import javax.inject.Named;
+
+import org.jboss.errai.ioc.client.container.SyncBeanDef;
+import org.jboss.errai.ioc.client.container.SyncBeanManager;
+import org.junit.Before;
+import org.junit.Test;
 
 public class ActivityBeansInfoTest {
 
@@ -66,8 +64,8 @@ public class ActivityBeansInfoTest {
 
     }
 
-    private Collection<IOCBeanDef<WorkbenchScreenActivity>> generateBeansList() {
-        Collection<IOCBeanDef<WorkbenchScreenActivity>> beans = new ArrayList<IOCBeanDef<WorkbenchScreenActivity>>(  );
+    private Collection<SyncBeanDef<WorkbenchScreenActivity>> generateBeansList() {
+        Collection<SyncBeanDef<WorkbenchScreenActivity>> beans = new ArrayList<SyncBeanDef<WorkbenchScreenActivity>>(  );
 
         beans.add( generateBeanDef( "Z", true ) );
         beans.add( generateBeanDef( "A", false ) );
@@ -77,8 +75,8 @@ public class ActivityBeansInfoTest {
         return beans;
     }
 
-    private IOCBeanDef<WorkbenchScreenActivity> generateBeanDef( final String beanName, final boolean hasAnnotations ) {
-        return new IOCBeanDef<WorkbenchScreenActivity>() {
+    private SyncBeanDef<WorkbenchScreenActivity> generateBeanDef(final String beanName, final boolean hasAnnotations) {
+        return new SyncBeanDef<WorkbenchScreenActivity>() {
             @Override
             public Class<WorkbenchScreenActivity> getType() {
                 return null;
@@ -96,11 +94,6 @@ public class ActivityBeansInfoTest {
 
             @Override
             public WorkbenchScreenActivity getInstance() {
-                return null;
-            }
-
-            @Override
-            public WorkbenchScreenActivity getInstance( CreationalContext context ) {
                 return null;
             }
 

--- a/uberfire-workbench/uberfire-workbench-client/src/test/java/org/uberfire/client/mvp/ActivityManagerActivatedByTest.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/test/java/org/uberfire/client/mvp/ActivityManagerActivatedByTest.java
@@ -16,18 +16,22 @@
 
 package org.uberfire.client.mvp;
 
-import static java.util.Collections.*;
-import static org.junit.Assert.*;
-import static org.mockito.Matchers.*;
-import static org.mockito.Mockito.*;
+import static java.util.Collections.singletonList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Set;
 
-import org.jboss.errai.ioc.client.container.CreationalContext;
-import org.jboss.errai.ioc.client.container.IOCBeanDef;
+import org.jboss.errai.ioc.client.container.SyncBeanDef;
 import org.jboss.errai.ioc.client.container.SyncBeanManager;
 import org.jboss.errai.security.shared.api.identity.User;
 import org.junit.After;
@@ -67,10 +71,10 @@ public class ActivityManagerActivatedByTest {
     private Activity activatedActivity;
 
     @SuppressWarnings("unchecked")
-    private final IOCBeanDef<Activity> activatedActivityBean = mock( IOCBeanDef.class );
+    private final SyncBeanDef<Activity> activatedActivityBean = mock( SyncBeanDef.class );
 
     @SuppressWarnings("unchecked")
-    private final IOCBeanDef<Activity> nonActivatedActivityBean = mock( IOCBeanDef.class );
+    private final SyncBeanDef<Activity> nonActivatedActivityBean = mock( SyncBeanDef.class );
 
     @Before
     public void setup() {
@@ -84,7 +88,7 @@ public class ActivityManagerActivatedByTest {
 
         when( nonActivatedActivityBean.isActivated() ).thenReturn( false );
 
-        Collection<IOCBeanDef<Activity>> activityList = new ArrayList<IOCBeanDef<Activity>>();
+        Collection<SyncBeanDef<Activity>> activityList = new ArrayList<SyncBeanDef<Activity>>();
         activityList.add( activatedActivityBean );
         activityList.add( nonActivatedActivityBean );
 
@@ -106,7 +110,6 @@ public class ActivityManagerActivatedByTest {
 
         // no matter what else we're testing, the non-activated bean should never be instantiated
         verify( nonActivatedActivityBean, never() ).getInstance();
-        verify( nonActivatedActivityBean, never() ).getInstance( any( CreationalContext.class) );
         verify( nonActivatedActivityBean, never() ).newInstance();
     }
 

--- a/uberfire-workbench/uberfire-workbench-client/src/test/java/org/uberfire/client/mvp/PlaceRequestHistoryMapperImplTest.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/test/java/org/uberfire/client/mvp/PlaceRequestHistoryMapperImplTest.java
@@ -16,18 +16,22 @@
 
 package org.uberfire.client.mvp;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import java.io.UnsupportedEncodingException;
 import java.lang.annotation.Annotation;
 import java.net.URLDecoder;
-import java.util.Collections;
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.Map;
-import java.util.Set;
 
-import org.jboss.errai.ioc.client.container.CreationalContext;
+import javax.enterprise.context.Dependent;
+
+import org.jboss.errai.ioc.client.QualifierUtil;
 import org.jboss.errai.ioc.client.container.IOC;
-import org.jboss.errai.ioc.client.container.IOCBeanDef;
+import org.jboss.errai.ioc.client.container.SyncBeanManagerImpl;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -35,6 +39,7 @@ import org.uberfire.backend.vfs.ObservablePath;
 import org.uberfire.backend.vfs.Path;
 import org.uberfire.backend.vfs.PathFactory;
 import org.uberfire.backend.vfs.impl.ObservablePathImpl;
+import org.uberfire.client.util.MockIOCBeanDef;
 import org.uberfire.mvp.PlaceRequest;
 import org.uberfire.mvp.impl.PathPlaceRequest;
 
@@ -43,71 +48,21 @@ import com.google.common.collect.ImmutableMap;
 public class PlaceRequestHistoryMapperImplTest {
 
     private PlaceRequestHistoryMapperImpl placeRequestHistoryMapper;
-
+    
     @BeforeClass
     public static void setupBeans() {
-        IOC.getBeanManager().destroyAllBeans();
+        ((SyncBeanManagerImpl) IOC.getBeanManager()).reset();
 
-        final ObservablePath opath = new ObservablePathImpl();
-
-        IOC.getBeanManager().destroyAllBeans();
-        IOC.getBeanManager().registerBean( new IOCBeanDef<ObservablePath>() {
-            @Override
-            public Class<ObservablePath> getType() {
-                return ObservablePath.class;
-            }
-
-            @Override
-            public Class<?> getBeanClass() {
-                return ObservablePath.class;
-            }
-
-            @Override
-            public Class<? extends Annotation> getScope() {
-                return null;
-            }
-
-            @Override
-            public ObservablePath getInstance() {
-                return opath;
-            }
-
-            @Override
-            public ObservablePath getInstance( CreationalContext creationalContext ) {
-                return opath;
-            }
-
-            @Override
-            public ObservablePath newInstance() {
-                return opath;
-            }
-
-            @Override
-            public Set<Annotation> getQualifiers() {
-                return Collections.emptySet();
-            }
-
-            @Override
-            public boolean matches( Set<Annotation> annotations ) {
-                return annotations.isEmpty();
-            }
-
-            @Override
-            public String getName() {
-                return ObservablePath.class.getName();
-            }
-
-            @Override
-            public boolean isConcrete() {
-                return false;
-            }
-
-            @Override
-            public boolean isActivated() {
-                return true;
-            }
-        } );
+        IOC.getBeanManager().registerBean( new MockIOCBeanDef<ObservablePath, ObservablePathImpl>( new ObservablePathImpl(),
+                                                                                                   ObservablePath.class,
+                                                                                                   Dependent.class,
+                                                                                                   new HashSet<Annotation>( Arrays.asList( QualifierUtil.DEFAULT_QUALIFIERS ) ),
+                                                                                                   null,
+                                                                                                   true,
+                                                                                                   true ) );
     }
+
+
 
     @Before
     public void setup() {

--- a/uberfire-workbench/uberfire-workbench-client/src/test/java/org/uberfire/client/util/MockIOCBeanDef.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/test/java/org/uberfire/client/util/MockIOCBeanDef.java
@@ -1,0 +1,92 @@
+package org.uberfire.client.util;
+
+import java.lang.annotation.Annotation;
+import java.util.Collections;
+import java.util.Set;
+
+import org.jboss.errai.ioc.client.QualifierUtil;
+import org.jboss.errai.ioc.client.container.SyncBeanDef;
+
+public class MockIOCBeanDef<T,B extends T>
+    implements
+    SyncBeanDef<T> {
+
+    private final B beanInstance;
+    private final Class<T> type;
+    private final Class<? extends Annotation> scope;
+    private final Set<Annotation> qualifiers;
+    private final String name;
+    private final boolean concrete;
+    private final boolean activated;
+
+    public MockIOCBeanDef( final B beanInstance,
+                           final Class<T> type,
+                           final Class< ? extends Annotation> scope,
+                           final Set<Annotation> qualifiers,
+                           final String name,
+                           final boolean concrete,
+                           final boolean activated ) {
+        this.beanInstance = beanInstance;
+        this.type = type;
+        this.scope = scope;
+        this.qualifiers = qualifiers;
+        this.name = name;
+        this.concrete = concrete;
+        this.activated = activated;
+    }
+
+    @Override
+    public Class<T> getType() {
+        return type;
+    }
+
+    @Override
+    public Class< ? > getBeanClass() {
+        return beanInstance.getClass();
+    }
+
+    @Override
+    public Class< ? extends Annotation> getScope() {
+        return scope;
+    }
+
+    @Override
+    public T getInstance() {
+        return beanInstance;
+    }
+
+    @Override
+    public T newInstance() {
+        return beanInstance;
+    }
+
+    @Override
+    public Set<Annotation> getQualifiers() {
+        if (qualifiers == null) {
+            return Collections.emptySet();
+        } else {
+            return qualifiers;
+        }
+    }
+
+    @Override
+    public boolean matches( final Set<Annotation> annotations ) {
+        return QualifierUtil.matches( annotations, getQualifiers() );
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public boolean isConcrete() {
+        return concrete;
+    }
+
+    @Override
+    public boolean isActivated() {
+        return activated;
+    }
+
+}

--- a/uberfire-workbench/uberfire-workbench-processors-tests/src/test/java/org/uberfire/annotations/processors/WorkbenchSplashScreenProcessorTest.java
+++ b/uberfire-workbench/uberfire-workbench-processors-tests/src/test/java/org/uberfire/annotations/processors/WorkbenchSplashScreenProcessorTest.java
@@ -109,8 +109,8 @@ public class WorkbenchSplashScreenProcessorTest extends AbstractProcessorTest {
         assertSuccessfulCompilation( diagnostics );
         assertNotNull( result.getActualCode() );
         assertNotNull( result.getExpectedCode() );
-        assertEquals( result.getActualCode(),
-                      result.getExpectedCode() );
+        assertEquals( result.getExpectedCode(),
+                      result.getActualCode() );
     }
 
     @Test
@@ -127,8 +127,8 @@ public class WorkbenchSplashScreenProcessorTest extends AbstractProcessorTest {
         assertSuccessfulCompilation( diagnostics );
         assertNotNull( result.getActualCode() );
         assertNotNull( result.getExpectedCode() );
-        assertEquals( result.getActualCode(),
-                      result.getExpectedCode() );
+        assertEquals( result.getExpectedCode(),
+                      result.getActualCode() );
     }
 
     @Test
@@ -163,8 +163,8 @@ public class WorkbenchSplashScreenProcessorTest extends AbstractProcessorTest {
         assertSuccessfulCompilation( diagnostics );
         assertNotNull( result.getActualCode() );
         assertNotNull( result.getExpectedCode() );
-        assertEquals( result.getActualCode(),
-                      result.getExpectedCode() );
+        assertEquals( result.getExpectedCode(),
+                      result.getActualCode() );
     }
 
 }


### PR DESCRIPTION
* Fixes for ambiguous dependencies caused by new resolution
algorithm for concrete beans.
* Explicity enable alternatives.
* Update code using old bean manager API.
* Replace @TestMock with @Alternative