### PR TITLE
Scrollbars always displayed on latest version of Chrome (48)

### DIFF
--- a/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/main/resources/org/uberfire/client/views/static/uberfire-patternfly.css
+++ b/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/main/resources/org/uberfire/client/views/static/uberfire-patternfly.css
@@ -294,3 +294,8 @@
 .form-horizontal .uf-form-label {
     text-align: right;
 }
+
+.uf-workbench-layout > div:first-child > div:first-child,
+.uf-workbench-layout > div:first-child > div:nth-child(2) {
+    overflow: hidden !important;
+}

--- a/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/WorkbenchLayoutImpl.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/WorkbenchLayoutImpl.java
@@ -16,20 +16,16 @@
 
 package org.uberfire.client.workbench;
 
-import static java.util.Collections.sort;
-
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
-import javax.annotation.PostConstruct;
-import javax.enterprise.context.ApplicationScoped;
-import javax.inject.Inject;
-
+import com.google.gwt.animation.client.Animation;
+import com.google.gwt.core.client.Scheduler;
+import com.google.gwt.core.client.Scheduler.ScheduledCommand;
+import com.google.gwt.dom.client.Element;
+import com.google.gwt.dom.client.Style;
+import com.google.gwt.dom.client.Style.Position;
+import com.google.gwt.dom.client.Style.Unit;
+import com.google.gwt.user.client.Timer;
+import com.google.gwt.user.client.Window;
+import com.google.gwt.user.client.ui.*;
 import org.jboss.errai.ioc.client.container.SyncBeanDef;
 import org.jboss.errai.ioc.client.container.SyncBeanManager;
 import org.uberfire.client.util.Layouts;
@@ -39,23 +35,12 @@ import org.uberfire.client.workbench.widgets.dnd.WorkbenchPickupDragController;
 import org.uberfire.mvp.Command;
 import org.uberfire.workbench.model.PerspectiveDefinition;
 
-import com.google.gwt.animation.client.Animation;
-import com.google.gwt.core.client.Scheduler;
-import com.google.gwt.core.client.Scheduler.ScheduledCommand;
-import com.google.gwt.dom.client.Style;
-import com.google.gwt.dom.client.Style.Position;
-import com.google.gwt.dom.client.Style.Unit;
-import com.google.gwt.user.client.Timer;
-import com.google.gwt.user.client.Window;
-import com.google.gwt.user.client.ui.AbsolutePanel;
-import com.google.gwt.user.client.ui.DockLayoutPanel;
-import com.google.gwt.user.client.ui.FlowPanel;
-import com.google.gwt.user.client.ui.HasWidgets;
-import com.google.gwt.user.client.ui.HeaderPanel;
-import com.google.gwt.user.client.ui.Panel;
-import com.google.gwt.user.client.ui.RequiresResize;
-import com.google.gwt.user.client.ui.SimpleLayoutPanel;
-import com.google.gwt.user.client.ui.Widget;
+import javax.annotation.PostConstruct;
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import java.util.*;
+
+import static java.util.Collections.sort;
 
 /**
  * The default layout implementation.
@@ -182,6 +167,7 @@ public class WorkbenchLayoutImpl implements WorkbenchLayout {
         headerPanel.ensureDebugId("workbenchHeaderPanel");
         footerPanel.ensureDebugId("workbenchFooterPanel");
         dragController.getBoundaryPanel().ensureDebugId("workbenchDragBoundary");
+        root.addStyleName("uf-workbench-layout");
     }
 
     @Override


### PR DESCRIPTION
Scrollbars are always displayed on Google Chrome 48. After further investigation, we figure out that this only happens on OSX + Chrome 48 + Big Screens. See the magic: http://cl.ly/2x0o0P1h3w3X

Uberfire's uses a Header Panel, that creates a container to wrap the header widget. This container has  a ResizeLayoutPanel inside that has "overflow: scroll" defined and chromes 48 thinks that it's a good idea to show them in biggers screens (only on osx). (╯°□°）╯︵ ┻━┻

https://github.com/google-web-toolkit/gwt.svn/blob/master/user/src/com/google/gwt/user/client/ui/HeaderPanel.java#L71
https://github.com/gwtproject/gwt/blob/master/user/src/com/google/gwt/user/client/ui/ResizeLayoutPanel.java#L163

See this gist: https://gist.github.com/ederign/79a10546fa60277ac587#file-gistfile1-txt-L25

In order to fix that, I've to add a id on this header panel in order to access inner div with a css selector.

@cristianonicolai could you please take a look on it and see if you figure out a better solution?