### PR TITLE
Remove no longer needed javassist exclusions/inclusions

### DIFF
--- a/uberfire-api/pom.xml
+++ b/uberfire-api/pom.xml
@@ -47,12 +47,6 @@
       <groupId>org.jboss.errai</groupId>
       <artifactId>errai-security-server</artifactId>
     </dependency>
-    <!-- Needed as replacement for the javassist:javassist which is excluded from errai-security-server -->
-    <dependency>
-      <groupId>org.javassist</groupId>
-      <artifactId>javassist</artifactId>
-      <scope>runtime</scope>
-    </dependency>
 
     <dependency>
       <groupId>org.jboss.errai</groupId>

--- a/uberfire-parent-with-dependencies/pom.xml
+++ b/uberfire-parent-with-dependencies/pom.xml
@@ -215,19 +215,6 @@
       </dependency>
 
       <dependency>
-        <groupId>org.jboss.errai</groupId>
-        <artifactId>errai-security-server</artifactId>
-        <version>${version.org.jboss.errai}</version>
-        <exclusions>
-          <!-- Old javassist groupId. Uses same class FQNs as the new one so we need to exclude this artifact. -->
-          <exclusion>
-            <groupId>javassist</groupId>
-            <artifactId>javassist</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-
-      <dependency>
         <groupId>javax.enterprise</groupId>
         <artifactId>cdi-api</artifactId>
         <version>${version.javax.enterprise}</version>

--- a/uberfire-testing-utils/pom.xml
+++ b/uberfire-testing-utils/pom.xml
@@ -47,12 +47,6 @@
       <groupId>org.jboss.errai</groupId>
       <artifactId>errai-security-server</artifactId>
     </dependency>
-    <!-- Needed as replacement for the above javassist:javassist exclusion from errai-security-server -->
-    <dependency>
-      <groupId>org.javassist</groupId>
-      <artifactId>javassist</artifactId>
-      <scope>runtime</scope>
-    </dependency>
 
     <dependency>
       <groupId>org.jboss.errai</groupId>


### PR DESCRIPTION
 * javassist:javassist is now properly excluded directly in the
   Errai, and replaced by org.javassist:javassist

 * we still have the enforcer rule in place, in case it would
   somehow got back. The build would fail in that case.