### PR TITLE
Update SyncBeanDef implementations to upstream API change.

### DIFF
--- a/uberfire-js/src/main/java/org/uberfire/client/exporter/EditorJSExporter.java
+++ b/uberfire-js/src/main/java/org/uberfire/client/exporter/EditorJSExporter.java
@@ -70,7 +70,8 @@ public class EditorJSExporter implements UberfireJSExporter {
                                                                                                 qualifiers,
                                                                                                 newNativeEditor.getId(),
                                                                                                 true,
-                                                                                                true );
+                                                                                                WorkbenchEditorActivity.class,
+                                                                                                Activity.class );
             beanManager.registerBean( beanDef );
             beanManager.registerBeanTypeAlias( beanDef, WorkbenchEditorActivity.class );
             beanManager.registerBeanTypeAlias( beanDef, Activity.class );

--- a/uberfire-js/src/main/java/org/uberfire/client/exporter/PerspectiveJSExporter.java
+++ b/uberfire-js/src/main/java/org/uberfire/client/exporter/PerspectiveJSExporter.java
@@ -63,7 +63,7 @@ public class PerspectiveJSExporter implements UberfireJSExporter {
                                                                   new HashSet<Annotation>( Arrays.asList( DEFAULT_QUALIFIERS ) ),
                                                                   newNativePerspective.getId(),
                                                                   true,
-                                                                  true ) );
+                                                                  JSWorkbenchPerspectiveActivity.class ) );
 
             activityBeansCache.addNewPerspectiveActivity( beanManager.lookupBeans( newNativePerspective.getId() ).iterator().next() );
         }

--- a/uberfire-js/src/main/java/org/uberfire/client/exporter/PluginJSExporter.java
+++ b/uberfire-js/src/main/java/org/uberfire/client/exporter/PluginJSExporter.java
@@ -68,7 +68,8 @@ public class PluginJSExporter implements UberfireJSExporter {
                                                                                                 qualifiers,
                                                                                                 newNativePlugin.getId(),
                                                                                                 true,
-                                                                                                true );
+                                                                                                WorkbenchScreenActivity.class,
+                                                                                                Activity.class );
             beanManager.registerBean( beanDef );
             beanManager.registerBeanTypeAlias( beanDef, WorkbenchScreenActivity.class );
             beanManager.registerBeanTypeAlias( beanDef, Activity.class );

--- a/uberfire-js/src/main/java/org/uberfire/client/exporter/SingletonBeanDef.java
+++ b/uberfire-js/src/main/java/org/uberfire/client/exporter/SingletonBeanDef.java
@@ -17,7 +17,9 @@
 package org.uberfire.client.exporter;
 
 import java.lang.annotation.Annotation;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Set;
 
 import javax.inject.Singleton;
@@ -33,21 +35,22 @@ public class SingletonBeanDef<T, B extends T>
     private final Class<T> type;
     private final Set<Annotation> qualifiers;
     private final String name;
-    private final boolean concrete;
     private final boolean activated;
+    private final Set<Class<?>> assignableTypes = new HashSet<>();
 
     public SingletonBeanDef( final B instance,
                              final Class<T> type,
                              final Set<Annotation> qualifiers,
                              final String name,
-                             final boolean concrete,
-                             final boolean activated ) {
+                             final boolean activated,
+                             final Class<?>... otherAssignableTypes ) {
         this.instance = instance;
         this.type = type;
         this.qualifiers = qualifiers;
         this.name = name;
-        this.concrete = concrete;
         this.activated = activated;
+        assignableTypes.add( type );
+        assignableTypes.addAll( Arrays.asList( otherAssignableTypes ) );
     }
 
     @Override
@@ -95,13 +98,13 @@ public class SingletonBeanDef<T, B extends T>
     }
 
     @Override
-    public boolean isConcrete() {
-        return concrete;
+    public boolean isActivated() {
+        return activated;
     }
 
     @Override
-    public boolean isActivated() {
-        return activated;
+    public boolean isAssignableTo( final Class< ? > type ) {
+        return assignableTypes.contains( type );
     }
 
 }

--- a/uberfire-js/src/main/java/org/uberfire/client/exporter/SplashScreenJSExporter.java
+++ b/uberfire-js/src/main/java/org/uberfire/client/exporter/SplashScreenJSExporter.java
@@ -69,7 +69,8 @@ public class SplashScreenJSExporter implements UberfireJSExporter {
                                                                                           qualifiers,
                                                                                           newNativePlugin.getId(),
                                                                                           true,
-                                                                                          true );
+                                                                                          SplashScreenActivity.class,
+                                                                                          Activity.class );
             beanManager.registerBean( beanDef );
             beanManager.registerBeanTypeAlias( beanDef, SplashScreenActivity.class );
             beanManager.registerBeanTypeAlias( beanDef, Activity.class );

--- a/uberfire-workbench/uberfire-workbench-client/src/test/java/org/uberfire/client/mvp/ActivityBeansInfoTest.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/test/java/org/uberfire/client/mvp/ActivityBeansInfoTest.java
@@ -133,13 +133,13 @@ public class ActivityBeansInfoTest {
             }
 
             @Override
-            public boolean isConcrete() {
+            public boolean isActivated() {
                 return false;
             }
 
             @Override
-            public boolean isActivated() {
-                return false;
+            public boolean isAssignableTo( Class< ? > type ) {
+                return WorkbenchScreenActivity.class.equals( type );
             }
         };
     }

--- a/uberfire-workbench/uberfire-workbench-client/src/test/java/org/uberfire/client/mvp/ActivityManagerLifecycleTest.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/test/java/org/uberfire/client/mvp/ActivityManagerLifecycleTest.java
@@ -385,7 +385,6 @@ public class ActivityManagerLifecycleTest {
                                                                 Dependent.class,
                                                                 null,
                                                                 beanInstance.getClass().getSimpleName(),
-                                                                true,
                                                                 true );
         when( (IOCBeanDef<T>) iocManager.lookupBean( beanInstance.getClass() ) ).thenReturn( beanDef );
         return beanDef;
@@ -411,7 +410,6 @@ public class ActivityManagerLifecycleTest {
                                                           ApplicationScoped.class,
                                                           null,
                                                           name,
-                                                          true,
                                                           true );
 
         when( (IOCBeanDef<T>) iocManager.lookupBean( beanInstance.getClass() ) ).thenReturn( beanDef );

--- a/uberfire-workbench/uberfire-workbench-client/src/test/java/org/uberfire/client/mvp/PlaceRequestHistoryMapperImplTest.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/test/java/org/uberfire/client/mvp/PlaceRequestHistoryMapperImplTest.java
@@ -48,7 +48,7 @@ import com.google.common.collect.ImmutableMap;
 public class PlaceRequestHistoryMapperImplTest {
 
     private PlaceRequestHistoryMapperImpl placeRequestHistoryMapper;
-    
+
     @BeforeClass
     public static void setupBeans() {
         ((SyncBeanManagerImpl) IOC.getBeanManager()).reset();
@@ -58,7 +58,6 @@ public class PlaceRequestHistoryMapperImplTest {
                                                                                                    Dependent.class,
                                                                                                    new HashSet<Annotation>( Arrays.asList( QualifierUtil.DEFAULT_QUALIFIERS ) ),
                                                                                                    null,
-                                                                                                   true,
                                                                                                    true ) );
     }
 

--- a/uberfire-workbench/uberfire-workbench-client/src/test/java/org/uberfire/client/util/MockIOCBeanDef.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/test/java/org/uberfire/client/util/MockIOCBeanDef.java
@@ -17,7 +17,9 @@
 package org.uberfire.client.util;
 
 import java.lang.annotation.Annotation;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Set;
 
 import org.jboss.errai.ioc.client.QualifierUtil;
@@ -32,23 +34,24 @@ public class MockIOCBeanDef<T,B extends T>
     private final Class<? extends Annotation> scope;
     private final Set<Annotation> qualifiers;
     private final String name;
-    private final boolean concrete;
     private final boolean activated;
+    private final Set<Class<?>> assignableTypes = new HashSet<>();
 
     public MockIOCBeanDef( final B beanInstance,
                            final Class<T> type,
                            final Class< ? extends Annotation> scope,
                            final Set<Annotation> qualifiers,
                            final String name,
-                           final boolean concrete,
-                           final boolean activated ) {
+                           final boolean activated,
+                           final Class<?>... otherTypes) {
         this.beanInstance = beanInstance;
         this.type = type;
         this.scope = scope;
         this.qualifiers = qualifiers;
         this.name = name;
-        this.concrete = concrete;
         this.activated = activated;
+        assignableTypes.add( type );
+        assignableTypes.addAll( Arrays.asList( otherTypes ) );
     }
 
     @Override
@@ -96,13 +99,13 @@ public class MockIOCBeanDef<T,B extends T>
     }
 
     @Override
-    public boolean isConcrete() {
-        return concrete;
+    public boolean isActivated() {
+        return activated;
     }
 
     @Override
-    public boolean isActivated() {
-        return activated;
+    public boolean isAssignableTo( final Class< ? > type ) {
+        return assignableTypes.contains( type );
     }
 
 }

--- a/uberfire-workbench/uberfire-workbench-client/src/test/java/org/uberfire/client/workbench/panels/impl/PlaceManagerTest.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/test/java/org/uberfire/client/workbench/panels/impl/PlaceManagerTest.java
@@ -142,7 +142,6 @@ public class PlaceManagerTest {
                                                                                                Dependent.class,
                                                                                                new HashSet<Annotation>( Arrays.asList( QualifierUtil.DEFAULT_QUALIFIERS ) ),
                                                                                                "ObservablePath",
-                                                                                               true,
                                                                                                true ) );
 
         // every test starts in Kansas, with no side effect interactions recorded


### PR DESCRIPTION
This PR should stay open until @psiroky is able to add Errai to the Jenkins job that tests PRs.

This updates usage of the SyncBeanDef interface updated in [this PR](https://github.com/errai/errai/pull/161). At present the Jenkins job that builds this PR will fail because it does not build the changes from the Errai PR.