### PR TITLE
[0.8.x] GUVNOR-2362: Project Explorer freezes after uploading an item with an extension-free name

### DIFF
--- a/uberfire-server/src/main/java/org/uberfire/server/FileUploadServlet.java
+++ b/uberfire-server/src/main/java/org/uberfire/server/FileUploadServlet.java
@@ -58,28 +58,17 @@ public class FileUploadServlet
 
                 final FileItem fileItem = getFileItem( request );
 
-                finalizeResponse(response, fileItem, uri);
+                finalizeResponse( response, fileItem, uri );
 
             } else if ( request.getParameter( PARAM_FOLDER ) != null ) {
 
-                //See https://bugzilla.redhat.com/show_bug.cgi?id=1091204
-                //If the User-provided file name has an extension use that; otherwise use the same extension as the original (OS FileSystem) extension
-                String targetFileName;
-                final FileItem fileItem = getFileItem( request );
-                final String originalFileName = fileItem.getName();
-                final String providedFileName = request.getParameter( PARAM_FILENAME );
-                if ( providedFileName.contains( "." ) ) {
-                    targetFileName = providedFileName;
-                } else {
-                    targetFileName = providedFileName + getExtension( originalFileName );
-                }
-
                 //See https://bugzilla.redhat.com/show_bug.cgi?id=1202926
-                targetFileName = FileServletUtil.encodeFileName( targetFileName );
+                final String encodedFileName = FileServletUtil.encodeFileName( request.getParameter( PARAM_FILENAME ) );
+                final URI uri = new URI( request.getParameter( PARAM_FOLDER ) + "/" + encodedFileName );
 
-                final URI uri = new URI( request.getParameter( PARAM_FOLDER ) + "/" + targetFileName );
+                final FileItem fileItem = getFileItem( request );
 
-                finalizeResponse(response, fileItem, uri);
+                finalizeResponse( response, fileItem, uri );
             }
 
         } catch ( FileUploadException e ) {
@@ -94,7 +83,9 @@ public class FileUploadServlet
         }
     }
 
-    private void finalizeResponse(HttpServletResponse response, FileItem fileItem, URI uri) throws IOException {
+    private void finalizeResponse( HttpServletResponse response,
+                                   FileItem fileItem,
+                                   URI uri ) throws IOException {
         if ( !validateAccess( uri,
                               response ) ) {
             return;


### PR DESCRIPTION
See https://issues.jboss.org/browse/GUVNOR-2362

This is the corollary of https://github.com/uberfire/uberfire/pull/315 for 0.8.x

(cherry picked from commit 61922b92a984e66a8d1f39a49d264cf1dea36d64)

Branch name is consistent across Uberfire and KIE to help Jenkins CI.
