### PR TITLE
Fix tests after latest Errai changes (see below)

### DIFF
--- a/uberfire-api/src/main/java/org/uberfire/mvp/impl/PathPlaceRequest.java
+++ b/uberfire-api/src/main/java/org/uberfire/mvp/impl/PathPlaceRequest.java
@@ -27,9 +27,6 @@ import org.uberfire.mvp.PlaceRequest;
 
 import static org.uberfire.util.URIUtil.*;
 
-/**
- *
- */
 @Portable
 public class PathPlaceRequest extends DefaultPlaceRequest {
 

--- a/uberfire-workbench/uberfire-workbench-client/src/test/java/org/uberfire/client/mvp/PlaceRequestHistoryMapperImplTest.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/test/java/org/uberfire/client/mvp/PlaceRequestHistoryMapperImplTest.java
@@ -35,6 +35,7 @@ import org.jboss.errai.ioc.client.container.SyncBeanManagerImpl;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.uberfire.backend.vfs.ObservablePath;
 import org.uberfire.backend.vfs.Path;
 import org.uberfire.backend.vfs.PathFactory;
@@ -44,7 +45,9 @@ import org.uberfire.mvp.PlaceRequest;
 import org.uberfire.mvp.impl.PathPlaceRequest;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.gwtmockito.GwtMockitoTestRunner;
 
+@RunWith(GwtMockitoTestRunner.class)
 public class PlaceRequestHistoryMapperImplTest {
 
     private PlaceRequestHistoryMapperImpl placeRequestHistoryMapper;

--- a/uberfire-workbench/uberfire-workbench-client/src/test/java/org/uberfire/client/workbench/panels/impl/PlaceManagerTest.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/test/java/org/uberfire/client/workbench/panels/impl/PlaceManagerTest.java
@@ -262,8 +262,24 @@ public class PlaceManagerTest {
 
     @Test
     public void testGoToPlaceByPath() throws Exception {
-        Path yellowBrickRoadPath = mock( Path.class );
-        PathPlaceRequest yellowBrickRoad = new PathPlaceRequest( yellowBrickRoadPath, "YellowBrickRoadID" );
+        class FakePathPlaceRequest extends PathPlaceRequest {
+            final ObservablePath path;
+            FakePathPlaceRequest(ObservablePath path) {
+                this.path = path;
+            }
+
+            @Override
+            public ObservablePath getPath() {
+                return path;
+            }
+
+            @Override
+            public int hashCode() {
+                return 42;
+            }
+        }
+        
+        PathPlaceRequest yellowBrickRoad = new FakePathPlaceRequest( mock( ObservablePath.class ) );
         WorkbenchScreenActivity ozActivity = mock( WorkbenchScreenActivity.class );
 
         when( activityManager.getActivities( yellowBrickRoad ) ).thenReturn( singleton( (Activity) ozActivity ) );


### PR DESCRIPTION
- Errai's IOC beanmanager is no longer unit testable as it
now references WindowInjectionContext which has JSNI methods. This
is a necessary change to support looking up beans that have been
registered at runtime by external scripts (dynamic plugins).