### PR TITLE
[UF-299] disable git/ssh daemons by default when running tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -259,6 +259,11 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
           <configuration>
+            <systemPropertyVariables>
+              <org.uberfire.nio.git.daemon.enabled>false</org.uberfire.nio.git.daemon.enabled>
+              <org.uberfire.nio.git.ssh.enabled>false</org.uberfire.nio.git.ssh.enabled>
+              <org.uberfire.sys.repo.monitor.disabled>true</org.uberfire.sys.repo.monitor.disabled>
+            </systemPropertyVariables>
             <includes>
               <include>**/*Test.java</include>
             </includes>


### PR DESCRIPTION
 * disabling the git/ssh daemons by default makes the tests more stable.
   Maven build is usually executed in parallel (e.g. -TC), which means
   tests in multiple modules are executed in parallel (in different JVM of course).
   That sometimes leads into random test failures caused by failure
   to bind to the default git/ssh ports.

Tested with both uberfire and uberfire-extensions repos (and with kie-wb running to make sure the ports are already bound).