### PR TITLE
UF-300: bug goTo(screen) doesn't work properly on JS Perspectives

### DIFF
--- a/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/main/java/org/uberfire/client/views/pfly/tab/MultiTabWorkbenchPanelView.java
+++ b/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/main/java/org/uberfire/client/views/pfly/tab/MultiTabWorkbenchPanelView.java
@@ -23,6 +23,9 @@ import org.uberfire.client.util.Layouts;
 import org.uberfire.client.workbench.panels.MultiPartWidget;
 import org.uberfire.client.workbench.panels.impl.AbstractMultiPartWorkbenchPanelView;
 import org.uberfire.client.workbench.panels.impl.MultiTabWorkbenchPanelPresenter;
+import org.uberfire.workbench.model.PartDefinition;
+
+import java.util.Collection;
 
 @Dependent
 @Named( "MultiTabWorkbenchPanelView" )
@@ -46,4 +49,8 @@ public class MultiTabWorkbenchPanelView
         return uberTabPanel;
     }
 
+    @Override
+    public Collection<PartDefinition> getParts() {
+        return uberTabPanel.getParts();
+    }
 }

--- a/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/main/java/org/uberfire/client/views/pfly/tab/UberTabPanel.java
+++ b/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/main/java/org/uberfire/client/views/pfly/tab/UberTabPanel.java
@@ -16,18 +16,14 @@
 
 package org.uberfire.client.views.pfly.tab;
 
-import static org.uberfire.commons.validation.PortablePreconditions.checkNotNull;
-
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-
-import javax.annotation.PostConstruct;
-import javax.enterprise.context.Dependent;
-import javax.inject.Inject;
-
+import com.google.gwt.event.dom.client.ClickEvent;
+import com.google.gwt.event.dom.client.ClickHandler;
+import com.google.gwt.event.logical.shared.BeforeSelectionEvent;
+import com.google.gwt.event.logical.shared.BeforeSelectionHandler;
+import com.google.gwt.event.logical.shared.SelectionEvent;
+import com.google.gwt.event.logical.shared.SelectionHandler;
+import com.google.gwt.event.shared.HandlerRegistration;
+import com.google.gwt.user.client.ui.*;
 import org.gwtbootstrap3.client.shared.event.TabShowEvent;
 import org.gwtbootstrap3.client.shared.event.TabShowHandler;
 import org.gwtbootstrap3.client.shared.event.TabShownEvent;
@@ -43,18 +39,12 @@ import org.uberfire.client.workbench.widgets.dnd.WorkbenchDragAndDropManager;
 import org.uberfire.mvp.Command;
 import org.uberfire.workbench.model.PartDefinition;
 
-import com.google.gwt.event.dom.client.ClickEvent;
-import com.google.gwt.event.dom.client.ClickHandler;
-import com.google.gwt.event.logical.shared.BeforeSelectionEvent;
-import com.google.gwt.event.logical.shared.BeforeSelectionHandler;
-import com.google.gwt.event.logical.shared.SelectionEvent;
-import com.google.gwt.event.logical.shared.SelectionHandler;
-import com.google.gwt.event.shared.HandlerRegistration;
-import com.google.gwt.user.client.ui.Button;
-import com.google.gwt.user.client.ui.IsWidget;
-import com.google.gwt.user.client.ui.RequiresResize;
-import com.google.gwt.user.client.ui.ResizeComposite;
-import com.google.gwt.user.client.ui.Widget;
+import javax.annotation.PostConstruct;
+import javax.enterprise.context.Dependent;
+import javax.inject.Inject;
+import java.util.*;
+
+import static org.uberfire.commons.validation.PortablePreconditions.checkNotNull;
 
 /**
  * A wrapper around {@link TabPanelWithDropdowns} that adds the following capabilities:
@@ -106,18 +96,22 @@ public class UberTabPanel extends ResizeComposite implements MultiPartWidget, Cl
             public void onShow( TabShowEvent e ) {
                 if ( e.getTab() != null ) {
                     final TabPanelEntry selected = tabPanel.findEntryForTabWidget( e.getTab() );
-                    BeforeSelectionEvent.fire( UberTabPanel.this, tabInvertedIndex.get( selected ).getPresenter().getDefinition() );
+                    BeforeSelectionEvent
+                            .fire( UberTabPanel.this, tabInvertedIndex.get( selected ).getPresenter().getDefinition() );
                 }
             }
         } );
         tabPanel.addShownHandler( new TabShownHandler() {
 
             @Override
+
+
             public void onShown( TabShownEvent e ) {
                 onResize();
                 if ( e.getTab() != null ) {
                     final TabPanelEntry selected = tabPanel.findEntryForTabWidget( e.getTab() );
-                    SelectionEvent.fire( UberTabPanel.this, tabInvertedIndex.get( selected ).getPresenter().getDefinition() );
+                    SelectionEvent
+                            .fire( UberTabPanel.this, tabInvertedIndex.get( selected ).getPresenter().getDefinition() );
                 }
             }
         } );
@@ -290,11 +284,12 @@ public class UberTabPanel extends ResizeComposite implements MultiPartWidget, Cl
     /**
      * The GwtBootstrap3 TabPanel doesn't support the RequiresResize/ProvidesResize contract, and UberTabPanel fills in
      * the gap. This helper method allows us to call onResize() on the widgets that need it.
+     *
      * @param widget the widget that has just been resized
      */
     private void resizeIfNeeded( final Widget widget ) {
         if ( isAttached() && widget instanceof RequiresResize ) {
-            ( (RequiresResize) widget ).onResize();
+            ( ( RequiresResize ) widget ).onResize();
         }
     }
 
@@ -360,4 +355,11 @@ public class UberTabPanel extends ResizeComposite implements MultiPartWidget, Cl
     public int getPartsSize() {
         return partTabIndex.size();
     }
+
+    @Override
+    public Collection<PartDefinition> getParts() {
+        return Collections.unmodifiableSet( partTabIndex.keySet() );
+    }
+
+
 }

--- a/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/test/java/org/uberfire/client/views/pfly/listbar/ListBarWidgetImplTest.java
+++ b/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/test/java/org/uberfire/client/views/pfly/listbar/ListBarWidgetImplTest.java
@@ -25,6 +25,8 @@ import org.uberfire.client.workbench.PanelManager;
 import org.uberfire.commons.data.Pair;
 import org.uberfire.workbench.model.PartDefinition;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
@@ -61,5 +63,16 @@ public class ListBarWidgetImplTest {
 
     }
 
+    @Test
+    public void partsIsAddedToListBar() {
+        final PartDefinition firstPart = mock( PartDefinition.class );
+        final PartDefinition secondPart = mock( PartDefinition.class );
+
+        listBar.parts.add( firstPart );
+        listBar.parts.add( secondPart );
+
+        assertEquals(2, listBar.getParts().size());
+
+    }
 
 }

--- a/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/panels/MultiPartWidget.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/panels/MultiPartWidget.java
@@ -16,15 +16,17 @@
 
 package org.uberfire.client.workbench.panels;
 
+import com.google.gwt.event.logical.shared.HasBeforeSelectionHandlers;
+import com.google.gwt.event.logical.shared.HasSelectionHandlers;
+import com.google.gwt.user.client.ui.IsWidget;
+import com.google.gwt.user.client.ui.RequiresResize;
 import org.uberfire.client.workbench.part.WorkbenchPartPresenter;
 import org.uberfire.client.workbench.widgets.dnd.WorkbenchDragAndDropManager;
 import org.uberfire.mvp.Command;
 import org.uberfire.workbench.model.PartDefinition;
 
-import com.google.gwt.event.logical.shared.HasBeforeSelectionHandlers;
-import com.google.gwt.event.logical.shared.HasSelectionHandlers;
-import com.google.gwt.user.client.ui.IsWidget;
-import com.google.gwt.user.client.ui.RequiresResize;
+import java.util.Collection;
+import java.util.List;
 
 public interface MultiPartWidget extends IsWidget,
 RequiresResize,
@@ -94,4 +96,9 @@ HasSelectionHandlers<PartDefinition> {
      * Returns the number of parts currently held by this widget.
      */
     int getPartsSize();
+
+    /**
+     * Returns the parts currently held by this widget.
+     */
+    Collection<PartDefinition> getParts();
 }

--- a/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/panels/WorkbenchPanelView.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/panels/WorkbenchPanelView.java
@@ -28,6 +28,8 @@ import com.google.gwt.user.client.ui.IsWidget;
 import com.google.gwt.user.client.ui.RequiresResize;
 import com.google.gwt.user.client.ui.Widget;
 
+import java.util.Collection;
+
 /**
  * Manages the Widget and DOM interaction of a panel. Part of the UberFire MVC system for panels. For a full explanation
  * of what a panel is in UberFire, see the class-level documentation for {@link WorkbenchPanelPresenter}.
@@ -172,4 +174,10 @@ public interface WorkbenchPanelView<P extends WorkbenchPanelPresenter> extends U
      * Restores this view to its original unmaximized size and position using {@link WorkbenchLayout#unmaximize(Widget)}.
      */
     void unmaximize();
+
+    /**
+     * Returns the parts currently held by the view.
+     */
+    Collection<PartDefinition> getParts();
+
 }

--- a/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/panels/impl/AbstractSimpleWorkbenchPanelView.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/panels/impl/AbstractSimpleWorkbenchPanelView.java
@@ -18,7 +18,9 @@ package org.uberfire.client.workbench.panels.impl;
 import javax.annotation.PostConstruct;
 import javax.inject.Inject;
 
+import com.google.gwt.core.client.GWT;
 import com.google.gwt.dom.client.Style;
+import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.ui.IsWidget;
 import com.google.gwt.user.client.ui.RequiresResize;
 import org.uberfire.client.util.Layouts;
@@ -28,6 +30,8 @@ import org.uberfire.client.workbench.part.WorkbenchPartPresenter;
 import org.uberfire.client.workbench.widgets.listbar.ListBarWidget;
 import org.uberfire.mvp.Command;
 import org.uberfire.workbench.model.PartDefinition;
+
+import java.util.Collection;
 
 /**
  * Supertype for both the DnD and non-DnD simple workbench panel views.
@@ -90,6 +94,9 @@ public abstract class AbstractSimpleWorkbenchPanelView<P extends WorkbenchPanelP
         if( listBar.getPartsSize() == 0 ){
             listBar.addPart( view );
         }
+        else{
+           throw new RuntimeException( "Uberfire Panel Invalid State: This panel support only one part." );
+        }
     }
 
     @Override
@@ -142,5 +149,10 @@ public abstract class AbstractSimpleWorkbenchPanelView<P extends WorkbenchPanelP
     public void setElementId( String elementId ) {
         super.setElementId( elementId );
         listBar.getMaximizeButton().getView().asWidget().ensureDebugId( elementId + "-maximizeButton" );
+    }
+
+    @Override
+    public Collection<PartDefinition> getParts() {
+        return listBar.getParts();
     }
 }

--- a/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/panels/impl/AdaptiveWorkbenchPanelView.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/panels/impl/AdaptiveWorkbenchPanelView.java
@@ -15,12 +15,19 @@
  */
 package org.uberfire.client.workbench.panels.impl;
 
+import org.uberfire.client.workbench.part.WorkbenchPartPresenter;
+
 import javax.enterprise.context.Dependent;
 import javax.inject.Named;
 
 @Dependent
-@Named("AdaptiveWorkbenchPanelView")
+@Named( "AdaptiveWorkbenchPanelView" )
 public class AdaptiveWorkbenchPanelView
         extends AbstractSimpleWorkbenchPanelView<AdaptiveWorkbenchPanelPresenter> {
+
+    @Override
+    public void addPart( final WorkbenchPartPresenter.View view ) {
+        listBar.addPart( view );
+    }
 
 }

--- a/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/panels/impl/ClosableSimpleWorkbenchPanelPresenter.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/panels/impl/ClosableSimpleWorkbenchPanelPresenter.java
@@ -15,13 +15,15 @@
  */
 package org.uberfire.client.workbench.panels.impl;
 
+import org.uberfire.client.mvp.PerspectiveManager;
+import org.uberfire.client.mvp.PlaceManager;
+import org.uberfire.client.workbench.panels.DockingWorkbenchPanelView;
+import org.uberfire.client.workbench.panels.WorkbenchPanelView;
+import org.uberfire.client.workbench.part.WorkbenchPartPresenter;
+
 import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
 import javax.inject.Named;
-
-import org.uberfire.client.mvp.PerspectiveManager;
-import org.uberfire.client.workbench.panels.DockingWorkbenchPanelView;
-import org.uberfire.client.workbench.panels.WorkbenchPanelView;
 
 /**
  * A panel with a title bar. Can contain one part at a time. The part's view fills the entire space not used up by
@@ -33,10 +35,15 @@ import org.uberfire.client.workbench.panels.WorkbenchPanelView;
 @Dependent
 public class ClosableSimpleWorkbenchPanelPresenter extends AbstractDockingWorkbenchPanelPresenter<ClosableSimpleWorkbenchPanelPresenter> {
 
+    private final PlaceManager placeManager;
+
     @Inject
-    public ClosableSimpleWorkbenchPanelPresenter( @Named( "ClosableSimpleWorkbenchPanelView" ) final WorkbenchPanelView<ClosableSimpleWorkbenchPanelPresenter> view,
-                                                  final PerspectiveManager perspectiveManager ) {
+    public ClosableSimpleWorkbenchPanelPresenter(
+            @Named( "ClosableSimpleWorkbenchPanelView" ) final WorkbenchPanelView<ClosableSimpleWorkbenchPanelPresenter> view,
+            final PerspectiveManager perspectiveManager,
+            PlaceManager placeManager ) {
         super( view, perspectiveManager );
+        this.placeManager = placeManager;
     }
 
     @Override
@@ -48,4 +55,30 @@ public class ClosableSimpleWorkbenchPanelPresenter extends AbstractDockingWorkbe
     public DockingWorkbenchPanelView<ClosableSimpleWorkbenchPanelPresenter> getPanelView() {
         return super.getPanelView();
     }
+
+    @Override
+    public void addPart( WorkbenchPartPresenter part ) {
+        SinglePartPanelHelper h = createSinglePartPanelHelper();
+        if ( h.hasNoParts() ) {
+            super.addPart( part );
+        } else {
+            h.closeFirstPartAndAddNewOne( () -> super.addPart( part ) );
+        }
+    }
+
+    @Override
+    public void addPart( WorkbenchPartPresenter part, String contextId ) {
+        SinglePartPanelHelper h = createSinglePartPanelHelper();
+        if ( h.hasNoParts() ) {
+            super.addPart( part, contextId );
+        } else {
+            h.closeFirstPartAndAddNewOne( () -> super.addPart( part, contextId ) );
+        }
+    }
+
+    SinglePartPanelHelper createSinglePartPanelHelper() {
+        return new SinglePartPanelHelper( getPanelView().getParts(), placeManager);
+    }
+
+
 }

--- a/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/panels/impl/LayoutPanelView.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/panels/impl/LayoutPanelView.java
@@ -32,6 +32,8 @@ import com.google.gwt.user.client.ui.IsWidget;
 import com.google.gwt.user.client.ui.LayoutPanel;
 import com.google.gwt.user.client.ui.Widget;
 
+import java.util.Collection;
+
 /**
  * A simple {@link LayoutPanel} presenter. Can be used for both perspectives and panels. Does not support drag-and-drop.
  */
@@ -103,6 +105,10 @@ public class LayoutPanelView implements WorkbenchPanelView<LayoutPanelPresenter>
         return true;
     }
 
+    @Override
+    public Collection<PartDefinition> getParts() {
+        return partManager.getParts();
+    }
     @Override
     public Widget getPartDropRegion() {
         return null;

--- a/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/panels/impl/MultiListWorkbenchPanelView.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/panels/impl/MultiListWorkbenchPanelView.java
@@ -23,6 +23,9 @@ import org.uberfire.client.workbench.panels.MaximizeToggleButtonPresenter;
 import org.uberfire.client.workbench.panels.MultiPartWidget;
 import org.uberfire.client.workbench.widgets.listbar.ListBarWidget;
 import org.uberfire.mvp.Command;
+import org.uberfire.workbench.model.PartDefinition;
+
+import java.util.Collection;
 
 /**
  * A Workbench panel that can contain WorkbenchParts.
@@ -74,5 +77,10 @@ extends AbstractMultiPartWorkbenchPanelView<MultiListWorkbenchPanelPresenter> {
     public void setElementId( String elementId ) {
         super.setElementId( elementId );
         listBar.getMaximizeButton().getView().asWidget().ensureDebugId( elementId + "-maximizeButton" );
+    }
+
+    @Override
+    public Collection<PartDefinition> getParts() {
+        return listBar.getParts();
     }
 }

--- a/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/panels/impl/SimpleDnDWorkbenchPanelPresenter.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/panels/impl/SimpleDnDWorkbenchPanelPresenter.java
@@ -15,10 +15,12 @@
  */
 package org.uberfire.client.workbench.panels.impl;
 
+import org.uberfire.client.mvp.PerspectiveManager;
+import org.uberfire.client.mvp.PlaceManager;
+import org.uberfire.client.workbench.part.WorkbenchPartPresenter;
+
 import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
-
-import org.uberfire.client.mvp.PerspectiveManager;
 
 /**
  * Exactly like {@link SimpleWorkbenchPanelPresenter} but has drag and drop enabled by default.
@@ -26,16 +28,44 @@ import org.uberfire.client.mvp.PerspectiveManager;
 @Dependent
 public class SimpleDnDWorkbenchPanelPresenter extends AbstractDockingWorkbenchPanelPresenter<SimpleDnDWorkbenchPanelPresenter> {
 
+    private PlaceManager placeManager;
+
     @Inject
     public SimpleDnDWorkbenchPanelPresenter( final SimpleDnDWorkbenchPanelView view,
-                                             final PerspectiveManager perspectiveManager ) {
+                                             final PerspectiveManager perspectiveManager,
+                                             final PlaceManager placeManager ) {
         super( view, perspectiveManager );
+        this.placeManager = placeManager;
         view.enableDnd();
     }
 
     @Override
     protected SimpleDnDWorkbenchPanelPresenter asPresenterType() {
         return this;
+    }
+
+    @Override
+    public void addPart( WorkbenchPartPresenter part ) {
+        SinglePartPanelHelper h = createSinglePartPanelHelper();
+        if ( h.hasNoParts() ) {
+            super.addPart( part );
+        } else {
+            h.closeFirstPartAndAddNewOne( () -> super.addPart( part ) );
+        }
+    }
+
+    @Override
+    public void addPart( WorkbenchPartPresenter part, String contextId ) {
+        SinglePartPanelHelper h = createSinglePartPanelHelper();
+        if ( h.hasNoParts() ) {
+            super.addPart( part, contextId );
+        } else {
+            h.closeFirstPartAndAddNewOne( () -> super.addPart( part, contextId ) );
+        }
+    }
+
+    SinglePartPanelHelper createSinglePartPanelHelper() {
+        return new SinglePartPanelHelper( getPanelView().getParts(), placeManager );
     }
 
 }

--- a/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/panels/impl/SimpleWorkbenchPanelPresenter.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/panels/impl/SimpleWorkbenchPanelPresenter.java
@@ -20,8 +20,10 @@ import javax.inject.Inject;
 import javax.inject.Named;
 
 import org.uberfire.client.mvp.PerspectiveManager;
+import org.uberfire.client.mvp.PlaceManager;
 import org.uberfire.client.workbench.panels.DockingWorkbenchPanelView;
 import org.uberfire.client.workbench.panels.WorkbenchPanelView;
+import org.uberfire.client.workbench.part.WorkbenchPartPresenter;
 
 /**
  * A panel with a title bar. Can contain one part at a time. The part's view fills the entire space not used up by
@@ -33,10 +35,38 @@ import org.uberfire.client.workbench.panels.WorkbenchPanelView;
 @Dependent
 public class SimpleWorkbenchPanelPresenter extends AbstractDockingWorkbenchPanelPresenter<SimpleWorkbenchPanelPresenter> {
 
+    private final PlaceManager placeManager;
+
     @Inject
     public SimpleWorkbenchPanelPresenter( @Named("SimpleWorkbenchPanelView") final WorkbenchPanelView<SimpleWorkbenchPanelPresenter> view,
-                                          final PerspectiveManager perspectiveManager ) {
+                                          final PerspectiveManager perspectiveManager,
+                                          final PlaceManager placeManager) {
         super( view, perspectiveManager );
+        this.placeManager = placeManager;
+    }
+
+    @Override
+    public void addPart( WorkbenchPartPresenter part ) {
+        SinglePartPanelHelper h = createSinglePartPanelHelper();
+        if ( h.hasNoParts() ) {
+            super.addPart( part );
+        } else {
+            h.closeFirstPartAndAddNewOne( () -> super.addPart( part ) );
+        }
+    }
+
+    @Override
+    public void addPart( WorkbenchPartPresenter part, String contextId ) {
+        SinglePartPanelHelper h = createSinglePartPanelHelper();
+        if ( h.hasNoParts() ) {
+            super.addPart( part, contextId );
+        } else {
+            h.closeFirstPartAndAddNewOne( () -> super.addPart( part, contextId ) );
+        }
+    }
+
+    SinglePartPanelHelper createSinglePartPanelHelper() {
+        return new SinglePartPanelHelper( getPanelView().getParts(), placeManager);
     }
 
     @Override

--- a/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/panels/impl/SinglePartPanelHelper.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/panels/impl/SinglePartPanelHelper.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.uberfire.client.workbench.panels.impl;
+
+import org.uberfire.client.mvp.PlaceManager;
+import org.uberfire.mvp.Command;
+import org.uberfire.mvp.PlaceRequest;
+import org.uberfire.workbench.model.PartDefinition;
+
+import java.util.Collection;
+
+public class SinglePartPanelHelper {
+
+    private Collection<PartDefinition> parts;
+    private PlaceManager placeManager;
+
+    public SinglePartPanelHelper( Collection<PartDefinition> parts, PlaceManager placeManager ) {
+        this.parts = parts;
+        this.placeManager = placeManager;
+    }
+
+    public boolean hasNoParts() {
+        return parts.isEmpty();
+    }
+
+    public void closeFirstPartAndAddNewOne( Command command ) {
+        placeManager.tryClosePlace( getPlaceFromFirstPart(),
+                                    command );
+    }
+
+    PlaceRequest getPlaceFromFirstPart() {
+        if(parts.iterator().hasNext()){
+            PartDefinition part = this.parts.iterator().next();
+            if ( part != null ){
+                return part.getPlace();
+            }
+        }
+        return null;
+    }
+
+}

--- a/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/panels/impl/SplitLayoutPanelView.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/panels/impl/SplitLayoutPanelView.java
@@ -35,6 +35,8 @@ import com.google.gwt.user.client.ui.LayoutPanel;
 import com.google.gwt.user.client.ui.SplitLayoutPanel;
 import com.google.gwt.user.client.ui.Widget;
 
+import java.util.Collection;
+
 /**
  * Corresponding view to {@link SplitLayoutPanelPresenter}. Only supports panels, not parts.
  * Enforces lifecycle callbacks on center parts.
@@ -130,6 +132,11 @@ public class SplitLayoutPanelView implements WorkbenchPanelView<SplitLayoutPanel
     }
 
     @Override
+    public Collection<PartDefinition> getParts() {
+        throw new IllegalArgumentException("Presenter doesn't manage parts!");
+    }
+
+    @Override
     public Widget getPartDropRegion() {
         return null;
     }
@@ -169,4 +176,5 @@ public class SplitLayoutPanelView implements WorkbenchPanelView<SplitLayoutPanel
     public void unmaximize() {
         layoutSelection.get().unmaximize( asWidget() );
     }
+
 }

--- a/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/panels/impl/StaticWorkbenchPanelPresenter.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/panels/impl/StaticWorkbenchPanelPresenter.java
@@ -20,6 +20,8 @@ import javax.inject.Inject;
 import javax.inject.Named;
 
 import org.uberfire.client.mvp.PerspectiveManager;
+import org.uberfire.client.mvp.PlaceManager;
+import org.uberfire.client.workbench.part.WorkbenchPartPresenter;
 
 /**
  * An undecorated panel that can contain one part at a time and does not support child panels. The part's view fills
@@ -29,10 +31,14 @@ import org.uberfire.client.mvp.PerspectiveManager;
 @Dependent
 public class StaticWorkbenchPanelPresenter extends AbstractWorkbenchPanelPresenter<StaticWorkbenchPanelPresenter> {
 
+    private PlaceManager placeManager;
+
     @Inject
     public StaticWorkbenchPanelPresenter( @Named("StaticWorkbenchPanelView") final StaticWorkbenchPanelView view,
-                                          final PerspectiveManager perspectiveManager ) {
+                                          final PerspectiveManager perspectiveManager,
+                                          final PlaceManager placeManager) {
         super( view, perspectiveManager );
+        this.placeManager = placeManager;
     }
 
     @Override
@@ -46,5 +52,29 @@ public class StaticWorkbenchPanelPresenter extends AbstractWorkbenchPanelPresent
     @Override
     public String getDefaultChildType() {
         return null;
+    }
+
+    @Override
+    public void addPart( WorkbenchPartPresenter part ) {
+        SinglePartPanelHelper h = createSinglePartPanelHelper();
+        if ( h.hasNoParts() ) {
+            super.addPart( part );
+        } else {
+            h.closeFirstPartAndAddNewOne( () -> super.addPart( part ) );
+        }
+    }
+
+    @Override
+    public void addPart( WorkbenchPartPresenter part, String contextId ) {
+        SinglePartPanelHelper h = createSinglePartPanelHelper();
+        if ( h.hasNoParts() ) {
+            super.addPart( part, contextId );
+        } else {
+            h.closeFirstPartAndAddNewOne( () -> super.addPart( part, contextId ) );
+        }
+    }
+
+    SinglePartPanelHelper createSinglePartPanelHelper() {
+        return new SinglePartPanelHelper( getPanelView().getParts(), placeManager);
     }
 }

--- a/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/panels/impl/StaticWorkbenchPanelView.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/panels/impl/StaticWorkbenchPanelView.java
@@ -15,11 +15,12 @@
  */
 package org.uberfire.client.workbench.panels.impl;
 
-import javax.annotation.PostConstruct;
-import javax.enterprise.context.Dependent;
-import javax.inject.Inject;
-import javax.inject.Named;
-
+import com.google.gwt.event.dom.client.FocusEvent;
+import com.google.gwt.event.dom.client.FocusHandler;
+import com.google.gwt.event.logical.shared.SelectionEvent;
+import com.google.gwt.event.logical.shared.SelectionHandler;
+import com.google.gwt.user.client.ui.IsWidget;
+import com.google.gwt.user.client.ui.Widget;
 import org.uberfire.client.mvp.PlaceManager;
 import org.uberfire.client.util.Layouts;
 import org.uberfire.client.workbench.part.WorkbenchPartPresenter;
@@ -28,20 +29,21 @@ import org.uberfire.client.workbench.widgets.panel.StaticFocusedResizePanel;
 import org.uberfire.mvp.Command;
 import org.uberfire.workbench.model.PartDefinition;
 
-import com.google.gwt.event.dom.client.FocusEvent;
-import com.google.gwt.event.dom.client.FocusHandler;
-import com.google.gwt.event.logical.shared.SelectionEvent;
-import com.google.gwt.event.logical.shared.SelectionHandler;
-import com.google.gwt.user.client.ui.IsWidget;
-import com.google.gwt.user.client.ui.Widget;
+import javax.annotation.PostConstruct;
+import javax.enterprise.context.Dependent;
+import javax.inject.Inject;
+import javax.inject.Named;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
 
 /**
  * The view component of {@link StaticWorkbenchPanelPresenter}.
  */
 @Dependent
-@Named("StaticWorkbenchPanelView")
+@Named( "StaticWorkbenchPanelView" )
 public class StaticWorkbenchPanelView
-extends AbstractWorkbenchPanelView<StaticWorkbenchPanelPresenter> {
+        extends AbstractWorkbenchPanelView<StaticWorkbenchPanelPresenter> {
 
     @Inject
     PlaceManager placeManager;
@@ -95,17 +97,11 @@ extends AbstractWorkbenchPanelView<StaticWorkbenchPanelPresenter> {
 
     @Override
     public void addPart( final WorkbenchPartPresenter.View view ) {
-        if ( panel.getPartView() != null ) {
-            placeManager.tryClosePlace( getCurrentPartDefinition().getPlace(), new Command() {
-                @Override
-                public void execute() {
-                    panel.setPart( view );
-                    onResize();
-                }
-            } );
-        } else {
+        if ( panel.getPartView() == null ) {
             panel.setPart( view );
             onResize();
+        } else {
+            throw new RuntimeException( "Uberfire Panel Invalid State: This panel support only one part." );
         }
     }
 
@@ -145,7 +141,7 @@ extends AbstractWorkbenchPanelView<StaticWorkbenchPanelPresenter> {
         super.onResize();
     }
 
-    private PartDefinition getCurrentPartDefinition() {
+    PartDefinition getCurrentPartDefinition() {
         View partView = panel.getPartView();
         if ( partView == null ) {
             return null;
@@ -157,5 +153,14 @@ extends AbstractWorkbenchPanelView<StaticWorkbenchPanelPresenter> {
         }
 
         return presenter.getDefinition();
+    }
+
+    @Override
+    public Collection<PartDefinition> getParts() {
+        PartDefinition currentPartDefinition = getCurrentPartDefinition();
+        if ( currentPartDefinition == null ) {
+            return new ArrayList<>();
+        }
+        return Arrays.asList( currentPartDefinition );
     }
 }

--- a/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/panels/impl/TemplatedWorkbenchPanelView.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/panels/impl/TemplatedWorkbenchPanelView.java
@@ -16,6 +16,8 @@
 
 package org.uberfire.client.workbench.panels.impl;
 
+import java.util.Collection;
+import java.util.Collections;
 import java.util.IdentityHashMap;
 
 import javax.enterprise.context.Dependent;
@@ -129,6 +131,11 @@ public class TemplatedWorkbenchPanelView implements WorkbenchPanelView<Templated
 
     @Override
     public void addPart( View view ) {
+        throw new UnsupportedOperationException("This view doesn't support parts");
+    }
+
+    @Override
+    public Collection<PartDefinition> getParts() {
         throw new UnsupportedOperationException("This view doesn't support parts");
     }
 

--- a/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/panels/impl/UnanchoredStaticWorkbenchPanelPresenter.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/panels/impl/UnanchoredStaticWorkbenchPanelPresenter.java
@@ -20,6 +20,7 @@ import javax.inject.Inject;
 import javax.inject.Named;
 
 import org.uberfire.client.mvp.PerspectiveManager;
+import org.uberfire.client.mvp.PlaceManager;
 import org.uberfire.client.workbench.part.WorkbenchPartPresenter;
 import org.uberfire.client.workbench.pmgr.unanchored.part.UnanchoredWorkbenchPartPresenter;
 
@@ -31,10 +32,14 @@ import org.uberfire.client.workbench.pmgr.unanchored.part.UnanchoredWorkbenchPar
 @Dependent
 public class UnanchoredStaticWorkbenchPanelPresenter extends AbstractWorkbenchPanelPresenter<UnanchoredStaticWorkbenchPanelPresenter> {
 
+    private PlaceManager placeManager;
+
     @Inject
     public UnanchoredStaticWorkbenchPanelPresenter( @Named("UnanchoredStaticWorkbenchPanelView") final UnanchoredStaticWorkbenchPanelView view,
-                                                    final PerspectiveManager perspectiveManager ) {
+                                                    final PerspectiveManager perspectiveManager,
+                                                    final PlaceManager placeManager) {
         super( view, perspectiveManager );
+        this.placeManager = placeManager;
     }
 
     @Override
@@ -52,5 +57,29 @@ public class UnanchoredStaticWorkbenchPanelPresenter extends AbstractWorkbenchPa
 
     public Class<? extends WorkbenchPartPresenter> getPartType() {
         return UnanchoredWorkbenchPartPresenter.class;
+    }
+
+    @Override
+    public void addPart( WorkbenchPartPresenter part ) {
+        SinglePartPanelHelper h = createSinglePartPanelHelper();
+        if ( h.hasNoParts() ) {
+            super.addPart( part );
+        } else {
+            h.closeFirstPartAndAddNewOne( () -> super.addPart( part ) );
+        }
+    }
+
+    @Override
+    public void addPart( WorkbenchPartPresenter part, String contextId ) {
+        SinglePartPanelHelper h = createSinglePartPanelHelper();
+        if ( h.hasNoParts() ) {
+            super.addPart( part, contextId );
+        } else {
+            h.closeFirstPartAndAddNewOne( () -> super.addPart( part, contextId ) );
+        }
+    }
+
+    SinglePartPanelHelper createSinglePartPanelHelper() {
+        return new SinglePartPanelHelper( getPanelView().getParts(), placeManager);
     }
 }

--- a/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/panels/impl/UnanchoredStaticWorkbenchPanelView.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/panels/impl/UnanchoredStaticWorkbenchPanelView.java
@@ -15,11 +15,6 @@
  */
 package org.uberfire.client.workbench.panels.impl;
 
-import javax.annotation.PostConstruct;
-import javax.enterprise.context.Dependent;
-import javax.inject.Inject;
-import javax.inject.Named;
-
 import com.google.gwt.event.dom.client.FocusEvent;
 import com.google.gwt.event.dom.client.FocusHandler;
 import com.google.gwt.event.logical.shared.SelectionEvent;
@@ -31,14 +26,21 @@ import org.uberfire.client.util.Layouts;
 import org.uberfire.client.workbench.part.WorkbenchPartPresenter;
 import org.uberfire.client.workbench.part.WorkbenchPartPresenter.View;
 import org.uberfire.client.workbench.widgets.panel.StaticFocusedResizePanel;
-import org.uberfire.mvp.Command;
 import org.uberfire.workbench.model.PartDefinition;
+
+import javax.annotation.PostConstruct;
+import javax.enterprise.context.Dependent;
+import javax.inject.Inject;
+import javax.inject.Named;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
 
 /**
  * The view component of {@link UnanchoredStaticWorkbenchPanelPresenter}.
  */
 @Dependent
-@Named("UnanchoredStaticWorkbenchPanelView")
+@Named( "UnanchoredStaticWorkbenchPanelView" )
 public class UnanchoredStaticWorkbenchPanelView
         extends AbstractWorkbenchPanelView<UnanchoredStaticWorkbenchPanelPresenter> {
 
@@ -94,17 +96,11 @@ public class UnanchoredStaticWorkbenchPanelView
 
     @Override
     public void addPart( final WorkbenchPartPresenter.View view ) {
-        if ( panel.getPartView() != null ) {
-            placeManager.tryClosePlace( getCurrentPartDefinition().getPlace(), new Command() {
-                @Override
-                public void execute() {
-                    panel.setPart( view );
-                    onResize();
-                }
-            } );
-        } else {
+        if ( panel.getPartView() == null ) {
             panel.setPart( view );
             onResize();
+        } else {
+            throw new RuntimeException( "Uberfire Panel Invalid State: This panel support only one part." );
         }
     }
 
@@ -144,7 +140,7 @@ public class UnanchoredStaticWorkbenchPanelView
         super.onResize();
     }
 
-    private PartDefinition getCurrentPartDefinition() {
+    PartDefinition getCurrentPartDefinition() {
         View partView = panel.getPartView();
         if ( partView == null ) {
             return null;
@@ -156,5 +152,14 @@ public class UnanchoredStaticWorkbenchPanelView
         }
 
         return presenter.getDefinition();
+    }
+
+    @Override
+    public Collection<PartDefinition> getParts() {
+        PartDefinition currentPartDefinition = getCurrentPartDefinition();
+        if ( currentPartDefinition == null ) {
+            return new ArrayList<>();
+        }
+        return Arrays.asList( currentPartDefinition );
     }
 }

--- a/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/panels/support/PartManager.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/panels/support/PartManager.java
@@ -22,6 +22,8 @@ import org.uberfire.commons.data.Pair;
 import org.uberfire.workbench.model.PartDefinition;
 
 import javax.enterprise.context.ApplicationScoped;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -68,6 +70,11 @@ public class PartManager {
         widgets.clear();
         activePart = null;
     }
+
+    public Collection<PartDefinition> getParts() {
+        return Collections.unmodifiableSet( widgets.keySet() );
+    }
+
     public boolean hasPart(PartDefinition partDef)
     {
         return widgets.containsKey(partDef);

--- a/uberfire-workbench/uberfire-workbench-client/src/test/java/org/uberfire/client/workbench/panels/impl/AbstractSimpleWorkbenchPanelViewTest.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/test/java/org/uberfire/client/workbench/panels/impl/AbstractSimpleWorkbenchPanelViewTest.java
@@ -16,6 +16,8 @@
 
 package org.uberfire.client.workbench.panels.impl;
 
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.concurrent.atomic.AtomicLong;
 
 import com.google.gwt.dom.client.Style;
@@ -79,31 +81,26 @@ public abstract class AbstractSimpleWorkbenchPanelViewTest extends AbstractDocki
                 return parts.intValue();
             }
         } );
+        when( listBar.getParts() ).thenAnswer( new Answer<Collection<PartDefinition>>() {
+            @Override
+            public Collection<PartDefinition> answer( InvocationOnMock invocation ) throws Throwable {
+
+                return new ArrayList<PartDefinition>( parts.intValue() );
+            }
+        } );
+
 
     }
 
     @Test
-    public void shouldOnlyHaveOnePart() {
+    public void addAndGetPartsTest() {
         assertEquals( 0, listBar.getPartsSize() );
 
-        //Add first part
-        getViewToTest().addPart( mock( WorkbenchPartPresenter.View.class ) );
+        getViewToTest().addPart(  mock( WorkbenchPartPresenter.View.class ) );
         verify( listBar ).addPart( any( WorkbenchPartPresenter.View.class ) );
+
         assertEquals( 1, listBar.getPartsSize() );
 
-        //Second part will be ignored
-        getViewToTest().addPart( mock( WorkbenchPartPresenter.View.class ) );
-        verify( listBar ).addPart( any( WorkbenchPartPresenter.View.class ) );
-        assertEquals( 1, listBar.getPartsSize() );
-
-        //Remove part
-        getViewToTest().removePart( mock( PartDefinition.class ) );
-        assertEquals( 0, listBar.getPartsSize() );
-
-        //Add part again
-        getViewToTest().addPart( mock( WorkbenchPartPresenter.View.class ) );
-        verify( listBar, times( 2 ) ).addPart( any( WorkbenchPartPresenter.View.class ) );
-        assertEquals( 1, listBar.getPartsSize() );
     }
 
 }

--- a/uberfire-workbench/uberfire-workbench-client/src/test/java/org/uberfire/client/workbench/panels/impl/AdaptiveWorkbenchPanelViewTest.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/test/java/org/uberfire/client/workbench/panels/impl/AdaptiveWorkbenchPanelViewTest.java
@@ -13,33 +13,46 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.uberfire.client.workbench.panels.impl;
 
+import com.google.gwt.dom.client.Style;
+import com.google.gwt.user.client.Element;
+import com.google.gwt.user.client.ui.Widget;
 import com.google.gwtmockito.GwtMockitoTestRunner;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.uberfire.client.workbench.panels.MaximizeToggleButtonPresenter;
 import org.uberfire.client.workbench.part.WorkbenchPartPresenter;
+import org.uberfire.client.workbench.widgets.listbar.ListBarWidget;
+import org.uberfire.workbench.model.PartDefinition;
 
-import static org.junit.Assert.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.*;
 
 @RunWith( GwtMockitoTestRunner.class )
-public class ClosableSimpleWorkbenchPanelViewTest extends AbstractSimpleWorkbenchPanelViewTest {
+public class AdaptiveWorkbenchPanelViewTest extends AbstractSimpleWorkbenchPanelViewTest {
 
     @InjectMocks
-    private ClosableSimpleWorkbenchPanelView view;
+    private AdaptiveWorkbenchPanelView view;
 
     // Not a @Mock or @GwtMock because we want to test the view.init() method
-    private ClosableSimpleWorkbenchPanelPresenter presenter;
+    private AdaptiveWorkbenchPanelPresenter presenter;
 
     @Before
     public void setup() {
         super.setup();
 
-        presenter = mock( ClosableSimpleWorkbenchPanelPresenter.class );
+        presenter = mock( AdaptiveWorkbenchPanelPresenter.class );
 
         view.setup(); // PostConstruct
         view.init( presenter );
@@ -51,28 +64,15 @@ public class ClosableSimpleWorkbenchPanelViewTest extends AbstractSimpleWorkbenc
     }
 
     @Test
-    public void shouldAddPresenterOnInit() {
-        assertEquals( presenter, view.getPresenter() );
-    }
-
-    @Test
-    public void shouldEnableCloseParts() {
-        verify( listBar, never() ).disableClosePart();
-        verify( listBar ).enableClosePart();
-    }
-
-    @Test(expected = RuntimeException.class)
-    public void shouldOnlyHaveOnePart() {
+    public void couldHaveMoreThanOnePart() {
         assertEquals( 0, listBar.getPartsSize() );
 
         getViewToTest().addPart( mock( WorkbenchPartPresenter.View.class ) );
-        verify( listBar ).addPart( any( WorkbenchPartPresenter.View.class ) );
         assertEquals( 1, listBar.getPartsSize() );
 
-        //Second part add is a leak should throw exception
+        //Second part
         getViewToTest().addPart( mock( WorkbenchPartPresenter.View.class ) );
-        verify( listBar ).addPart( any( WorkbenchPartPresenter.View.class ) );
-        assertEquals( 1, listBar.getPartsSize() );
+        assertEquals( 2, listBar.getPartsSize() );
     }
 
 }

--- a/uberfire-workbench/uberfire-workbench-client/src/test/java/org/uberfire/client/workbench/panels/impl/SimpleDnDWorkbenchPanelPresenterTest.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/test/java/org/uberfire/client/workbench/panels/impl/SimpleDnDWorkbenchPanelPresenterTest.java
@@ -13,54 +13,39 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.uberfire.client.workbench.panels.impl;
 
-import org.junit.Before;
+import com.google.gwtmockito.GwtMockitoTestRunner;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
 import org.uberfire.client.mvp.PerspectiveManager;
 import org.uberfire.client.mvp.PlaceManager;
-import org.uberfire.client.workbench.panels.DockingWorkbenchPanelView;
 import org.uberfire.client.workbench.part.WorkbenchPartPresenter;
 import org.uberfire.mvp.Command;
 import org.uberfire.workbench.model.PartDefinition;
+import org.uberfire.workbench.model.impl.PanelDefinitionImpl;
 
+import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.*;
 
-@RunWith( MockitoJUnitRunner.class )
-public class ClosableSimpleWorkbenchPanelPresenterTest extends AbstractDockingWorkbenchPanelPresenterTest {
-
-    @Mock( name = "view" )
-    protected DockingWorkbenchPanelView<ClosableSimpleWorkbenchPanelPresenter> view;
+@RunWith( GwtMockitoTestRunner.class )
+public class SimpleDnDWorkbenchPanelPresenterTest {
 
     @Mock
     private PlaceManager placeManager;
 
-    @InjectMocks
-    ClosableSimpleWorkbenchPanelPresenter presenter;
+    @Mock
+    SimpleDnDWorkbenchPanelView view;
 
-    @Before
-    public void setUp2() {
-        presenter.init();
-        presenter.setDefinition( panelPresenterPanelDefinition );
-    }
+    SimpleDnDWorkbenchPanelPresenter presenter;
 
-    @Override
-    AbstractDockingWorkbenchPanelPresenter<?> getPresenterToTest() {
-        return presenter;
-    }
-
-    @Test
-    public void initShouldBindPresenterToView() {
-        verify( view ).init( presenter );
-    }
 
     @Test
     public void addPartTest() {
+        presenter = new SimpleDnDWorkbenchPanelPresenter( view, mock( PerspectiveManager.class ), placeManager );
+        presenter.init();
+        presenter.setDefinition( new PanelDefinitionImpl() );
 
         WorkbenchPartPresenter part = mock( WorkbenchPartPresenter.class );
         when( part.getDefinition() ).thenReturn( mock( PartDefinition.class ) );
@@ -75,16 +60,14 @@ public class ClosableSimpleWorkbenchPanelPresenterTest extends AbstractDockingWo
 
         SinglePartPanelHelper singlePartPanelHelper = mock( SinglePartPanelHelper.class );
 
-        ClosableSimpleWorkbenchPanelPresenter presenter = new ClosableSimpleWorkbenchPanelPresenter( view,
-                                                                                                     mock( PerspectiveManager.class ),
-                                                                                                     placeManager ) {
+        presenter = new SimpleDnDWorkbenchPanelPresenter( view, mock( PerspectiveManager.class ), placeManager ) {
             SinglePartPanelHelper createSinglePartPanelHelper() {
                 return singlePartPanelHelper;
             }
         };
 
         presenter.init();
-        presenter.setDefinition( panelPresenterPanelDefinition );
+        presenter.setDefinition( new PanelDefinitionImpl() );
 
         //there is already a part
         when( singlePartPanelHelper.hasNoParts() ).thenReturn( false );
@@ -97,5 +80,4 @@ public class ClosableSimpleWorkbenchPanelPresenterTest extends AbstractDockingWo
         verify( singlePartPanelHelper ).closeFirstPartAndAddNewOne( any( Command.class ) );
 
     }
-
 }

--- a/uberfire-workbench/uberfire-workbench-client/src/test/java/org/uberfire/client/workbench/panels/impl/SimpleWorkbenchPanelPresenterTest.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/test/java/org/uberfire/client/workbench/panels/impl/SimpleWorkbenchPanelPresenterTest.java
@@ -16,21 +16,29 @@
 
 package org.uberfire.client.workbench.panels.impl;
 
-import static org.mockito.Mockito.*;
-
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
+import org.uberfire.client.mvp.PerspectiveManager;
+import org.uberfire.client.mvp.PlaceManager;
 import org.uberfire.client.workbench.panels.DockingWorkbenchPanelView;
+import org.uberfire.client.workbench.part.WorkbenchPartPresenter;
+import org.uberfire.mvp.Command;
+import org.uberfire.workbench.model.PartDefinition;
 
-@RunWith(MockitoJUnitRunner.class)
+import static org.mockito.Mockito.*;
+
+@RunWith( MockitoJUnitRunner.class )
 public class SimpleWorkbenchPanelPresenterTest extends AbstractDockingWorkbenchPanelPresenterTest {
 
-    @Mock(name="view")
+    @Mock( name = "view" )
     protected DockingWorkbenchPanelView<SimpleWorkbenchPanelPresenter> view;
+
+    @Mock
+    private PlaceManager placeManager;
 
     @InjectMocks
     SimpleWorkbenchPanelPresenter presenter;
@@ -49,5 +57,44 @@ public class SimpleWorkbenchPanelPresenterTest extends AbstractDockingWorkbenchP
     @Test
     public void initShouldBindPresenterToView() {
         verify( view ).init( presenter );
+    }
+
+    @Test
+    public void addPartTest() {
+
+        WorkbenchPartPresenter part = mock( WorkbenchPartPresenter.class );
+        when( part.getDefinition() ).thenReturn( mock( PartDefinition.class ) );
+
+        presenter.addPart( part );
+
+        verify( view ).addPart( any() );
+    }
+
+    @Test
+    public void addPartTwiceShouldCloseOtherPartTest() {
+
+        SinglePartPanelHelper singlePartPanelHelper = mock( SinglePartPanelHelper.class );
+
+        SimpleWorkbenchPanelPresenter presenter = new SimpleWorkbenchPanelPresenter( view,
+                                                                                     mock( PerspectiveManager.class ),
+                                                                                     placeManager ) {
+            SinglePartPanelHelper createSinglePartPanelHelper() {
+                return singlePartPanelHelper;
+            }
+        };
+
+        presenter.init();
+        presenter.setDefinition( panelPresenterPanelDefinition );
+
+        //there is already a part
+        when( singlePartPanelHelper.hasNoParts() ).thenReturn( false );
+
+        WorkbenchPartPresenter part2 = mock( WorkbenchPartPresenter.class );
+        when( part2.getDefinition() ).thenReturn( mock( PartDefinition.class ) );
+
+        presenter.addPart( part2 );
+
+        verify( singlePartPanelHelper ).closeFirstPartAndAddNewOne( any( Command.class ) );
+
     }
 }

--- a/uberfire-workbench/uberfire-workbench-client/src/test/java/org/uberfire/client/workbench/panels/impl/SimpleWorkbenchPanelViewTest.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/test/java/org/uberfire/client/workbench/panels/impl/SimpleWorkbenchPanelViewTest.java
@@ -22,6 +22,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
+import org.uberfire.client.workbench.part.WorkbenchPartPresenter;
 import org.uberfire.mvp.Command;
 
 import static org.junit.Assert.*;
@@ -99,4 +100,17 @@ public class SimpleWorkbenchPanelViewTest extends AbstractSimpleWorkbenchPanelVi
         verify( listBar, never() ).enableClosePart();
     }
 
+    @Test(expected = RuntimeException.class)
+    public void shouldOnlyHaveOnePart() {
+        assertEquals( 0, listBar.getPartsSize() );
+
+        getViewToTest().addPart( mock( WorkbenchPartPresenter.View.class ) );
+        verify( listBar ).addPart( any( WorkbenchPartPresenter.View.class ) );
+        assertEquals( 1, listBar.getPartsSize() );
+
+        //Second part add is a leak should throw exception
+        getViewToTest().addPart( mock( WorkbenchPartPresenter.View.class ) );
+        verify( listBar ).addPart( any( WorkbenchPartPresenter.View.class ) );
+        assertEquals( 1, listBar.getPartsSize() );
+    }
 }

--- a/uberfire-workbench/uberfire-workbench-client/src/test/java/org/uberfire/client/workbench/panels/impl/SinglePartPanelHelperTest.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/test/java/org/uberfire/client/workbench/panels/impl/SinglePartPanelHelperTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.uberfire.client.workbench.panels.impl;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.uberfire.client.mvp.PlaceManager;
+import org.uberfire.mvp.Command;
+import org.uberfire.mvp.PlaceRequest;
+import org.uberfire.workbench.model.PartDefinition;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+
+import static org.jgroups.util.Util.assertEquals;
+import static org.jgroups.util.Util.assertTrue;
+import static org.mockito.Mockito.*;
+
+
+@RunWith( MockitoJUnitRunner.class )
+public class SinglePartPanelHelperTest {
+
+
+    private SinglePartPanelHelper singlePartHelper;
+
+    @Mock
+    private PlaceManager placeManager;
+
+    @Test
+    public void thereIsNoPartsTest() {
+
+        singlePartHelper = new SinglePartPanelHelper( new ArrayList<>(), placeManager );
+        assertTrue( singlePartHelper.hasNoParts() );
+
+    }
+
+    @Test
+    public void getPlaceFromFirstPartTest() {
+
+        PlaceRequest place = mock( PlaceRequest.class );
+        PartDefinition part = mock( PartDefinition.class );
+        when( part.getPlace() ).thenReturn( place );
+
+        Collection<PartDefinition> parts = Arrays.asList( part );
+        singlePartHelper = new SinglePartPanelHelper( parts, placeManager );
+
+        assertTrue( !singlePartHelper.hasNoParts() );
+        assertEquals( place, singlePartHelper.getPlaceFromFirstPart() );
+
+    }
+
+    @Test
+    public void closeFirstPartAndAddNewOneTest() {
+
+        PlaceRequest place = mock( PlaceRequest.class );
+        PartDefinition part = mock( PartDefinition.class );
+        Command cmd = mock( Command.class );
+
+        when( part.getPlace() ).thenReturn( place );
+
+        Collection<PartDefinition> parts = Arrays.asList( part );
+        singlePartHelper = new SinglePartPanelHelper( parts, placeManager );
+
+        singlePartHelper.closeFirstPartAndAddNewOne( cmd );
+        verify( placeManager ).tryClosePlace( place, cmd );
+
+    }
+
+}

--- a/uberfire-workbench/uberfire-workbench-client/src/test/java/org/uberfire/client/workbench/panels/impl/StaticWorkbenchPanelPresenterTest.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/test/java/org/uberfire/client/workbench/panels/impl/StaticWorkbenchPanelPresenterTest.java
@@ -13,50 +13,47 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.uberfire.client.workbench.panels.impl;
 
+import com.google.gwtmockito.GwtMockitoTestRunner;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
 import org.uberfire.client.mvp.PerspectiveManager;
 import org.uberfire.client.mvp.PlaceManager;
-import org.uberfire.client.workbench.panels.DockingWorkbenchPanelView;
 import org.uberfire.client.workbench.part.WorkbenchPartPresenter;
 import org.uberfire.mvp.Command;
 import org.uberfire.workbench.model.PartDefinition;
+import org.uberfire.workbench.model.impl.PanelDefinitionImpl;
 
+import static org.junit.Assert.assertNull;
+import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.*;
 
-@RunWith( MockitoJUnitRunner.class )
-public class ClosableSimpleWorkbenchPanelPresenterTest extends AbstractDockingWorkbenchPanelPresenterTest {
-
-    @Mock( name = "view" )
-    protected DockingWorkbenchPanelView<ClosableSimpleWorkbenchPanelPresenter> view;
+@RunWith( GwtMockitoTestRunner.class )
+public class StaticWorkbenchPanelPresenterTest {
 
     @Mock
     private PlaceManager placeManager;
 
-    @InjectMocks
-    ClosableSimpleWorkbenchPanelPresenter presenter;
+    @Mock
+    StaticWorkbenchPanelView view;
+
+    StaticWorkbenchPanelPresenter presenter;
 
     @Before
-    public void setUp2() {
+    public void setup() {
+        presenter = new StaticWorkbenchPanelPresenter( view, mock( PerspectiveManager.class ), placeManager );
         presenter.init();
-        presenter.setDefinition( panelPresenterPanelDefinition );
-    }
-
-    @Override
-    AbstractDockingWorkbenchPanelPresenter<?> getPresenterToTest() {
-        return presenter;
+        presenter.setDefinition( new PanelDefinitionImpl() );
     }
 
     @Test
-    public void initShouldBindPresenterToView() {
-        verify( view ).init( presenter );
+    public void getDefaultChildTypeTest() {
+
+        assertNull( presenter.getDefaultChildType() );
+
     }
 
     @Test
@@ -75,16 +72,16 @@ public class ClosableSimpleWorkbenchPanelPresenterTest extends AbstractDockingWo
 
         SinglePartPanelHelper singlePartPanelHelper = mock( SinglePartPanelHelper.class );
 
-        ClosableSimpleWorkbenchPanelPresenter presenter = new ClosableSimpleWorkbenchPanelPresenter( view,
-                                                                                                     mock( PerspectiveManager.class ),
-                                                                                                     placeManager ) {
+        StaticWorkbenchPanelPresenter presenter = new StaticWorkbenchPanelPresenter( view,
+                                                                                     mock( PerspectiveManager.class ),
+                                                                                     placeManager ) {
             SinglePartPanelHelper createSinglePartPanelHelper() {
                 return singlePartPanelHelper;
             }
         };
 
         presenter.init();
-        presenter.setDefinition( panelPresenterPanelDefinition );
+        presenter.setDefinition( new PanelDefinitionImpl() );
 
         //there is already a part
         when( singlePartPanelHelper.hasNoParts() ).thenReturn( false );
@@ -97,5 +94,4 @@ public class ClosableSimpleWorkbenchPanelPresenterTest extends AbstractDockingWo
         verify( singlePartPanelHelper ).closeFirstPartAndAddNewOne( any( Command.class ) );
 
     }
-
 }

--- a/uberfire-workbench/uberfire-workbench-client/src/test/java/org/uberfire/client/workbench/panels/impl/StaticWorkbenchPanelViewTest.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/test/java/org/uberfire/client/workbench/panels/impl/StaticWorkbenchPanelViewTest.java
@@ -16,29 +16,25 @@
 
 package org.uberfire.client.workbench.panels.impl;
 
-import static org.junit.Assert.*;
-import static org.mockito.Matchers.*;
-import static org.mockito.Mockito.*;
-
+import com.google.gwtmockito.GwtMockitoTestRunner;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Answers;
-import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.uberfire.client.mvp.PlaceManager;
 import org.uberfire.client.workbench.PanelManager;
 import org.uberfire.client.workbench.part.WorkbenchPartPresenter;
 import org.uberfire.client.workbench.widgets.panel.StaticFocusedResizePanel;
-import org.uberfire.mvp.Command;
 import org.uberfire.mvp.impl.DefaultPlaceRequest;
 import org.uberfire.workbench.model.PartDefinition;
 import org.uberfire.workbench.model.impl.PartDefinitionImpl;
 
-import com.google.gwtmockito.GwtMockitoTestRunner;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
 
-@RunWith(GwtMockitoTestRunner.class)
+@RunWith( GwtMockitoTestRunner.class )
 public class StaticWorkbenchPanelViewTest {
 
     @InjectMocks
@@ -53,7 +49,7 @@ public class StaticWorkbenchPanelViewTest {
     @Mock
     private PlaceManager placeManager;
 
-    @Mock(answer=Answers.RETURNS_MOCKS)
+    @Mock( answer = Answers.RETURNS_MOCKS )
     private StaticFocusedResizePanel panel;
 
     @Before
@@ -75,25 +71,7 @@ public class StaticWorkbenchPanelViewTest {
         view.addPart( viewWbPartPresenter );
 
         verify( panel ).setPart( viewWbPartPresenter );
-    }
 
-    @Test
-    public void addPartShouldCloseCurrentPlaceWhenReplacingExistingPart() {
-        WorkbenchPartPresenter mockPresenter = mock( WorkbenchPartPresenter.class );
-        WorkbenchPartPresenter.View mockPartView = mock( WorkbenchPartPresenter.View.class );
-        PartDefinition mockPartDefinition = new PartDefinitionImpl( new DefaultPlaceRequest( "mockPlace" ) );
-
-        when( panel.getPartView() ).thenReturn( mockPartView );
-        when( mockPartView.getPresenter() ).thenReturn( mockPresenter );
-        when( mockPresenter.getDefinition() ).thenReturn( mockPartDefinition );
-
-        view.addPart( mockPartView );
-
-        ArgumentCaptor<Command> afterCloseCallback = ArgumentCaptor.forClass( Command.class );
-        verify( placeManager ).tryClosePlace( refEq( mockPartDefinition.getPlace() ), afterCloseCallback.capture() );
-
-        afterCloseCallback.getValue().execute();
-        verify( panel ).setPart( mockPartView );
     }
 
     @Test
@@ -105,6 +83,7 @@ public class StaticWorkbenchPanelViewTest {
         when( mockPartView.getPresenter() ).thenReturn( mockPresenter );
         when( mockPresenter.getDefinition() ).thenReturn( mockPartDefinition );
 
+        when( view.panel.getPartView() ).thenReturn( null );
         view.addPart( mockPartView );
         when( view.panel.getPartView() ).thenReturn( mockPartView );
 
@@ -130,6 +109,7 @@ public class StaticWorkbenchPanelViewTest {
         when( mockPartView2.getPresenter() ).thenReturn( mockPresenter2 );
         when( mockPresenter2.getDefinition() ).thenReturn( mockPartDefinition2 );
 
+        when( view.panel.getPartView() ).thenReturn( null );
         view.addPart( mockPartView );
         when( view.panel.getPartView() ).thenReturn( mockPartView );
 
@@ -152,4 +132,8 @@ public class StaticWorkbenchPanelViewTest {
     }
 
 
+    @Test
+    public void getPartsShouldReturnCurrentPart() {
+        assertFalse( view.getParts().isEmpty() );
+    }
 }

--- a/uberfire-workbench/uberfire-workbench-client/src/test/java/org/uberfire/client/workbench/panels/impl/UnanchoredStaticWorkbenchPanelPresenterTest.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/test/java/org/uberfire/client/workbench/panels/impl/UnanchoredStaticWorkbenchPanelPresenterTest.java
@@ -13,50 +13,47 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.uberfire.client.workbench.panels.impl;
 
+import com.google.gwtmockito.GwtMockitoTestRunner;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
 import org.uberfire.client.mvp.PerspectiveManager;
 import org.uberfire.client.mvp.PlaceManager;
-import org.uberfire.client.workbench.panels.DockingWorkbenchPanelView;
 import org.uberfire.client.workbench.part.WorkbenchPartPresenter;
 import org.uberfire.mvp.Command;
 import org.uberfire.workbench.model.PartDefinition;
+import org.uberfire.workbench.model.impl.PanelDefinitionImpl;
 
+import static org.junit.Assert.assertNull;
+import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.*;
 
-@RunWith( MockitoJUnitRunner.class )
-public class ClosableSimpleWorkbenchPanelPresenterTest extends AbstractDockingWorkbenchPanelPresenterTest {
-
-    @Mock( name = "view" )
-    protected DockingWorkbenchPanelView<ClosableSimpleWorkbenchPanelPresenter> view;
+@RunWith( GwtMockitoTestRunner.class )
+public class UnanchoredStaticWorkbenchPanelPresenterTest {
 
     @Mock
     private PlaceManager placeManager;
 
-    @InjectMocks
-    ClosableSimpleWorkbenchPanelPresenter presenter;
+    @Mock
+    UnanchoredStaticWorkbenchPanelView view;
+
+    UnanchoredStaticWorkbenchPanelPresenter presenter;
 
     @Before
-    public void setUp2() {
+    public void setup() {
+        presenter = new UnanchoredStaticWorkbenchPanelPresenter( view, mock( PerspectiveManager.class ), placeManager );
         presenter.init();
-        presenter.setDefinition( panelPresenterPanelDefinition );
-    }
-
-    @Override
-    AbstractDockingWorkbenchPanelPresenter<?> getPresenterToTest() {
-        return presenter;
+        presenter.setDefinition( new PanelDefinitionImpl() );
     }
 
     @Test
-    public void initShouldBindPresenterToView() {
-        verify( view ).init( presenter );
+    public void getDefaultChildTypeTest() {
+
+        assertNull( presenter.getDefaultChildType() );
+
     }
 
     @Test
@@ -75,16 +72,16 @@ public class ClosableSimpleWorkbenchPanelPresenterTest extends AbstractDockingWo
 
         SinglePartPanelHelper singlePartPanelHelper = mock( SinglePartPanelHelper.class );
 
-        ClosableSimpleWorkbenchPanelPresenter presenter = new ClosableSimpleWorkbenchPanelPresenter( view,
-                                                                                                     mock( PerspectiveManager.class ),
-                                                                                                     placeManager ) {
+        UnanchoredStaticWorkbenchPanelPresenter presenter = new UnanchoredStaticWorkbenchPanelPresenter( view,
+                                                                                     mock( PerspectiveManager.class ),
+                                                                                     placeManager ) {
             SinglePartPanelHelper createSinglePartPanelHelper() {
                 return singlePartPanelHelper;
             }
         };
 
         presenter.init();
-        presenter.setDefinition( panelPresenterPanelDefinition );
+        presenter.setDefinition( new PanelDefinitionImpl() );
 
         //there is already a part
         when( singlePartPanelHelper.hasNoParts() ).thenReturn( false );
@@ -97,5 +94,4 @@ public class ClosableSimpleWorkbenchPanelPresenterTest extends AbstractDockingWo
         verify( singlePartPanelHelper ).closeFirstPartAndAddNewOne( any( Command.class ) );
 
     }
-
 }

--- a/uberfire-workbench/uberfire-workbench-client/src/test/java/org/uberfire/client/workbench/panels/impl/UnanchoredStaticWorkbenchPanelViewTest.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/test/java/org/uberfire/client/workbench/panels/impl/UnanchoredStaticWorkbenchPanelViewTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.uberfire.client.workbench.panels.impl;
+
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.uberfire.workbench.model.PartDefinition;
+
+import static org.junit.Assert.assertFalse;
+import static org.mockito.Mockito.mock;
+
+@RunWith( GwtMockitoTestRunner.class )
+public class UnanchoredStaticWorkbenchPanelViewTest {
+
+    private UnanchoredStaticWorkbenchPanelView view;
+
+    @Test
+    public void getPartsShouldReturnCurrentPartDefinition() {
+        view = new UnanchoredStaticWorkbenchPanelView() {
+            @Override
+            PartDefinition getCurrentPartDefinition() {
+                return mock( PartDefinition.class );
+            }
+        };
+
+        assertFalse(view.getParts().isEmpty());
+    }
+
+}

--- a/uberfire-workbench/uberfire-workbench-client/src/test/java/org/uberfire/client/workbench/panels/support/PartManagerTest.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/test/java/org/uberfire/client/workbench/panels/support/PartManagerTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.uberfire.client.workbench.panels.support;
+
+import com.google.gwt.user.client.ui.Widget;
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.uberfire.workbench.model.PartDefinition;
+
+import static org.jgroups.util.Util.assertEquals;
+import static org.mockito.Mockito.mock;
+
+@RunWith( GwtMockitoTestRunner.class )
+public class PartManagerTest {
+
+    private PartManager partManager;
+
+    @Test
+    public void getPartsShouldReturnCurrentWidgets() {
+        partManager = new PartManager();
+
+        partManager.registerPart( mock( PartDefinition.class ), mock( Widget.class ) );
+        partManager.registerPart( mock( PartDefinition.class ), mock( Widget.class ) );
+
+        assertEquals( 2, partManager.getParts().size() );
+    }
+}


### PR DESCRIPTION
**Description**: bug goTo(screen) doesn't work properly on JS Perspectives. This can be reproduced in uberfire showcase, using the screens menu to load screens in default perspective.

**Cause**: The root cause os this issue is this:
 https://github.com/uberfire/uberfire/blob/1c14cbfd947da6f4dd8a76c062295186dee9b4b9/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/panels/impl/AbstractSimpleWorkbenchPanelView.java#L90

All the presenters that support only one widget ( SimpleWbPresenter, ClosablePresenter,SimpleDndPresenter) have this base view. 

The issue happens when one of this panels is the root of a perspective and we do a goto(screen). Then this screen will be launched at the root panel and this view silently ignored attaching the view breaking the workbench because Uberfire cannot close everything.


The same behavior was well implemented in the StaticWorkbenchPanelView and UnanchoredStaticWorkbenchPanelview : 

https://github.com/uberfire/uberfire/blob/a0bf142be9c6cc63704e0de0e13d6ea5ec460d81/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/panels/impl/StaticWorkbenchPanelView.java#L98

When an activity is launched in this panel, they do the proper cleanup calling place manager to close the activity.

**Solution**:

Before adding any part in this type of presenters, I removed the current part in a proper way (i.e. ClosableSimpleWorkbenchPanelPresenter) to prevent part leak. I also refactored StaticWorkbenchPanelView and UnanchoredStaticWorkbenchPanelview logic to the respective presenter and add a lot of tests.


ps. AdaptivePanels are special one, because they behave like a Simple Panel until receives other part.