### PR TITLE
[0.8.x] BZ1323572: AsyncWatchService dies when a RuntimeException is thrown from IOWatchServiceExecutorImpl.execute()

### DIFF
--- a/uberfire-backend/uberfire-backend-server/src/main/java/org/uberfire/backend/server/io/watch/AbstractIOWatchService.java
+++ b/uberfire-backend/uberfire-backend-server/src/main/java/org/uberfire/backend/server/io/watch/AbstractIOWatchService.java
@@ -157,7 +157,11 @@ public abstract class AbstractIOWatchService implements IOWatchService,
                         break;
                     }
 
-                    wsExecutor.execute( wk, AbstractIOWatchService.this );
+                    try {
+                        wsExecutor.execute( wk, AbstractIOWatchService.this );
+                    } catch ( final Exception ex ) {
+                        LOG.error( "Unexpected error during WatchService execution", ex );
+                    }
 
                     // Reset the key -- this step is critical if you want to
                     // receive further watch events.  If the key is no longer valid,

--- a/uberfire-backend/uberfire-backend-server/src/main/java/org/uberfire/backend/server/io/watch/IOWatchServiceExecutorImpl.java
+++ b/uberfire-backend/uberfire-backend-server/src/main/java/org/uberfire/backend/server/io/watch/IOWatchServiceExecutorImpl.java
@@ -126,21 +126,17 @@ public class IOWatchServiceExecutorImpl implements IOWatchServiceExecutor {
                 resourceBatchChanges.fire( new ResourceBatchChangesEvent( changes, message( firstContext ), sessionInfo( firstContext ) ) );
             }
         } else if ( events.size() == 1 ) {
-            try {
-                final WatchEvent<?> event = events.get( 0 );
-                if ( !filter.doFilter( event ) ) {
-                    if ( event.kind().equals( StandardWatchEventKind.ENTRY_MODIFY ) ) {
-                        resourceUpdatedEvent.fire( buildEvent( ResourceUpdatedEvent.class, event ).getK2() );
-                    } else if ( event.kind().equals( StandardWatchEventKind.ENTRY_CREATE ) ) {
-                        resourceAddedEvent.fire( buildEvent( ResourceAddedEvent.class, event ).getK2() );
-                    } else if ( event.kind().equals( StandardWatchEventKind.ENTRY_RENAME ) ) {
-                        resourceRenamedEvent.fire( buildEvent( ResourceRenamedEvent.class, event ).getK2() );
-                    } else if ( event.kind().equals( StandardWatchEventKind.ENTRY_DELETE ) ) {
-                        resourceDeletedEvent.fire( buildEvent( ResourceDeletedEvent.class, event ).getK2() );
-                    }
+            final WatchEvent<?> event = events.get( 0 );
+            if ( !filter.doFilter( event ) ) {
+                if ( event.kind().equals( StandardWatchEventKind.ENTRY_MODIFY ) ) {
+                    resourceUpdatedEvent.fire( buildEvent( ResourceUpdatedEvent.class, event ).getK2() );
+                } else if ( event.kind().equals( StandardWatchEventKind.ENTRY_CREATE ) ) {
+                    resourceAddedEvent.fire( buildEvent( ResourceAddedEvent.class, event ).getK2() );
+                } else if ( event.kind().equals( StandardWatchEventKind.ENTRY_RENAME ) ) {
+                    resourceRenamedEvent.fire( buildEvent( ResourceRenamedEvent.class, event ).getK2() );
+                } else if ( event.kind().equals( StandardWatchEventKind.ENTRY_DELETE ) ) {
+                    resourceDeletedEvent.fire( buildEvent( ResourceDeletedEvent.class, event ).getK2() );
                 }
-            } catch ( final Exception ex ) {
-                LOGGER.error( "Unexpected error during WatchService events fire.", ex );
             }
         }
     }

--- a/uberfire-backend/uberfire-backend-server/src/test/java/org/uberfire/backend/server/io/watch/AbstractIOWatchServiceTest.java
+++ b/uberfire-backend/uberfire-backend-server/src/test/java/org/uberfire/backend/server/io/watch/AbstractIOWatchServiceTest.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.backend.server.io.watch;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Test;
+import org.uberfire.backend.server.util.Filter;
+import org.uberfire.java.nio.IOException;
+import org.uberfire.java.nio.file.ClosedWatchServiceException;
+import org.uberfire.java.nio.file.InterruptedException;
+import org.uberfire.java.nio.file.WatchEvent;
+import org.uberfire.java.nio.file.WatchKey;
+import org.uberfire.java.nio.file.WatchService;
+import org.uberfire.java.nio.file.Watchable;
+
+public class AbstractIOWatchServiceTest {
+
+    @Test
+    public void testAddWatchServiceException() {
+        // BZ1323572
+        try {
+            System.setProperty( "org.uberfire.watcher.autostart", "false" );
+
+            AbstractIOWatchService service = new AbstractIOWatchService() {
+
+                @Override
+                public boolean doFilter( WatchEvent<?> t ) {
+                    return false;
+                }
+            };
+
+            WatchService ws = new WatchService() {
+
+                @Override
+                public void close() throws IOException {
+                }
+
+                @Override
+                public WatchKey poll() throws ClosedWatchServiceException {
+                    return null;
+                }
+
+                @Override
+                public WatchKey poll( long timeout, TimeUnit unit ) throws ClosedWatchServiceException, InterruptedException {
+                    return null;
+                }
+
+                @Override
+                public WatchKey take() throws ClosedWatchServiceException, InterruptedException {
+                    return new WatchKey() {
+
+                        @Override
+                        public boolean isValid() {
+                            return false;
+                        }
+
+                        @Override
+                        public List<WatchEvent<?>> pollEvents() {
+                            return null;
+                        }
+
+                        @Override
+                        public boolean reset() {
+                            return false; // exit the loop in asyncWatchService.execute()
+                        }
+
+                        @Override
+                        public void cancel() {
+                        }
+
+                        @Override
+                        public Watchable watchable() {
+                            return null;
+                        }
+                    };
+                }
+
+                @Override
+                public boolean isClose() {
+                    return false;
+                }
+            };
+
+            service.addWatchService( null, ws );
+
+            Set<AsyncWatchService> watchThreads = null;
+            try {
+                Field field = AbstractIOWatchService.class.getDeclaredField( "watchThreads" );
+                field.setAccessible( true );
+                watchThreads = (Set<AsyncWatchService>) field.get( service );
+            } catch ( Exception e ) {
+                fail(e.getMessage());
+            }
+            AsyncWatchService asyncWatchService = watchThreads.iterator().next();
+
+            IOWatchServiceExecutor wsExecutor = new IOWatchServiceExecutor() {
+
+                @Override
+                public void execute( WatchKey watchKey, Filter<WatchEvent<?>> filter ) {
+                    throw new RuntimeException( "dummy" );
+                }
+            };
+
+            try {
+                asyncWatchService.execute( wsExecutor );
+                assertTrue( true );
+            } catch ( Exception e ) {
+                fail( "Exception is thrown from asyncWatchService.execute()" );
+            }
+
+        } finally {
+            System.clearProperty( "org.uberfire.watcher.autostart" );
+        }
+    }
+}


### PR DESCRIPTION
See https://bugzilla.redhat.com/show_bug.cgi?id=1323572

(cherry picked from commit f70ef4c059d312db1fc07692fb845fd703f3f82b)