### PR TITLE
BZ1333277: Upgrade of XStream library to 1.4.9 causing exceptions during Project navigation

### DIFF
--- a/uberfire-nio2-backport/uberfire-nio2-model/src/main/java/org/uberfire/java/nio/base/Properties.java
+++ b/uberfire-nio2-backport/uberfire-nio2-model/src/main/java/org/uberfire/java/nio/base/Properties.java
@@ -77,8 +77,10 @@ public class Properties extends HashMap<String, Object> {
         try {
             xstream.fromXML( in, temp );
         } catch ( final XStreamException ex ) {
-            if ( !ex.getMessage().equals( " : input contained no data" ) ) {
-                throw ex;
+            if ( ex.getCause() != null ) {
+                if ( !ex.getCause().getMessage().equals( "input contained no data" ) ) {
+                    throw ex;
+                }
             }
         }
 


### PR DESCRIPTION
See https://bugzilla.redhat.com/show_bug.cgi?id=1333277

I've tested this with both XStream 1.4.7 (currently used on master); and XStream 1.4.9 (used by KIE master, 6.3.x and 6.4.x). See https://bugzilla.redhat.com/show_bug.cgi?id=1322171. I've asked @mbiarnes to consider upgrading Uberfire to 1.4.9 too for consistency.