### PR TITLE
[0.7.x] BZ1333277: Upgrade of XStream library to 1.4.9 causing exceptions during Project navigation

### DIFF
--- a/uberfire-nio2-backport/uberfire-nio2-model/src/main/java/org/uberfire/java/nio/base/Properties.java
+++ b/uberfire-nio2-backport/uberfire-nio2-model/src/main/java/org/uberfire/java/nio/base/Properties.java
@@ -61,8 +61,10 @@ public class Properties extends HashMap<String, Object> {
         try {
             xstream.fromXML( in, temp );
         } catch ( final XStreamException ex ) {
-            if ( !ex.getMessage().equals( " : input contained no data" ) ) {
-                throw ex;
+            if ( ex.getCause() != null ) {
+                if ( !ex.getCause().getMessage().equals( "input contained no data" ) ) {
+                    throw ex;
+                }
             }
         }
 


### PR DESCRIPTION
See https://github.com/uberfire/uberfire/pull/360

(cherry picked from commit 344444375ceb94a2409e43420c250315ca8fe6c5)

This is the corollary for 0.7.x.