### PR TITLE
UF-306: AbstractWorkbenchEditorActivity: Allow Editors to provide their own LockManager handling

### DIFF
--- a/uberfire-client-api/src/main/java/org/uberfire/client/annotations/WorkbenchEditor.java
+++ b/uberfire-client-api/src/main/java/org/uberfire/client/annotations/WorkbenchEditor.java
@@ -66,7 +66,7 @@ public @interface WorkbenchEditor {
     /**
      * Array that defines all supported types of this editor.
      */
-    Class<? extends ClientResourceType>[] supportedTypes() default { };
+    Class<? extends ClientResourceType>[] supportedTypes() default {};
 
     /**
      * Defines the priority of editor over type resolution, editors with same supported type will be resolved by priority.
@@ -92,18 +92,19 @@ public @interface WorkbenchEditor {
      * is the trigger to create a new panel, if panel already exists this information is ignored.
      */
     int preferredWidth() default -1;
-    
+
     /**
-     * Defines how and if locks are acquired when using this editor. By default, a pessimistic locking 
+     * Defines how and if locks are acquired when using this editor. By default, a pessimistic locking
      * strategy is used, allowing edits by only one user at a time.
      */
-    LockingStrategy lockingStrategy() default LockingStrategy.PESSIMISTIC; 
-    
+    LockingStrategy lockingStrategy() default LockingStrategy.FRAMEWORK_PESSIMISTIC;
+
     /**
      * Locking strategies define how and if locks are acquired when using editors.
      */
-    public static enum LockingStrategy {
-        OPTIMISTIC, // No locks are acquired, editor implementations need their own conflict resolution logic (if desired).
-        PESSIMISTIC // Locks are acquired allowing edits by only one user at a time
+    enum LockingStrategy {
+        EDITOR_PROVIDED, // No locks are acquired, editor implementations need their own conflict resolution logic (if desired).
+        FRAMEWORK_PESSIMISTIC // Locks are acquired allowing edits by only one user at a time
     }
+
 }

--- a/uberfire-client-api/src/main/java/org/uberfire/client/mvp/LockTarget.java
+++ b/uberfire-client-api/src/main/java/org/uberfire/client/mvp/LockTarget.java
@@ -16,61 +16,60 @@
 
 package org.uberfire.client.mvp;
 
-import static org.uberfire.commons.validation.PortablePreconditions.checkNotNull;
-
+import com.google.gwt.user.client.ui.IsWidget;
 import org.uberfire.backend.vfs.Path;
 import org.uberfire.mvp.PlaceRequest;
 
-import com.google.gwt.user.client.ui.Widget;
+import static org.uberfire.commons.validation.PortablePreconditions.*;
 
 /**
- * Holds information about the target of a lock.  
+ * Holds information about the target of a lock.
  */
 public class LockTarget {
 
     public interface TitleProvider {
+
         String getTitle();
+
     }
-    
+
     private final Path path;
-    private final Widget widget;
+    private final IsWidget isWidget;
     private final PlaceRequest place;
     private final TitleProvider titleProvider;
     private final Runnable reloadRunnable;
-    
+
     public LockTarget( Path path,
-                       Widget widget,
+                       IsWidget isWidget,
                        PlaceRequest place,
                        TitleProvider titleProvider,
-                       Runnable reloadRunnable) {
-        
+                       Runnable reloadRunnable ) {
+
         checkNotNull( "path", path );
-        checkNotNull( "widget", widget );
+        checkNotNull( "isWidget", isWidget );
         checkNotNull( "place", place );
         checkNotNull( "titleProvider", titleProvider );
         checkNotNull( "reloadRunnable", reloadRunnable );
-        
+
         this.path = path;
-        this.widget = widget;
+        this.isWidget = isWidget;
         this.place = place;
         this.titleProvider = titleProvider;
         this.reloadRunnable = reloadRunnable;
     }
-    
+
     public Path getPath() {
         return path;
     }
 
-    
-    public Widget getWidget() {
-        return widget;
+    public IsWidget getWidget() {
+        return isWidget;
     }
 
-    
     public PlaceRequest getPlace() {
         return place;
     }
-    
+
     public String getTitle() {
         return titleProvider.getTitle();
     }
@@ -78,4 +77,5 @@ public class LockTarget {
     public Runnable getReloadRunnable() {
         return reloadRunnable;
     }
+
 }

--- a/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/WorkbenchEditorTest27.java
+++ b/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/WorkbenchEditorTest27.java
@@ -7,11 +7,11 @@ import org.jboss.errai.ioc.client.api.ActivatedBy;
 import org.uberfire.client.annotations.WorkbenchEditor;
 import org.uberfire.client.annotations.WorkbenchPartTitle;
 import org.uberfire.client.annotations.WorkbenchPartView;
-import static org.uberfire.client.annotations.WorkbenchEditor.LockingStrategy.PESSIMISTIC;
+import static org.uberfire.client.annotations.WorkbenchEditor.LockingStrategy.FRAMEWORK_PESSIMISTIC;
 import org.uberfire.client.mvp.MyTestType;
 import org.uberfire.security.annotations.Roles;
 
-@WorkbenchEditor(identifier = "test27", lockingStrategy = PESSIMISTIC)
+@WorkbenchEditor(identifier = "test27", lockingStrategy = FRAMEWORK_PESSIMISTIC)
 public class WorkbenchEditorTest27 {
 
     @WorkbenchPartView

--- a/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/WorkbenchEditorTest8.java
+++ b/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/WorkbenchEditorTest8.java
@@ -15,7 +15,7 @@ import org.uberfire.lifecycle.OnMayClose;
 import org.uberfire.lifecycle.OnOpen;
 import org.uberfire.lifecycle.OnStartup;
 
-@WorkbenchEditor(identifier = "test8", supportedTypes = { MyTestType.class }, lockingStrategy = LockingStrategy.OPTIMISTIC)
+@WorkbenchEditor(identifier = "test8", supportedTypes = { MyTestType.class }, lockingStrategy = LockingStrategy.EDITOR_PROVIDED)
 public class WorkbenchEditorTest8 {
 
     @WorkbenchPartView

--- a/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/WorkbenchEditorTest27.expected
+++ b/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/WorkbenchEditorTest27.expected
@@ -86,7 +86,7 @@ public class WorkbenchEditorTest27Activity extends AbstractWorkbenchEditorActivi
 
     @Override
     public LockingStrategy getLockingStrategy() {
-        return PESSIMISTIC;
+        return FRAMEWORK_PESSIMISTIC;
     }
     
     @Override

--- a/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/WorkbenchEditorTest8.expected
+++ b/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/WorkbenchEditorTest8.expected
@@ -127,7 +127,7 @@ public class WorkbenchEditorTest8Activity extends AbstractWorkbenchEditorActivit
 
     @Override
     public LockingStrategy getLockingStrategy() {
-        return OPTIMISTIC;
+        return EDITOR_PROVIDED;
     }
     
     @Override


### PR DESCRIPTION
See https://issues.jboss.org/browse/UF-306

```LockManager``` in ```AbstractWorkbenchEditorActivity``` is only instantiated *if* Uberfire is handling the locking; otherwise locking is left entirely to the editor itself. I also made a few changes to ```LockTarget``` (to support simplified Unit Testing) and related changes.