### PR TITLE
UF-308: UpdatedLockStatusEvent: Include Path parameter.

### DIFF
--- a/uberfire-client-api/src/main/java/org/uberfire/client/mvp/UpdatedLockStatusEvent.java
+++ b/uberfire-client-api/src/main/java/org/uberfire/client/mvp/UpdatedLockStatusEvent.java
@@ -16,23 +16,33 @@
 
 package org.uberfire.client.mvp;
 
+import org.uberfire.backend.vfs.Path;
+
 /**
- * Client-local event to inform UI components of a lock status change. 
+ * Client-local event to inform UI components of a lock status change.
  */
 public class UpdatedLockStatusEvent {
 
+    private final Path file;
     private final boolean locked;
     private final boolean lockedByCurrentUser;
 
-    public UpdatedLockStatusEvent( boolean locked, boolean lockedByCurrentUser ) {
+    public UpdatedLockStatusEvent( final Path file,
+                                   final boolean locked,
+                                   final boolean lockedByCurrentUser ) {
+        this.file = file;
         this.locked = locked;
         this.lockedByCurrentUser = lockedByCurrentUser;
+    }
+
+    public Path getFile() {
+        return file;
     }
 
     public boolean isLocked() {
         return locked;
     }
-    
+
     public boolean isLockedByCurrentUser() {
         return lockedByCurrentUser;
     }

--- a/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/mvp/LockManagerImpl.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/mvp/LockManagerImpl.java
@@ -345,7 +345,8 @@ public class LockManagerImpl implements LockManager {
 
     private void fireUpdatedLockStatusEvent() {
         if ( isVisible() ) {
-            updatedLockStatusEvent.fire( new UpdatedLockStatusEvent( lockInfo.isLocked(),
+            updatedLockStatusEvent.fire( new UpdatedLockStatusEvent( lockInfo.getFile(),
+                                                                     lockInfo.isLocked(),
                                                                      isLockedByCurrentUser() ) );
         }
     }


### PR DESCRIPTION
See https://issues.jboss.org/browse/UF-308

This PR simply adds the ```Path``` associated with the ```UpdatedLockStatusEvent``` so I can disambiguate events relating to different locks.