### PR TITLE
UF-311: PlaceManager: Add the ability to retrieve a collection of PlaceRequests for an open Editor that can handle a ResourceTypeDefinition

### DIFF
--- a/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/test/java/org/uberfire/client/views/pfly/mock/MockPlaceManager.java
+++ b/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/test/java/org/uberfire/client/views/pfly/mock/MockPlaceManager.java
@@ -17,9 +17,9 @@
 package org.uberfire.client.views.pfly.mock;
 
 import java.util.Collection;
-
 import javax.enterprise.inject.Alternative;
 
+import com.google.gwt.user.client.ui.HasWidgets;
 import org.uberfire.backend.vfs.Path;
 import org.uberfire.client.mvp.Activity;
 import org.uberfire.client.mvp.PlaceManager;
@@ -27,137 +27,142 @@ import org.uberfire.client.mvp.PlaceStatus;
 import org.uberfire.client.mvp.SplashScreenActivity;
 import org.uberfire.mvp.Command;
 import org.uberfire.mvp.PlaceRequest;
+import org.uberfire.mvp.impl.PathPlaceRequest;
 import org.uberfire.workbench.model.PanelDefinition;
 import org.uberfire.workbench.model.PartDefinition;
-
-import com.google.gwt.user.client.ui.HasWidgets;
+import org.uberfire.workbench.type.ResourceTypeDefinition;
 
 @Alternative
 public class MockPlaceManager implements PlaceManager {
 
     @Override
     public void goTo( String identifier ) {
-        throw new UnsupportedOperationException("Not implemented.");
+        throw new UnsupportedOperationException( "Not implemented." );
     }
 
     @Override
     public void goTo( PlaceRequest place ) {
-        throw new UnsupportedOperationException("Not implemented.");
+        throw new UnsupportedOperationException( "Not implemented." );
     }
 
     @Override
     public void goTo( Path path ) {
-        throw new UnsupportedOperationException("Not implemented.");
+        throw new UnsupportedOperationException( "Not implemented." );
     }
 
     @Override
     public void goTo( Path path,
                       PlaceRequest place ) {
-        throw new UnsupportedOperationException("Not implemented.");
+        throw new UnsupportedOperationException( "Not implemented." );
     }
 
     @Override
     public void goTo( PartDefinition part,
                       PanelDefinition panel ) {
-        throw new UnsupportedOperationException("Not implemented.");
+        throw new UnsupportedOperationException( "Not implemented." );
     }
 
     @Override
     public void goTo( String identifier,
                       PanelDefinition panel ) {
-        throw new UnsupportedOperationException("Not implemented.");
+        throw new UnsupportedOperationException( "Not implemented." );
     }
 
     @Override
     public void goTo( PlaceRequest place,
                       PanelDefinition panel ) {
-        throw new UnsupportedOperationException("Not implemented.");
+        throw new UnsupportedOperationException( "Not implemented." );
     }
 
     @Override
     public void goTo( Path path,
                       PanelDefinition panel ) {
-        throw new UnsupportedOperationException("Not implemented.");
+        throw new UnsupportedOperationException( "Not implemented." );
     }
 
     @Override
     public void goTo( Path path,
                       PlaceRequest place,
                       PanelDefinition panel ) {
-        throw new UnsupportedOperationException("Not implemented.");
+        throw new UnsupportedOperationException( "Not implemented." );
     }
 
     @Override
     public void goTo( PlaceRequest place,
                       HasWidgets addTo ) {
-        throw new UnsupportedOperationException("Not implemented.");
+        throw new UnsupportedOperationException( "Not implemented." );
     }
 
     @Override
     public Activity getActivity( PlaceRequest place ) {
-        throw new UnsupportedOperationException("Not implemented.");
+        throw new UnsupportedOperationException( "Not implemented." );
     }
 
     @Override
     public PlaceStatus getStatus( String id ) {
-        throw new UnsupportedOperationException("Not implemented.");
+        throw new UnsupportedOperationException( "Not implemented." );
     }
 
     @Override
     public PlaceStatus getStatus( PlaceRequest place ) {
-        throw new UnsupportedOperationException("Not implemented.");
+        throw new UnsupportedOperationException( "Not implemented." );
     }
 
     @Override
     public void closePlace( String id ) {
-        throw new UnsupportedOperationException("Not implemented.");
+        throw new UnsupportedOperationException( "Not implemented." );
     }
 
     @Override
     public void closePlace( PlaceRequest place ) {
-        throw new UnsupportedOperationException("Not implemented.");
+        throw new UnsupportedOperationException( "Not implemented." );
     }
 
     @Override
     public void tryClosePlace( PlaceRequest placeToClose,
                                Command onAfterClose ) {
-        throw new UnsupportedOperationException("Not implemented.");
+        throw new UnsupportedOperationException( "Not implemented." );
     }
 
     @Override
     public void forceClosePlace( String id ) {
-        throw new UnsupportedOperationException("Not implemented.");
+        throw new UnsupportedOperationException( "Not implemented." );
     }
 
     @Override
     public void forceClosePlace( PlaceRequest place ) {
-        throw new UnsupportedOperationException("Not implemented.");
+        throw new UnsupportedOperationException( "Not implemented." );
     }
 
     @Override
     public void closeAllPlaces() {
-        throw new UnsupportedOperationException("Not implemented.");
+        throw new UnsupportedOperationException( "Not implemented." );
     }
 
     @Override
     public void registerOnOpenCallback( PlaceRequest place,
                                         Command command ) {
-        throw new UnsupportedOperationException("Not implemented.");
+        throw new UnsupportedOperationException( "Not implemented." );
     }
 
     @Override
     public void unregisterOnOpenCallback( PlaceRequest place ) {
-        throw new UnsupportedOperationException("Not implemented.");
+        throw new UnsupportedOperationException( "Not implemented." );
     }
 
     @Override
     public void executeOnOpenCallback( PlaceRequest place ) {
-        throw new UnsupportedOperationException("Not implemented.");
+        throw new UnsupportedOperationException( "Not implemented." );
     }
 
     @Override
     public Collection<SplashScreenActivity> getActiveSplashScreens() {
-        throw new UnsupportedOperationException("Not implemented.");
+        throw new UnsupportedOperationException( "Not implemented." );
+    }
+
+    @Override
+    public Collection<PathPlaceRequest> getActivitiesForResourceType( final ResourceTypeDefinition type ) {
+        throw new UnsupportedOperationException( "Not implemented." );
     }
 
 }

--- a/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/mvp/PlaceManager.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/mvp/PlaceManager.java
@@ -18,6 +18,7 @@ package org.uberfire.client.mvp;
 
 import java.util.Collection;
 
+import com.google.gwt.user.client.ui.HasWidgets;
 import org.uberfire.backend.vfs.Path;
 import org.uberfire.client.annotations.WorkbenchEditor;
 import org.uberfire.client.annotations.WorkbenchPerspective;
@@ -26,10 +27,10 @@ import org.uberfire.client.annotations.WorkbenchScreen;
 import org.uberfire.client.util.Layouts;
 import org.uberfire.mvp.Command;
 import org.uberfire.mvp.PlaceRequest;
+import org.uberfire.mvp.impl.PathPlaceRequest;
 import org.uberfire.workbench.model.PanelDefinition;
 import org.uberfire.workbench.model.PartDefinition;
-
-import com.google.gwt.user.client.ui.HasWidgets;
+import org.uberfire.workbench.type.ResourceTypeDefinition;
 
 /**
  * A Workbench-centric abstraction over the browser's history mechanism. Allows the application to initiate navigation
@@ -123,5 +124,15 @@ public interface PlaceManager {
     void executeOnOpenCallback( final PlaceRequest place );
 
     Collection<SplashScreenActivity> getActiveSplashScreens();
+
+    /**
+     * Finds the <i>currently open</i> PlaceRequests for Activities that handle the given ResourceTypeDefinition.
+     *
+     * @param type
+     *            the ResourceTypeDefinition whose activity to search for
+     * @return an unmodifiable collection of PlaceRequests for the <i>currently open</i> WorkbenchEditorActivities that
+     * can handle the ResourceTypeDefinition. Returns an empty collection if no match was found.
+     */
+    Collection<PathPlaceRequest> getActivitiesForResourceType(final ResourceTypeDefinition type);
 
 }

--- a/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/mvp/PlaceManagerImpl.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/mvp/PlaceManagerImpl.java
@@ -57,6 +57,7 @@ import org.uberfire.workbench.model.PartDefinition;
 import org.uberfire.workbench.model.PerspectiveDefinition;
 import org.uberfire.workbench.model.Position;
 import org.uberfire.workbench.model.impl.PartDefinitionImpl;
+import org.uberfire.workbench.type.ResourceTypeDefinition;
 
 import static java.util.Collections.*;
 import static org.uberfire.commons.validation.PortablePreconditions.*;
@@ -532,6 +533,20 @@ public class PlaceManagerImpl
     @Override
     public Collection<SplashScreenActivity> getActiveSplashScreens() {
         return unmodifiableCollection( availableSplashScreens.values() );
+    }
+
+    @Override
+    public Collection<PathPlaceRequest> getActivitiesForResourceType( final ResourceTypeDefinition type ) {
+        final ArrayList<PathPlaceRequest> activities = new ArrayList<>();
+        for ( final PlaceRequest placeRequest : existingWorkbenchActivities.keySet() ) {
+            if ( placeRequest instanceof PathPlaceRequest ) {
+                final PathPlaceRequest ppr = (PathPlaceRequest) placeRequest;
+                if ( type.accept( ppr.getPath() ) ) {
+                    activities.add( ppr );
+                }
+            }
+        }
+        return unmodifiableCollection( activities );
     }
 
     /**

--- a/uberfire-workbench/uberfire-workbench-client/src/test/java/org/uberfire/client/workbench/panels/impl/PlaceManagerTest.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/test/java/org/uberfire/client/workbench/panels/impl/PlaceManagerTest.java
@@ -16,32 +16,15 @@
 
 package org.uberfire.client.workbench.panels.impl;
 
-import static java.util.Collections.singleton;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Matchers.isNull;
-import static org.mockito.Matchers.refEq;
-import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.inOrder;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.reset;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
 import java.lang.annotation.Annotation;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashSet;
-
 import javax.enterprise.context.Dependent;
 import javax.enterprise.event.Event;
 
+import com.google.gwt.event.shared.EventBus;
+import com.google.gwt.user.client.ui.HasWidgets;
 import org.jboss.errai.ioc.client.QualifierUtil;
 import org.jboss.errai.ioc.client.container.IOC;
 import org.jboss.errai.ioc.client.container.SyncBeanManagerImpl;
@@ -91,9 +74,15 @@ import org.uberfire.workbench.model.impl.PanelDefinitionImpl;
 import org.uberfire.workbench.model.impl.PartDefinitionImpl;
 import org.uberfire.workbench.model.impl.PerspectiveDefinitionImpl;
 import org.uberfire.workbench.model.menu.Menus;
+import org.uberfire.workbench.type.ResourceTypeDefinition;
 
-import com.google.gwt.event.shared.EventBus;
-import com.google.gwt.user.client.ui.HasWidgets;
+import static java.util.Collections.*;
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Matchers.isNull;
+import static org.mockito.Matchers.refEq;
+import static org.mockito.Mockito.*;
 
 @RunWith(MockitoJUnitRunner.class)
 public class PlaceManagerTest {
@@ -206,7 +195,7 @@ public class PlaceManagerTest {
             .thenAnswer( new Answer<PanelDefinition>() {
                 @Override
                 public PanelDefinition answer( InvocationOnMock invocation ) throws Throwable {
-                    return (PanelDefinition) invocation.getArguments()[0];
+                    return (PanelDefinition) invocation.getArguments()[ 0 ];
                 }
             } );
     }
@@ -262,23 +251,7 @@ public class PlaceManagerTest {
 
     @Test
     public void testGoToPlaceByPath() throws Exception {
-        class FakePathPlaceRequest extends PathPlaceRequest {
-            final ObservablePath path;
-            FakePathPlaceRequest(ObservablePath path) {
-                this.path = path;
-            }
 
-            @Override
-            public ObservablePath getPath() {
-                return path;
-            }
-
-            @Override
-            public int hashCode() {
-                return 42;
-            }
-        }
-        
         PathPlaceRequest yellowBrickRoad = new FakePathPlaceRequest( mock( ObservablePath.class ) );
         WorkbenchScreenActivity ozActivity = mock( WorkbenchScreenActivity.class );
 
@@ -290,6 +263,23 @@ public class PlaceManagerTest {
 
         // special contract just for path-type place requests (subject to preference)
         verify( yellowBrickRoad.getPath(), never() ).onDelete( any( Command.class ) );
+    }
+
+    class FakePathPlaceRequest extends PathPlaceRequest {
+        final ObservablePath path;
+        FakePathPlaceRequest(ObservablePath path) {
+            this.path = path;
+        }
+
+        @Override
+        public ObservablePath getPath() {
+            return path;
+        }
+
+        @Override
+        public int hashCode() {
+            return 42;
+        }
     }
 
     @Test
@@ -306,7 +296,7 @@ public class PlaceManagerTest {
         verify( activityManager ).destroyActivity( kansasActivity );
         verify( panelManager ).removePartForPlace( kansas );
 
-        assertEquals( PlaceStatus.CLOSE, placeManager.getStatus( kansas ));
+        assertEquals( PlaceStatus.CLOSE, placeManager.getStatus( kansas ) );
         assertNull( placeManager.getActivity( kansas ) );
         assertFalse( placeManager.getActivePlaceRequests().contains( kansas ) );
     }
@@ -365,7 +355,7 @@ public class PlaceManagerTest {
 
         // verify perspective changed to oz
         verify( perspectiveManager ).savePerspectiveState( any( Command.class ) );
-        verify( perspectiveManager ).switchToPerspective( any( PlaceRequest.class ), eq( ozPerspectiveActivity ), any( ParameterizedCommand.class) );
+        verify( perspectiveManager ).switchToPerspective( any( PlaceRequest.class ), eq( ozPerspectiveActivity ), any( ParameterizedCommand.class ) );
         verify( ozPerspectiveActivity ).onOpen();
         assertEquals( PlaceStatus.OPEN, placeManager.getStatus( ozPerspectivePlace ) );
         assertTrue( placeManager.getActivePlaceRequests().contains( ozPerspectivePlace ) );
@@ -446,7 +436,7 @@ public class PlaceManagerTest {
 
         // verify perspective changed to oz
         verify( perspectiveManager ).savePerspectiveState( any( Command.class ) );
-        verify( perspectiveManager ).switchToPerspective( any( PlaceRequest.class ), eq( ozPerspectiveActivity ), any( ParameterizedCommand.class) );
+        verify( perspectiveManager ).switchToPerspective( any( PlaceRequest.class ), eq( ozPerspectiveActivity ), any( ParameterizedCommand.class ) );
         assertEquals( PlaceStatus.OPEN, placeManager.getStatus( ozPerspectivePlace ) );
 
         // verify perspective opened before the activity that launches inside it
@@ -476,7 +466,7 @@ public class PlaceManagerTest {
 
         InOrder inOrder = inOrder( splashScreenActivity, newSplashScreenActiveEvent );
         inOrder.verify( splashScreenActivity ).onOpen();
-        inOrder.verify( newSplashScreenActiveEvent ).fire( any( NewSplashScreenActiveEvent.class) );
+        inOrder.verify( newSplashScreenActiveEvent ).fire( any( NewSplashScreenActiveEvent.class ) );
 
         assertTrue( placeManager.getActiveSplashScreens().contains( splashScreenActivity ) );
 
@@ -560,7 +550,7 @@ public class PlaceManagerTest {
         placeManager.closePlace( oz );
 
         assertTrue( placeManager.getActiveSplashScreens().isEmpty() );
-        verify( lollipopGuildActivity).closeIfOpen();
+        verify( lollipopGuildActivity ).closeIfOpen();
 
         // splash screens are Application Scoped, but we still "destroy" them (activity manager will call their onShutdown)
         verify( activityManager ).destroyActivity( lollipopGuildActivity );
@@ -583,7 +573,7 @@ public class PlaceManagerTest {
 
         verify( splashScreenActivity, never() ).onStartup( eq( somewhere ) );
         verify( splashScreenActivity, never() ).onOpen();
-        verify( newSplashScreenActiveEvent, never() ).fire( any( NewSplashScreenActiveEvent.class) );
+        verify( newSplashScreenActiveEvent, never() ).fire( any( NewSplashScreenActiveEvent.class ) );
         assertFalse( placeManager.getActiveSplashScreens().contains( splashScreenActivity ) );
     }
 
@@ -756,6 +746,62 @@ public class PlaceManagerTest {
         assertTrue( customPanelDef.getParts().isEmpty() );
         verify( panelManager ).removeWorkbenchPanel( customPanelDef );
     }
+
+    @Test
+    public void testGetActivitiesForResourceType_NoMatches() throws Exception {
+        final ObservablePath path = mock( ObservablePath.class );
+        final PathPlaceRequest yellowBrickRoad = new FakePathPlaceRequest( path );
+        final WorkbenchScreenActivity ozActivity = mock( WorkbenchScreenActivity.class );
+
+        when( activityManager.getActivities( yellowBrickRoad ) ).thenReturn( singleton( (Activity) ozActivity ) );
+
+        placeManager.goTo( yellowBrickRoad );
+
+        verifyActivityLaunchSideEffects( yellowBrickRoad,
+                                         ozActivity,
+                                         null );
+
+        final ResourceTypeDefinition resourceType = mock( ResourceTypeDefinition.class );
+        when( resourceType.accept( path ) ).thenReturn( false );
+
+        final Collection<PathPlaceRequest> resolvedActivities = placeManager.getActivitiesForResourceType( resourceType );
+        assertNotNull( resolvedActivities );
+        assertEquals( 0,
+                      resolvedActivities.size() );
+    }
+
+    @Test
+    public void testGetActivitiesForResourceType_Matches() throws Exception {
+        final ObservablePath path = mock( ObservablePath.class );
+        final PathPlaceRequest yellowBrickRoad = new FakePathPlaceRequest( path );
+        final WorkbenchScreenActivity ozActivity = mock( WorkbenchScreenActivity.class );
+
+        when( activityManager.getActivities( yellowBrickRoad ) ).thenReturn( singleton( (Activity) ozActivity ) );
+
+        placeManager.goTo( yellowBrickRoad );
+
+        verifyActivityLaunchSideEffects( yellowBrickRoad,
+                                         ozActivity,
+                                         null );
+
+        final ResourceTypeDefinition resourceType = mock( ResourceTypeDefinition.class );
+        when( resourceType.accept( path ) ).thenReturn( true );
+
+        final Collection<PathPlaceRequest> resolvedActivities = placeManager.getActivitiesForResourceType( resourceType );
+        assertNotNull( resolvedActivities );
+        assertEquals( 1,
+                      resolvedActivities.size() );
+
+        try {
+            resolvedActivities.clear();
+
+            fail( "PlaceManager.getActivitiesForResourceType() should return an unmodifiable collection." );
+
+        } catch ( UnsupportedOperationException uoe ) {
+            //This is correct. The result should be an unmodifiable collection
+        }
+    }
+
 
     // TODO test going to an unresolvable/unknown place
 


### PR DESCRIPTION
See https://issues.jboss.org/browse/UF-311

This essentially makes an already public method on ```PlaceManagerImpl``` available on the interface ```PlaceManager``` refining it to filter by ```ResourceTypeDefinition```.