### PR TITLE
Re-use uberfire's ValidationUtils

### DIFF
--- a/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-backend/src/main/java/org/uberfire/ext/editor/commons/backend/validation/ValidationUtils.java
+++ b/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-backend/src/main/java/org/uberfire/ext/editor/commons/backend/validation/ValidationUtils.java
@@ -19,6 +19,8 @@ package org.uberfire.ext.editor.commons.backend.validation;
 import java.io.File;
 import java.io.IOException;
 
+import javax.lang.model.SourceVersion;
+import org.apache.commons.lang3.CharUtils;
 import org.apache.commons.lang3.StringUtils;
 
 public class ValidationUtils {
@@ -50,6 +52,25 @@ public class ValidationUtils {
         } catch ( IOException e ) {
             return false;
         }
+    }
 
+    public static boolean isJavaIdentifier( final String value ) {
+        if ( StringUtils.isBlank( value ) ) {
+            return false;
+        }
+        if ( !SourceVersion.isIdentifier( value ) || SourceVersion.isKeyword( value ) ) {
+            return false;
+        }
+        for ( int i = 0; i < value.length(); i++ ) {
+            if ( !CharUtils.isAsciiPrintable( value.charAt( i ) ) ) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    public static boolean isArtifactIdentifier( final String value ) {
+        // See org.apache.maven.model.validation.DefaultModelValidator.java::ID_REGEX
+        return value != null && value.matches( "[A-Za-z0-9_\\-.]+" );
     }
 }

--- a/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-backend/src/test/java/org/uberfire/ext/editor/commons/backend/validation/ValidationUtils_ParameterizedArtifactIdTest.java
+++ b/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-backend/src/test/java/org/uberfire/ext/editor/commons/backend/validation/ValidationUtils_ParameterizedArtifactIdTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.uberfire.ext.editor.commons.backend.validation;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+@RunWith(Parameterized.class)
+public class ValidationUtils_ParameterizedArtifactIdTest {
+
+    @Parameters
+    public static Object[][] data() {
+        return new Object[][]{{null, false},
+                              {"", false},
+                              {" ", false},
+                              {"\n", false},
+                              {"\\", false},
+                              {"/", false},
+                              {"\r", false},
+                              {"\t", false},
+                              {"\"", false},
+                              {"`", false},
+                              {"?", false},
+                              {"*", false},
+                              {"<", false},
+                              {">", false},
+                              {"|", false},
+                              {":", false},
+
+                              {". ", false},
+                              {" .", false},
+                              {"a ", false},
+                              {" z", false},
+                              {"tchao salut", false},
+
+                              {"a\nz", false},
+                              {"a\\z", false},
+                              {"a/z", false},
+                              {"a\rz", false},
+                              {"a\tz", false},
+                              {"a\"z", false},
+                              {"a`z", false},
+                              {"a?z", false},
+                              {"a*z", false},
+                              {"a<z", false},
+                              {"a>z", false},
+                              {"a|z", false},
+                              {"a:z", false},
+
+                              {"Füür.füür.hilfe", false},
+
+                              {".", true},
+                              {"..", true},
+                              {".-.", true},
+
+                              {"a", true},
+                              {"a.z", true},
+                              {"under_score", true},
+                              {"0123456789", true},
+                              {"UPPERCASE", true}};
+    }
+
+    @Parameter(0)
+    public String input;
+    @Parameter(1)
+    public boolean valid;
+
+    @Test
+    public void isArtifactIdentifier() {
+        assertEquals(valid, ValidationUtils.isArtifactIdentifier(input));
+    }
+}

--- a/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-backend/src/test/java/org/uberfire/ext/editor/commons/backend/validation/ValidationUtils_ParameterizedFilenameTest.java
+++ b/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-backend/src/test/java/org/uberfire/ext/editor/commons/backend/validation/ValidationUtils_ParameterizedFilenameTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.uberfire.ext.editor.commons.backend.validation;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+@RunWith(Parameterized.class)
+public class ValidationUtils_ParameterizedFilenameTest {
+
+    @Parameters
+    public static Object[][] data() {
+        return new Object[][]{{null, false},
+                              {"", false},
+                              {" ", false},
+                              {"\n", false},
+                              {"\\", false},
+                              {"/", false},
+                              {"\r", false},
+                              {"\t", false},
+                              {"\"", false},
+                              {"`", false},
+                              {"?", false},
+                              {"*", false},
+                              {"<", false},
+                              {">", false},
+                              {"|", false},
+                              {":", false},
+
+                              {".", false},
+                              {"..", false},
+                              {". ", false},
+                              {" .", false},
+                              {".-.", false},
+
+                              {"a\nz", false},
+                              {"a\\z", false},
+                              {"a/z", false},
+                              {"a\rz", false},
+                              {"a\tz", false},
+                              {"a\"z", false},
+                              {"a`z", false},
+                              {"a?z", false},
+                              {"a*z", false},
+                              {"a<z", false},
+                              {"a>z", false},
+                              {"a|z", false},
+                              {"a:z", false},
+
+                              {"a", true},
+                              {"a ", true},
+                              {" z", true},
+                              {"a.z", true},
+                              {"Füür!füür!hilfe", true},
+                              {"tchao salut", true},
+                              {"under_score", true}};
+    }
+
+    @Parameter(0)
+    public String input;
+    @Parameter(1)
+    public boolean valid;
+
+    @Test
+    public void isValidFileName() {
+        assertEquals(valid, ValidationUtils.isFileName(input));
+    }
+}

--- a/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-backend/src/test/java/org/uberfire/ext/editor/commons/backend/validation/ValidationUtils_ParameterizedJavaIdTest.java
+++ b/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-backend/src/test/java/org/uberfire/ext/editor/commons/backend/validation/ValidationUtils_ParameterizedJavaIdTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 JBoss by Red Hat.
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@ import org.junit.runners.Parameterized.Parameter;
 import org.junit.runners.Parameterized.Parameters;
 
 @RunWith(Parameterized.class)
-public class ValidationUtilsTest {
+public class ValidationUtils_ParameterizedJavaIdTest {
 
     @Parameters
     public static Object[][] data() {
@@ -51,6 +51,7 @@ public class ValidationUtilsTest {
                               {". ", false},
                               {" .", false},
                               {".-.", false},
+                              {"a.z", false},
 
                               {"a\nz", false},
                               {"a\\z", false},
@@ -66,12 +67,28 @@ public class ValidationUtilsTest {
                               {"a|z", false},
                               {"a:z", false},
 
+                              {"a ", false},
+                              {" z", false},
+                              {"tchao salut", false},
+
+                              {"0one", false},
+                              {"dash-y", false},
+                              {"Fire!fire!help", false},
+                              {"Fire,help", false},
+                              {"füür", false},
+                              {"anyone()questionmark", false},
+
+                              {"true", false},
+                              {"==", false},
+                              {"null", false},
+                              {"class", false},
+
+                              {String.valueOf((char) 7), false},
+                              {String.valueOf((char) 127), false},
+
                               {"a", true},
-                              {"a ", true},
-                              {" z", true},
-                              {"a.z", true},
-                              {"Füür!füür!hilfe", true},
-                              {"tchao salut", true},
+                              {"classyAndSuperShinyNewCustomThing", true},
+                              {"Misc2", true},
                               {"under_score", true}};
     }
 
@@ -81,7 +98,7 @@ public class ValidationUtilsTest {
     public boolean valid;
 
     @Test
-    public void isValidFileName() {
-        assertEquals(valid, ValidationUtils.isFileName(input));
+    public void isJavaIdentifier() {
+        assertEquals(valid, ValidationUtils.isJavaIdentifier(input));
     }
 }


### PR DESCRIPTION
3 more PRs to follow (guvnor, kie-wb-common, jbpm-designer)

ValidationUtils class is copied and slightly extended (and then again copied) in other modules/repositories. This PR adds the extended functionality, so that the uberfire copy of the class can be re-used elsewhere (instead of being duplicated).