### PR TITLE
UF-272 PLANNER-579: Reduce WARN messages during startup

### DIFF
--- a/uberfire-backend/uberfire-backend-cdi/src/main/java/org/uberfire/backend/server/cdi/SystemConfigProducer.java
+++ b/uberfire-backend/uberfire-backend-cdi/src/main/java/org/uberfire/backend/server/cdi/SystemConfigProducer.java
@@ -41,6 +41,7 @@ import javax.enterprise.inject.spi.InjectionTarget;
 import javax.enterprise.inject.spi.ProcessAnnotatedType;
 import javax.enterprise.inject.spi.ProcessBean;
 import javax.enterprise.inject.spi.ProcessProducer;
+import javax.enterprise.inject.spi.WithAnnotations;
 import javax.enterprise.util.AnnotationLiteral;
 import javax.inject.Named;
 import javax.inject.Singleton;
@@ -175,10 +176,8 @@ public class SystemConfigProducer implements Extension {
         }
     }
 
-    <T> void processAnnotatedType( @Observes ProcessAnnotatedType<T> pat ) {
-        if ( pat.getAnnotatedType().isAnnotationPresent( Veto.class ) ) {
-            pat.veto();
-        }
+    <T> void processAnnotatedType( @Observes @WithAnnotations( Veto.class ) ProcessAnnotatedType<T> pat ) {
+        pat.veto();
     }
 
     void afterBeanDiscovery( @Observes final AfterBeanDiscovery abd,

--- a/uberfire-extensions/uberfire-widgets/uberfire-widgets-commons/src/main/resources/org/uberfire/ext/widgets/common/client/resources/css/common.css
+++ b/uberfire-extensions/uberfire-widgets/uberfire-widgets-commons/src/main/resources/org/uberfire/ext/widgets/common/client/resources/css/common.css
@@ -205,7 +205,7 @@
     min-height: 100%;
     font-size: 999px;
     text-align: right;
-    filter: alpha(opacity=0);
+    filter: literal("alpha(opacity=0)");
     opacity: 0;
     outline: none;
     background: white;


### PR DESCRIPTION
Fixes warnings when starting OptaPlanner WB in Super Dev Mode

WARN  [org.jboss.weld.Event] WELD-000411: Observer method [BackedAnnotatedMethod] org.uberfire.backend.server.cdi.SystemConfigProducer.processAnnotatedType(@Observes ProcessAnnotatedType<Object>) receives events for all annotated types. Consider restricting events using @WithAnnotations or a generic type with bounds.

         Computing all possible rebind results for 'org.uberfire.ext.widgets.common.client.resources.CommonResources'
            Rebinding org.uberfire.ext.widgets.common.client.resources.CommonResources
                        [WARN] Line 208 column 25: encountered "=". Was expecting one of: "+" "-" "," "/" ")" <STRING> <IDENT> <NUMBER> <URL> <PERCENTAGE> <PT> <MM> <CM> <PC> <IN> <PX> <EMS> <EXS> <DEG> <RAD> <GRAD> <MS> <SECOND> <HZ> <KHZ> <DIMEN> <HASH> <UNICODERANGE> <FUNCTION> 


