### PR TITLE
GUVNOR-2507: Guided Decision Table Editor: Add ability to open multiple decision tables in the same view

### DIFF
--- a/uberfire-client-api/src/main/java/org/uberfire/client/mvp/UberElement.java
+++ b/uberfire-client-api/src/main/java/org/uberfire/client/mvp/UberElement.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.client.mvp;
+
+import org.jboss.errai.common.client.api.IsElement;
+
+/**
+ * Interface to inject a Presenter into a View for MVP-based Element
+ * implementations. Due to limitations with CDI it is not possible to {@code @Inject}
+ * the correct instance of a Presenter into a View.
+ * <p/>
+ * Developers wishing to implement MVP-based Elements are encouraged to have
+ * their View implement this interface if they require access to the appropriate
+ * Presenter.
+ * @param <T> The Presenter type
+ */
+public interface UberElement<T> extends IsElement {
+
+    void init( T presenter );
+}

--- a/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/mvp/LockManagerImpl.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/mvp/LockManagerImpl.java
@@ -346,13 +346,17 @@ public class LockManagerImpl implements LockManager {
         return lockInfo.isLocked();
     }
 
-    private void fireChangeTitleEvent() {
+    protected LockInfo getLockInfo() {
+        return lockInfo;
+    }
+
+    protected void fireChangeTitleEvent() {
         changeTitleEvent.fire( LockTitleWidgetEvent.create( lockTarget,
                                                             lockInfo,
                                                             user ) );
     }
 
-    private void fireUpdatedLockStatusEvent() {
+    protected void fireUpdatedLockStatusEvent() {
         if ( isVisible() ) {
             updatedLockStatusEvent.fire( new UpdatedLockStatusEvent( lockInfo.getFile(),
                                                                      lockInfo.isLocked(),


### PR DESCRIPTION
See https://issues.jboss.org/browse/GUVNOR-2507

This PR adds a ```UberView<P>``` equivalent for use with ```Element``` based Views and allows me to override a couple of bits in ```LockManagerImpl``` in a subclass I have in ```drools-wb``` (where I only want to fire the ```UpdatedLockStatusEvent``` if the lock has changed for the visible/active document - tied to opening multiple decision tables in the same editor).