### PR TITLE
RHBPMS-4014 Tasks fails on load for Chinese localization

### DIFF
--- a/uberfire-extensions/uberfire-widgets/uberfire-widgets-commons/src/main/java/org/uberfire/ext/widgets/common/client/common/DatePicker.java
+++ b/uberfire-extensions/uberfire-widgets/uberfire-widgets-commons/src/main/java/org/uberfire/ext/widgets/common/client/common/DatePicker.java
@@ -106,6 +106,8 @@ public class DatePicker extends Composite
 
     private final org.gwtbootstrap3.extras.datepicker.client.ui.DatePicker datePicker;
 
+    private String localeName;
+
     public DatePicker() {
         this( true );
     }
@@ -126,6 +128,7 @@ public class DatePicker extends Composite
         datePicker.setContainer( RootPanel.get() );
 
         datePicker.setAutoClose( true );
+        setLocaleName();
         setFormat( gwtDateFormat );
 
         //When the popup Date Picker component is hidden assert empty values
@@ -266,34 +269,33 @@ public class DatePicker extends Composite
     public void setFormat( final String gwtDateFormat ) {
         this.gwtDateFormat = gwtDateFormat;
         this.gwtDateTimeFormat = DateTimeFormat.getFormat( this.gwtDateFormat );
-        String currentLang = getLangFromLocale( getLocaleName() );
-        datePicker.setLanguage( DatePickerLanguage.valueOf( currentLang.toUpperCase() ) );
+        if(getLocaleName().equals("")){
+            datePicker.setLanguage(DatePickerLanguage.EN);
+        } else {
+            datePicker.setLanguage(DatePickerLanguage.valueOf(getLocaleName().toUpperCase()));
+        }
         datePicker.setFormat( DatePickerFormatUtilities.convertToBS3DateFormat( gwtDateFormat ) );
     }
 
-    static String getLocaleName() {
-        final LocaleInfo locale = LocaleInfo.getCurrentLocale();
-        final String localeName = locale.getLocaleName();
-        return localeName;
+    public String getLocaleName() {
+        if ( localeName != null && !localeName.isEmpty() && !localeName.equalsIgnoreCase( "default" )) {
+            return localeName;
+        }
+        return "";
     }
 
-    protected String getLangFromLocale( String localeName ) {
-        if ( localeName == null || localeName.isEmpty() ) {
-            return "en";
-        }
-        if ( localeName.equalsIgnoreCase( "default" ) ) {
-            return "en";
-        }
-        String language = localeName.toLowerCase();
-        if ( language.contains( "_" ) ) {
-            language = language.substring( 0,
-                                           language.indexOf( "_" ) );
-        }
-        if ( language.equals( "en" ) ) {
-            return "en";
-        }
-        return language;
+    public void setLocaleName() {
+        localeName = LocaleInfo.getCurrentLocale().getLocaleName();
     }
+
+    public void setLocaleName(String localeName) {
+        if(localeName!=null) {
+            this.localeName = localeName;
+        } else {
+            this.localeName = "";
+        }
+    }
+
 
     @Override
     public void setHighlightToday( final boolean highlightToday ) {

--- a/uberfire-extensions/uberfire-widgets/uberfire-widgets-commons/src/test/java/org/uberfire/ext/widgets/common/client/common/DatePickerTest.java
+++ b/uberfire-extensions/uberfire-widgets/uberfire-widgets-commons/src/test/java/org/uberfire/ext/widgets/common/client/common/DatePickerTest.java
@@ -18,13 +18,10 @@ package org.uberfire.ext.widgets.common.client.common;
 
 import java.util.Date;
 
-import com.google.gwt.core.client.GWT;
 import com.google.gwt.i18n.client.DateTimeFormat;
-import com.google.gwt.i18n.client.LocaleInfo;
 import com.google.gwtmockito.GwtMockitoTestRunner;
 
 import org.gwtbootstrap3.client.ui.TextBox;
-import org.gwtbootstrap3.extras.datepicker.client.ui.base.constants.DatePickerDayOfWeek;
 import org.gwtbootstrap3.extras.datepicker.client.ui.base.constants.DatePickerLanguage;
 import org.junit.Before;
 import org.junit.Test;
@@ -56,6 +53,7 @@ public class DatePickerTest {
         String gwtDateFormat = "dd-MMM-yyyy";
         DateTimeFormat gwtDateTimeFormat = DateTimeFormat.getFormat(gwtDateFormat);
 
+        datePicker.setLocaleName("en");
         datePicker.setFormat( gwtDateFormat);
         verify(datePickerMock).setLanguage(DatePickerLanguage.EN);
         verify(datePickerMock).setFormat(DatePickerFormatUtilities.convertToBS3DateFormat(gwtDateFormat));
@@ -67,6 +65,67 @@ public class DatePickerTest {
         verify(textBox).setValue(gwtDateTimeFormat.format(now));
         when(textBox.getValue()).thenReturn(gwtDateTimeFormat.format(now));
         assertEquals(now, datePicker.getValue());
+
+    }
+    @Test
+    public void testSetDatePickerLang() {
+        datePicker = new DatePicker(datePickerMock);
+        String gwtDateFormat = "dd-MMM-yyyy";
+
+        datePicker.setLocaleName("es");
+        datePicker.setFormat(gwtDateFormat);
+        verify(datePickerMock).setLanguage(DatePickerLanguage.ES);
+
+        datePicker.setLocaleName("fr");
+        datePicker.setFormat(gwtDateFormat);
+        verify(datePickerMock).setLanguage(DatePickerLanguage.FR);
+
+        datePicker.setLocaleName("ja");
+        datePicker.setFormat(gwtDateFormat);
+        verify(datePickerMock).setLanguage(DatePickerLanguage.JA);
+
+        datePicker.setLocaleName("pt_BR");
+        datePicker.setFormat(gwtDateFormat);
+        verify(datePickerMock).setLanguage(DatePickerLanguage.PT_BR);
+
+        datePicker.setLocaleName("zh_CN");
+        datePicker.setFormat(gwtDateFormat);
+        verify(datePickerMock).setLanguage(DatePickerLanguage.ZH_CN);
+
+        datePicker.setLocaleName("de");
+        datePicker.setFormat(gwtDateFormat);
+        verify(datePickerMock).setLanguage(DatePickerLanguage.DE);
+
+        datePicker.setLocaleName("zh_TW");
+        datePicker.setFormat(gwtDateFormat);
+        verify(datePickerMock).setLanguage(DatePickerLanguage.ZH_TW);
+
+        datePicker.setLocaleName("ru");
+        datePicker.setFormat(gwtDateFormat);
+        verify(datePickerMock).setLanguage(DatePickerLanguage.RU);
+
+        datePicker.setLocaleName("en");
+        datePicker.setFormat(gwtDateFormat);
+        verify(datePickerMock).setLanguage(DatePickerLanguage.EN);
+
+    }
+
+    @Test
+    public void testGetLocaleName() {
+        datePicker = new DatePicker(datePickerMock);
+
+        datePicker.setLocaleName("");
+        assertEquals("", datePicker.getLocaleName());
+
+        datePicker.setLocaleName(null);
+        assertEquals("", datePicker.getLocaleName());
+
+        datePicker.setLocaleName("default");
+        assertEquals("", datePicker.getLocaleName());
+
+        String currentLocale = "testValue";
+        datePicker.setLocaleName(currentLocale);
+        assertEquals(currentLocale, datePicker.getLocaleName());
 
     }
 


### PR DESCRIPTION
@manstis @ederign  can you take a look? I have changed the code to avoid to use  the framework default language String. Only sets the datePicker to DatePickerLanguage.EN when the locale is "default" or it is not defined.