### PR TITLE
GUVNOR-2548: Guided Decision Table Editor: BasicFileMenuBuilderImpl: Support overriding default lock-sync behaviour

### DIFF
--- a/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/main/java/org/uberfire/ext/editor/commons/client/history/SaveButton.java
+++ b/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/main/java/org/uberfire/ext/editor/commons/client/history/SaveButton.java
@@ -18,6 +18,7 @@ package org.uberfire.ext.editor.commons.client.history;
 
 import java.util.Collection;
 
+import com.google.gwt.core.client.GWT;
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.user.client.ui.Widget;
@@ -33,11 +34,12 @@ import org.uberfire.workbench.model.menu.MenuVisitor;
 public class SaveButton
         implements MenuCustom<Widget> {
 
-    private Button button = new Button( CommonConstants.INSTANCE.Save() );
+    private Button button = GWT.create( Button.class );
 
     private Command command;
 
-    public SaveButton( ) {
+    public SaveButton() {
+        button.setText( CommonConstants.INSTANCE.Save() );
         button.addClickHandler( new ClickHandler() {
             @Override
             public void onClick( ClickEvent event ) {

--- a/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/main/java/org/uberfire/ext/editor/commons/client/menu/BasicFileMenuBuilder.java
+++ b/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/main/java/org/uberfire/ext/editor/commons/client/menu/BasicFileMenuBuilder.java
@@ -26,7 +26,7 @@ import org.uberfire.mvp.Command;
 import org.uberfire.workbench.model.menu.MenuItem;
 import org.uberfire.workbench.model.menu.Menus;
 
-public interface BasicFileMenuBuilder {
+public interface BasicFileMenuBuilder extends HasLockSyncMenuStateHelper {
 
     Menus build();
 
@@ -83,8 +83,18 @@ public interface BasicFileMenuBuilder {
 
     BasicFileMenuBuilder addNewTopLevelMenu( final MenuItem menu );
 
+    /**
+     * A provider of Paths, when the {@link Path} needs to be ascertained at runtime at the point of execution.
+     * Normally {@link MenuItem} are associated with a static path that is determined at development time.
+     * However there are occasions when the {@link Path} cannot be determined until the {@link MenuItem}
+     * is invoked for example when multiple paths can be represented by a single menu.
+     */
     interface PathProvider {
 
+        /**
+         * Gets a {@link Path} for which the {@link MenuItem} corresponds.
+         * @return A {@link Path} corresponding to the {@link MenuItem}
+         */
         Path getPath();
 
     }

--- a/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/main/java/org/uberfire/ext/editor/commons/client/menu/HasLockSyncMenuStateHelper.java
+++ b/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/main/java/org/uberfire/ext/editor/commons/client/menu/HasLockSyncMenuStateHelper.java
@@ -1,0 +1,65 @@
+package org.uberfire.ext.editor.commons.client.menu;
+
+import org.uberfire.backend.vfs.Path;
+import org.uberfire.backend.vfs.impl.LockInfo;
+import org.uberfire.workbench.model.menu.MenuItem;
+
+/**
+ * Marker interface for Menu Builders that have lock-sync helpers.
+ */
+public interface HasLockSyncMenuStateHelper {
+
+    /**
+     * Sets a helper for {@link MenuItem}s synchronized with locks state (see {@link LockInfo}. {@link MenuItem}s
+     * considered to be synchronized with lock state are 'Save', 'Delete', 'Rename' and 'Restore'.
+     * @param lockSyncMenuStateHelper Cannot be null.
+     */
+    void setLockSyncMenuStateHelper( final LockSyncMenuStateHelper lockSyncMenuStateHelper );
+
+    /**
+     * Helper to ascertain the enabled state of {@link MenuItem}s synchronized with lock state.
+     */
+    interface LockSyncMenuStateHelper {
+
+        /**
+         * Returns whether {@link MenuItem}s should be enabled or disabled based on the provide lock information.
+         * @param file {@link Path} to which the lock relates.
+         * @param isLocked true if the file is locked.
+         * @param isLockedByCurrentUser true if the file is locked by the current User.
+         * @return
+         */
+        Operation enable( final Path file,
+                          final boolean isLocked,
+                          final boolean isLockedByCurrentUser );
+
+        /**
+         * Possible operations; enable/disable MenuItem or veto any change all together.
+         */
+        enum Operation {
+            ENABLE,
+            DISABLE,
+            VETO
+        }
+
+    }
+
+    /**
+     * Basic implementation that enables {@link MenuItem}s if the file is either not locked; or locked by the current User.
+     */
+    class BasicLockSyncMenuStateHelper implements LockSyncMenuStateHelper {
+
+        @Override
+        public Operation enable( final Path file,
+                                 final boolean isLocked,
+                                 final boolean isLockedByCurrentUser ) {
+            if ( !isLocked ) {
+                return Operation.ENABLE;
+
+            } else if ( isLockedByCurrentUser ) {
+                return Operation.ENABLE;
+            }
+            return Operation.DISABLE;
+        }
+    }
+
+}

--- a/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/test/java/org/uberfire/ext/editor/commons/client/menu/BasicFileMenuBuilderTest.java
+++ b/uberfire-extensions/uberfire-commons-editor/uberfire-commons-editor-client/src/test/java/org/uberfire/ext/editor/commons/client/menu/BasicFileMenuBuilderTest.java
@@ -23,15 +23,19 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.uberfire.backend.vfs.Path;
+import org.uberfire.client.mvp.UpdatedLockStatusEvent;
 import org.uberfire.ext.editor.commons.client.file.CopyPopup;
 import org.uberfire.ext.editor.commons.client.file.CopyPopupView;
 import org.uberfire.ext.editor.commons.client.file.DeletePopup;
 import org.uberfire.ext.editor.commons.client.file.RenamePopup;
+import org.uberfire.ext.editor.commons.client.history.SaveButton;
+import org.uberfire.ext.editor.commons.client.menu.HasLockSyncMenuStateHelper.LockSyncMenuStateHelper.Operation;
 import org.uberfire.ext.editor.commons.client.validation.Validator;
 import org.uberfire.ext.editor.commons.service.support.SupportsCopy;
 import org.uberfire.ext.editor.commons.service.support.SupportsDelete;
 import org.uberfire.ext.editor.commons.service.support.SupportsRename;
 import org.uberfire.mocks.CallerMock;
+import org.uberfire.mvp.Command;
 import org.uberfire.workbench.model.menu.MenuItem;
 import org.uberfire.workbench.model.menu.MenuItemCommand;
 import org.uberfire.workbench.model.menu.Menus;
@@ -75,7 +79,7 @@ public class BasicFileMenuBuilderTest {
     private SupportsCopy copyService;
     private CallerMock<SupportsCopy> copyCaller;
 
-    private BasicFileMenuBuilder builder;
+    private BasicFileMenuBuilderImpl builder;
 
     @Before
     public void setup() {
@@ -159,6 +163,149 @@ public class BasicFileMenuBuilderTest {
 
         verify( provider,
                 times( 1 ) ).getPath();
+    }
+
+    @Test
+    public void menuItemsDisabledWhenLockedByDifferentUser() {
+        builder.addSave( new MockSaveButton() );
+        builder.addRename( mock( Command.class ) );
+        builder.addDelete( mock( Command.class ) );
+
+        final Menus menus = builder.build();
+
+        final UpdatedLockStatusEvent event = new UpdatedLockStatusEvent( mock( Path.class ),
+                                                                         true,
+                                                                         false );
+
+        builder.onEditorLockInfo( event );
+
+        assertMenuItemEnabled( menus.getItems().get( 0 ),
+                               false );
+        assertMenuItemEnabled( menus.getItems().get( 1 ),
+                               false );
+        assertMenuItemEnabled( menus.getItems().get( 2 ),
+                               false );
+    }
+
+    @Test
+    public void menuItemsEnabledWhenNotLocked() {
+        builder.addSave( new MockSaveButton() );
+        builder.addRename( mock( Command.class ) );
+        builder.addDelete( mock( Command.class ) );
+
+        final Menus menus = builder.build();
+
+        final UpdatedLockStatusEvent event = new UpdatedLockStatusEvent( mock( Path.class ),
+                                                                         false,
+                                                                         false );
+
+        builder.onEditorLockInfo( event );
+
+        assertMenuItemEnabled( menus.getItems().get( 0 ),
+                               true );
+        assertMenuItemEnabled( menus.getItems().get( 1 ),
+                               true );
+        assertMenuItemEnabled( menus.getItems().get( 2 ),
+                               true );
+    }
+
+    @Test
+    public void menuItemsEnabledWhenLockedByCurrentUser() {
+        builder.addSave( new MockSaveButton() );
+        builder.addRename( mock( Command.class ) );
+        builder.addDelete( mock( Command.class ) );
+
+        final Menus menus = builder.build();
+
+        final UpdatedLockStatusEvent event = new UpdatedLockStatusEvent( mock( Path.class ),
+                                                                         true,
+                                                                         true );
+
+        builder.onEditorLockInfo( event );
+
+        assertMenuItemEnabled( menus.getItems().get( 0 ),
+                               true );
+        assertMenuItemEnabled( menus.getItems().get( 1 ),
+                               true );
+        assertMenuItemEnabled( menus.getItems().get( 2 ),
+                               true );
+    }
+
+    @Test
+    public void menuItemsDisabledWhenNotLockedWithCustomStateHelper() {
+        builder.addSave( new MockSaveButton() );
+        builder.addRename( mock( Command.class ) );
+        builder.addDelete( mock( Command.class ) );
+        builder.setLockSyncMenuStateHelper( ( final Path file,
+                                              final boolean isLocked,
+                                              final boolean isLockedByCurrentUser ) -> Operation.DISABLE );
+
+        final Menus menus = builder.build();
+
+        //Not locked, MenuItems should normally be enabled however our custom helper forces disable
+        final UpdatedLockStatusEvent event = new UpdatedLockStatusEvent( mock( Path.class ),
+                                                                         false,
+                                                                         false );
+
+        builder.onEditorLockInfo( event );
+
+        assertMenuItemEnabled( menus.getItems().get( 0 ),
+                               false );
+        assertMenuItemEnabled( menus.getItems().get( 1 ),
+                               false );
+        assertMenuItemEnabled( menus.getItems().get( 2 ),
+                               false );
+    }
+
+    @Test
+    public void menuItemsStateChangeVetoedWhenLockedWithCustomStateHelper() {
+        builder.addSave( new MockSaveButton() );
+        builder.addRename( mock( Command.class ) );
+        builder.addDelete( mock( Command.class ) );
+        builder.setLockSyncMenuStateHelper( ( final Path file,
+                                              final boolean isLocked,
+                                              final boolean isLockedByCurrentUser ) -> Operation.VETO );
+
+        final Menus menus = builder.build();
+        menus.getItems().get( 0 ).setEnabled( true );
+        menus.getItems().get( 1 ).setEnabled( true );
+        menus.getItems().get( 2 ).setEnabled( true );
+
+        //Locked, MenuItems should normally be disabled however our custom helper vetos changes
+        final UpdatedLockStatusEvent event = new UpdatedLockStatusEvent( mock( Path.class ),
+                                                                         true,
+                                                                         false );
+
+        builder.onEditorLockInfo( event );
+
+        assertMenuItemEnabled( menus.getItems().get( 0 ),
+                               true );
+        assertMenuItemEnabled( menus.getItems().get( 1 ),
+                               true );
+        assertMenuItemEnabled( menus.getItems().get( 2 ),
+                               true );
+    }
+
+    private void assertMenuItemEnabled( final MenuItem menuItem,
+                                        final boolean enabled ) {
+        assertEquals( enabled,
+                      menuItem.isEnabled() );
+    }
+
+    //The real SaveButton keeps state in the GWT Widget.. override to keep in the Presenter
+    private class MockSaveButton extends SaveButton {
+
+        private boolean enabled;
+
+        @Override
+        public boolean isEnabled() {
+            return this.enabled;
+        }
+
+        @Override
+        public void setEnabled( final boolean enabled ) {
+            this.enabled = enabled;
+        }
     }
 
 }


### PR DESCRIPTION
See https://issues.jboss.org/browse/GUVNOR-2548

This PR delegates the decision as to whether to enable or disable (or veto any change in state) to a helper class. The default implementation retains the current behaviour (I also have a new implementation in ```kie-wb-common``` - see linked PR - that only applies changes to ```MenuItem``` enabled state if change in lock is associated with the "active document".