### PR TITLE
ERRAI-963: Remove errai-js.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -728,12 +728,6 @@
 
       <dependency>
         <groupId>org.jboss.errai</groupId>
-        <artifactId>errai-js</artifactId>
-        <version>${version.org.jboss.errai}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>org.jboss.errai</groupId>
         <artifactId>errai-marshalling</artifactId>
         <version>${version.org.jboss.errai}</version>
       </dependency>

--- a/uberfire-archetype/uberfire-project-archetype/src/main/resources/archetype-resources/__rootArtifactId__-parent-with-dependencies/pom.xml
+++ b/uberfire-archetype/uberfire-project-archetype/src/main/resources/archetype-resources/__rootArtifactId__-parent-with-dependencies/pom.xml
@@ -389,12 +389,6 @@
 
       <dependency>
         <groupId>org.jboss.errai</groupId>
-        <artifactId>errai-js</artifactId>
-        <version>\${version.org.jboss.errai}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>org.jboss.errai</groupId>
         <artifactId>errai-marshalling</artifactId>
         <version>\${version.org.jboss.errai}</version>
       </dependency>


### PR DESCRIPTION
[This issue](https://issues.jboss.org/browse/ERRAI-963) describes why errai-js is being removed. It seems as though it was only ever referenced in Uberfire in dependency management.