### PR TITLE
GUVNOR-2559: Guided Decision Table Editor: Improve appearance (for Red Hat Summit) - Some colour changes and add icon to Linked columns

### DIFF
--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/grid/impl/BaseGridWidgetMouseDoubleClickHandler.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/grid/impl/BaseGridWidgetMouseDoubleClickHandler.java
@@ -66,15 +66,16 @@ public class BaseGridWidgetMouseDoubleClickHandler implements NodeMouseDoubleCli
         if ( !gridWidget.isVisible() ) {
             return;
         }
-        handleHeaderCellDoubleClick( event );
-        handleBodyCellDoubleClick( event );
+        if ( !handleHeaderCellDoubleClick( event ) ) {
+            handleBodyCellDoubleClick( event );
+        }
     }
 
     /**
      * Enters or exits "pinned" mode; where one GridWidget is displayed and is scrollable.
      * @param event
      */
-    void handleHeaderCellDoubleClick( final NodeMouseDoubleClickEvent event ) {
+    boolean handleHeaderCellDoubleClick( final NodeMouseDoubleClickEvent event ) {
         //Convert Canvas co-ordinate to Grid co-ordinate
         final Point2D ap = CoordinateTransformationUtils.convertDOMToGridCoordinate( gridWidget,
                                                                                      new Point2D( event.getX(),
@@ -88,10 +89,10 @@ public class BaseGridWidgetMouseDoubleClickHandler implements NodeMouseDoubleCli
         final double headerMaxY = ( header == null ? renderer.getHeaderHeight() : renderer.getHeaderHeight() + header.getY() );
 
         if ( cx < 0 || cx > gridWidget.getWidth() ) {
-            return;
+            return false;
         }
         if ( cy < headerMinY || cy > headerMaxY ) {
-            return;
+            return false;
         }
 
         if ( !pinnedModeManager.isGridPinned() ) {
@@ -101,6 +102,8 @@ public class BaseGridWidgetMouseDoubleClickHandler implements NodeMouseDoubleCli
         } else {
             pinnedModeManager.exitPinnedMode( () -> {/*Nothing*/} );
         }
+
+        return true;
     }
 
     private double getHeaderRowsYOffset() {
@@ -121,7 +124,7 @@ public class BaseGridWidgetMouseDoubleClickHandler implements NodeMouseDoubleCli
      * @param event
      */
 
-    void handleBodyCellDoubleClick( final NodeMouseDoubleClickEvent event ) {
+    boolean handleBodyCellDoubleClick( final NodeMouseDoubleClickEvent event ) {
         //Convert Canvas co-ordinate to Grid co-ordinate
         final Point2D ap = CoordinateTransformationUtils.convertDOMToGridCoordinate( gridWidget,
                                                                                      new Point2D( event.getX(),
@@ -133,13 +136,13 @@ public class BaseGridWidgetMouseDoubleClickHandler implements NodeMouseDoubleCli
         final double headerMaxY = ( header == null ? renderer.getHeaderHeight() : renderer.getHeaderHeight() + header.getY() );
 
         if ( cx < 0 || cx > gridWidget.getWidth() ) {
-            return;
+            return false;
         }
         if ( cy < headerMaxY || cy > gridWidget.getHeight() ) {
-            return;
+            return false;
         }
         if ( gridModel.getRowCount() == 0 ) {
-            return;
+            return false;
         }
 
         //Get row index
@@ -151,26 +154,26 @@ public class BaseGridWidgetMouseDoubleClickHandler implements NodeMouseDoubleCli
             uiRowIndex++;
         }
         if ( uiRowIndex < 0 || uiRowIndex > gridModel.getRowCount() - 1 ) {
-            return;
+            return false;
         }
 
         //Get column information
         final BaseGridRendererHelper.ColumnInformation ci = rendererHelper.getColumnInformation( cx );
         final GridColumn<?> column = ci.getColumn();
         if ( column == null ) {
-            return;
+            return false;
         }
         final int uiColumnIndex = ci.getUiColumnIndex();
         final List<GridColumn<?>> columns = gridModel.getColumns();
         if ( uiColumnIndex < 0 || uiColumnIndex > columns.size() - 1 ) {
-            return;
+            return false;
         }
         final double offsetX = ci.getOffsetX();
 
         //Get rendering information
         final BaseGridRendererHelper.RenderingInformation renderingInformation = rendererHelper.getRenderingInformation();
         if ( renderingInformation == null ) {
-            return;
+            return false;
         }
 
         final BaseGridRendererHelper.RenderingBlockInformation floatingBlockInformation = renderingInformation.getFloatingBlockInformation();
@@ -200,6 +203,8 @@ public class BaseGridWidgetMouseDoubleClickHandler implements NodeMouseDoubleCli
                                                                                  renderer );
 
         onDoubleClick( context );
+
+        return true;
     }
 
     /**

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/grid/renderers/grids/impl/BaseGridRenderer.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/grid/renderers/grids/impl/BaseGridRenderer.java
@@ -21,6 +21,7 @@ import com.ait.lienzo.client.core.shape.Group;
 import com.ait.lienzo.client.core.shape.Line;
 import com.ait.lienzo.client.core.shape.MultiPath;
 import com.ait.lienzo.client.core.shape.Rectangle;
+import com.ait.lienzo.client.core.shape.Text;
 import com.ait.lienzo.client.core.types.Point2D;
 import com.ait.lienzo.client.core.types.Point2DArray;
 import com.ait.lienzo.client.core.types.Transform;
@@ -44,6 +45,12 @@ public class BaseGridRenderer implements GridRenderer {
     private static final int HEADER_HEIGHT = 64;
 
     private static final int HEADER_ROW_HEIGHT = 32;
+
+    private static final String LINK_FONT_FAMILY = "Glyphicons Halflings";
+
+    private static final double LINK_FONT_SIZE = 10.0;
+
+    private static final String LINK_ICON = "\ue144";
 
     protected GridRendererTheme theme;
 
@@ -254,6 +261,24 @@ public class BaseGridRenderer implements GridRenderer {
                 g.add( headerGroup );
 
                 x = x + columnWidth;
+            }
+        }
+
+        //Linked column icons
+        x = 0;
+        for ( final GridColumn<?> column : visibleBlockColumns ) {
+            if ( column.isVisible() ) {
+                final double w = column.getWidth();
+                if ( column.isLinked() ) {
+                    final Text t = theme.getBodyText()
+                            .setFontFamily( LINK_FONT_FAMILY )
+                            .setFontSize( LINK_FONT_SIZE )
+                            .setText( LINK_ICON )
+                            .setY( headerRowsYOffset + LINK_FONT_SIZE )
+                            .setX( x + w - LINK_FONT_SIZE );
+                    g.add( t );
+                }
+                x = x + w;
             }
         }
 

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/grid/impl/BaseGridWidgetMouseClickHandlerTest.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/grid/impl/BaseGridWidgetMouseClickHandlerTest.java
@@ -148,9 +148,9 @@ public class BaseGridWidgetMouseClickHandlerTest {
         verify( handler,
                 times( 1 ) ).handleHeaderCellClick( any( NodeMouseClickEvent.class ) );
         verify( handler,
-                times( 1 ) ).handleBodyCellClick( any( NodeMouseClickEvent.class ) );
+                never() ).handleBodyCellClick( any( NodeMouseClickEvent.class ) );
         verify( selectionManager,
-                times( 1 ) ).select( eq( gridWidget ) );
+                never() ).select( eq( gridWidget ) );
         verify( selectionManager,
                 times( 1 ) ).selectLinkedColumn( eq( uiLinkedColumn ) );
     }

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/grid/impl/BaseGridWidgetMouseDoubleClickHandlerTest.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/grid/impl/BaseGridWidgetMouseDoubleClickHandlerTest.java
@@ -139,7 +139,7 @@ public class BaseGridWidgetMouseDoubleClickHandlerTest {
         verify( handler,
                 times( 1 ) ).handleHeaderCellDoubleClick( any( NodeMouseDoubleClickEvent.class ) );
         verify( handler,
-                times( 1 ) ).handleBodyCellDoubleClick( any( NodeMouseDoubleClickEvent.class ) );
+                never() ).handleBodyCellDoubleClick( any( NodeMouseDoubleClickEvent.class ) );
         verify( pinnedModeManager,
                 times( 1 ) ).enterPinnedMode( eq( gridWidget ),
                                               any( Command.class ) );
@@ -163,7 +163,7 @@ public class BaseGridWidgetMouseDoubleClickHandlerTest {
         verify( handler,
                 times( 1 ) ).handleHeaderCellDoubleClick( any( NodeMouseDoubleClickEvent.class ) );
         verify( handler,
-                times( 1 ) ).handleBodyCellDoubleClick( any( NodeMouseDoubleClickEvent.class ) );
+                never() ).handleBodyCellDoubleClick( any( NodeMouseDoubleClickEvent.class ) );
         verify( pinnedModeManager,
                 never() ).enterPinnedMode( any( GridWidget.class ),
                                            any( Command.class ) );


### PR DESCRIPTION
Changed some mouse handlers to only try alternative checks if a match was not found by the prior check. There was a problem that selecting a "linked" column (which selects the "linked" grid) also was selecting the grid that contained the column clicked on - because a single "click" was handled twice; once to select the linked grid, and once to select the grid clicked on. Unit Test changes reflect the change in behaviour.