### PR TITLE
squid:S3027 - String function use should be optimized for single characters

### DIFF
--- a/uberfire-server/src/main/java/org/uberfire/server/FileUploadServlet.java
+++ b/uberfire-server/src/main/java/org/uberfire/server/FileUploadServlet.java
@@ -103,7 +103,7 @@ public class FileUploadServlet
 
     private String getExtension( final String originalFileName ) {
         if ( originalFileName.contains( "." ) ) {
-            return "." + originalFileName.substring( originalFileName.lastIndexOf( "." ) + 1 );
+            return "." + originalFileName.substring( originalFileName.lastIndexOf( '.' ) + 1 );
         }
         return "";
     }

--- a/uberfire-server/src/main/java/org/uberfire/server/util/FileServletUtil.java
+++ b/uberfire-server/src/main/java/org/uberfire/server/util/FileServletUtil.java
@@ -25,7 +25,7 @@ public class FileServletUtil {
         if ( path == null ) {
             return null;
         } else {
-            int index = path.lastIndexOf( "/" );
+            int index = path.lastIndexOf( '/' );
             StringBuilder builder = new StringBuilder(  );
             if ( index >= 0 ) {
                 builder.append( path.substring( 0, index + 1 ) );


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S3027 - String function use should be optimized for single characters.
An indexOf or lastIndexOf call with a single letter String can be made more performant by switching to a call with a char argument.

Noncompliant Code Example

`String myStr = "Hello World";`
`// ...`
`int pos = myStr.indexOf("W");  // Noncompliant`
`// ...`
`int otherPos = myStr.lastIndexOf("r"); // Noncompliant`
`// ...`
Compliant Solution

`String myStr = "Hello World";`
`// ...`
`int pos = myStr.indexOf('W'); `
`// ...`
`int otherPos = myStr.lastIndexOf('r');`
`// ...`
Please let me know if you have any questions.
George Kankava