### PR TITLE
squid:S1166 - Exception handlers should preserve the original exception

### DIFF
--- a/uberfire-server/src/main/java/org/uberfire/server/BaseFilteredServlet.java
+++ b/uberfire-server/src/main/java/org/uberfire/server/BaseFilteredServlet.java
@@ -59,7 +59,7 @@ public abstract class BaseFilteredServlet extends HttpServlet {
             try {
                 response.sendError( SC_FORBIDDEN );
             } catch ( Exception ex ) {
-                logger.error( ex.getMessage() );
+                logger.error( ex.getMessage(), ex);
             }
             return false;
         }
@@ -73,7 +73,7 @@ public abstract class BaseFilteredServlet extends HttpServlet {
             try {
                 response.sendError( SC_FORBIDDEN );
             } catch ( Exception ex ) {
-                logger.error( ex.getMessage() );
+                logger.error( ex.getMessage(), ex);
             }
             return false;
         }


### PR DESCRIPTION
This pull request is focused on resolving occurrence of Sonar rule
squid:S1166 - Exception handlers should preserve the original exception.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1166
Please let me know if you have any questions.
George Kankava