### PR TITLE
squid:S1132 - Strings literals should be placed on the left side when checking for equality

### DIFF
--- a/uberfire-commons/src/main/java/org/uberfire/commons/regex/util/AntPathMatcher.java
+++ b/uberfire-commons/src/main/java/org/uberfire/commons/regex/util/AntPathMatcher.java
@@ -104,12 +104,12 @@ public class AntPathMatcher {
             if ( !fullMatch ) {
                 return true;
             }
-            if ( pattIdxStart == pattIdxEnd && pattDirs[ pattIdxStart ].equals( "*" )
+            if ( pattIdxStart == pattIdxEnd && "*".equals( pattDirs[ pattIdxStart ] )
                     && path.endsWith( this.pathSeparator ) ) {
                 return true;
             }
             for ( int i = pattIdxStart; i <= pattIdxEnd; i++ ) {
-                if ( !pattDirs[ i ].equals( "**" ) ) {
+                if ( !"**".equals( pattDirs[ i ] ) ) {
                     return false;
                 }
             }
@@ -125,7 +125,7 @@ public class AntPathMatcher {
         // up to last '**'
         while ( pattIdxStart <= pattIdxEnd && pathIdxStart <= pathIdxEnd ) {
             String patDir = pattDirs[ pattIdxEnd ];
-            if ( patDir.equals( "**" ) ) {
+            if ( "**".equals( patDir ) ) {
                 break;
             }
             if ( !matchStrings( patDir, pathDirs[ pathIdxEnd ] ) ) {
@@ -137,7 +137,7 @@ public class AntPathMatcher {
         if ( pathIdxStart > pathIdxEnd ) {
             // String is exhausted
             for ( int i = pattIdxStart; i <= pattIdxEnd; i++ ) {
-                if ( !pattDirs[ i ].equals( "**" ) ) {
+                if ( !"**".equals( pattDirs[ i ] ) ) {
                     return false;
                 }
             }
@@ -147,7 +147,7 @@ public class AntPathMatcher {
         while ( pattIdxStart != pattIdxEnd && pathIdxStart <= pathIdxEnd ) {
             int patIdxTmp = -1;
             for ( int i = pattIdxStart + 1; i <= pattIdxEnd; i++ ) {
-                if ( pattDirs[ i ].equals( "**" ) ) {
+                if ( "**".equals( pattDirs[ i ] ) ) {
                     patIdxTmp = i;
                     break;
                 }
@@ -185,7 +185,7 @@ public class AntPathMatcher {
         }
 
         for ( int i = pattIdxStart; i <= pattIdxEnd; i++ ) {
-            if ( !pattDirs[ i ].equals( "**" ) ) {
+            if ( !"**".equals( pattDirs[ i ] ) ) {
                 return false;
             }
         }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1132 - Strings literals should be placed on the left side when checking for equality.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1132
Please let me know if you have any questions.
George Kankava