### PR TITLE
squid:S1168 - Empty arrays and collections should be returned instead of null

### DIFF
--- a/uberfire-commons/src/main/java/org/uberfire/commons/regex/util/AntPathMatcher.java
+++ b/uberfire-commons/src/main/java/org/uberfire/commons/regex/util/AntPathMatcher.java
@@ -417,7 +417,7 @@ public class AntPathMatcher {
     public static String[] tokenizeToStringArray( String str,
                                                   String delimiters ) {
         if ( str == null ) {
-            return null;
+            return new String[] {};
         }
         final StringTokenizer st = new StringTokenizer( str, delimiters );
         final List<String> tokens = new ArrayList<String>();


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S1168 - Empty arrays and collections should be returned instead of null.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1168
Please let me know if you have any questions.
George Kankava