### PR TITLE
Multiple code improvements - squid:S1192, squid:S1132, squid:S3027

### DIFF
--- a/uberfire-commons/src/main/java/org/uberfire/commons/regex/util/AntPathMatcher.java
+++ b/uberfire-commons/src/main/java/org/uberfire/commons/regex/util/AntPathMatcher.java
@@ -104,12 +104,12 @@ public class AntPathMatcher {
             if ( !fullMatch ) {
                 return true;
             }
-            if ( pattIdxStart == pattIdxEnd && pattDirs[ pattIdxStart ].equals( "*" )
+            if ( pattIdxStart == pattIdxEnd && "*".equals( pattDirs[ pattIdxStart ] )
                     && path.endsWith( this.pathSeparator ) ) {
                 return true;
             }
             for ( int i = pattIdxStart; i <= pattIdxEnd; i++ ) {
-                if ( !pattDirs[ i ].equals( "**" ) ) {
+                if ( !"**".equals( pattDirs[ i ] ) ) {
                     return false;
                 }
             }
@@ -125,7 +125,7 @@ public class AntPathMatcher {
         // up to last '**'
         while ( pattIdxStart <= pattIdxEnd && pathIdxStart <= pathIdxEnd ) {
             String patDir = pattDirs[ pattIdxEnd ];
-            if ( patDir.equals( "**" ) ) {
+            if ( "**".equals( patDir ) ) {
                 break;
             }
             if ( !matchStrings( patDir, pathDirs[ pathIdxEnd ] ) ) {
@@ -137,7 +137,7 @@ public class AntPathMatcher {
         if ( pathIdxStart > pathIdxEnd ) {
             // String is exhausted
             for ( int i = pattIdxStart; i <= pattIdxEnd; i++ ) {
-                if ( !pattDirs[ i ].equals( "**" ) ) {
+                if ( !"**".equals( pattDirs[ i ] ) ) {
                     return false;
                 }
             }
@@ -147,7 +147,7 @@ public class AntPathMatcher {
         while ( pattIdxStart != pattIdxEnd && pathIdxStart <= pathIdxEnd ) {
             int patIdxTmp = -1;
             for ( int i = pattIdxStart + 1; i <= pattIdxEnd; i++ ) {
-                if ( pattDirs[ i ].equals( "**" ) ) {
+                if ( "**".equals( pattDirs[ i ] ) ) {
                     patIdxTmp = i;
                     break;
                 }
@@ -185,7 +185,7 @@ public class AntPathMatcher {
         }
 
         for ( int i = pattIdxStart; i <= pattIdxEnd; i++ ) {
-            if ( !pattDirs[ i ].equals( "**" ) ) {
+            if ( !"**".equals( pattDirs[ i ] ) ) {
                 return false;
             }
         }

--- a/uberfire-io/src/main/java/org/uberfire/io/regex/AntPathMatcher.java
+++ b/uberfire-io/src/main/java/org/uberfire/io/regex/AntPathMatcher.java
@@ -27,6 +27,8 @@ public final class AntPathMatcher {
 
     private static org.uberfire.commons.regex.util.AntPathMatcher matcher = new org.uberfire.commons.regex.util.AntPathMatcher();
 
+    private static final String PATTERNS = "patterns";
+
     public static boolean filter( final Collection<String> includes,
                                   final Collection<String> excludes,
                                   final Path path ) {
@@ -61,28 +63,28 @@ public final class AntPathMatcher {
 
     public static boolean includes( final Collection<String> patterns,
                                     final Path path ) {
-        checkNotNull( "patterns", patterns );
+        checkNotNull( PATTERNS, patterns );
         checkNotNull( "path", path );
         return matches( patterns, path );
     }
 
     public static boolean includes( final Collection<String> patterns,
                                     final URI uri ) {
-        checkNotNull( "patterns", patterns );
+        checkNotNull( PATTERNS, patterns );
         checkNotNull( "uri", uri );
         return matches( patterns, uri );
     }
 
     public static boolean excludes( final Collection<String> patterns,
                                     final URI uri ) {
-        checkNotNull( "patterns", patterns );
+        checkNotNull( PATTERNS, patterns );
         checkNotNull( "uri", uri );
         return matches( patterns, uri );
     }
 
     public static boolean excludes( final Collection<String> patterns,
                                     final Path path ) {
-        checkNotNull( "patterns", patterns );
+        checkNotNull( PATTERNS, patterns );
         checkNotNull( "path", path );
         return matches( patterns, path );
     }

--- a/uberfire-server/src/main/java/org/uberfire/server/FileUploadServlet.java
+++ b/uberfire-server/src/main/java/org/uberfire/server/FileUploadServlet.java
@@ -103,7 +103,7 @@ public class FileUploadServlet
 
     private String getExtension( final String originalFileName ) {
         if ( originalFileName.contains( "." ) ) {
-            return "." + originalFileName.substring( originalFileName.lastIndexOf( "." ) + 1 );
+            return "." + originalFileName.substring( originalFileName.lastIndexOf( '.' ) + 1 );
         }
         return "";
     }

--- a/uberfire-server/src/main/java/org/uberfire/server/util/FileServletUtil.java
+++ b/uberfire-server/src/main/java/org/uberfire/server/util/FileServletUtil.java
@@ -25,7 +25,7 @@ public class FileServletUtil {
         if ( path == null ) {
             return null;
         } else {
-            int index = path.lastIndexOf( "/" );
+            int index = path.lastIndexOf( '/' );
             StringBuilder builder = new StringBuilder(  );
             if ( index >= 0 ) {
                 builder.append( path.substring( 0, index + 1 ) );


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S1192 - String literals should not be duplicated.
squid:S1132 - Strings literals should be placed on the left side when checking for equality.
squid:S3027 - String function use should be optimized for single characters.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1192
https://dev.eclipse.org/sonar/rules/show/squid:S1132
Please let me know if you have any questions.
George Kankava