### PR TITLE
UF-335: Fix NPE when injected SessionInfo used outside of request, an…

### DIFF
--- a/uberfire-io/src/main/java/org/uberfire/io/impl/AbstractIOService.java
+++ b/uberfire-io/src/main/java/org/uberfire/io/impl/AbstractIOService.java
@@ -16,6 +16,11 @@
 
 package org.uberfire.io.impl;
 
+import static org.uberfire.commons.validation.PortablePreconditions.checkNotNull;
+import static org.uberfire.java.nio.file.StandardOpenOption.CREATE_NEW;
+import static org.uberfire.java.nio.file.StandardOpenOption.TRUNCATE_EXISTING;
+import static org.uberfire.java.nio.file.StandardOpenOption.WRITE;
+
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.InputStream;
@@ -28,6 +33,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -61,8 +67,6 @@ import org.uberfire.java.nio.file.ProviderNotFoundException;
 import org.uberfire.java.nio.file.StandardOpenOption;
 import org.uberfire.java.nio.file.attribute.FileAttribute;
 import org.uberfire.java.nio.file.attribute.FileTime;
-
-import static org.uberfire.java.nio.file.StandardOpenOption.*;
 
 public abstract class AbstractIOService implements IOServiceIdentifiable,
                                                    IOServiceLockable {
@@ -144,7 +148,7 @@ public abstract class AbstractIOService implements IOServiceIdentifiable,
                                           Option[] options ) {
         if ( options != null && options.length == 1 ) {
             for ( FileSystem fs : fss ) {
-                setAttribute( fs.getRootDirectories().iterator().next(), FileSystemState.FILE_SYSTEM_STATE_ATTR, options[ 0 ] );
+                setAttribute( getFirstRootDirectory( fs ), FileSystemState.FILE_SYSTEM_STATE_ATTR, options[ 0 ] );
             }
         }
     }
@@ -203,11 +207,18 @@ public abstract class AbstractIOService implements IOServiceIdentifiable,
     }
 
     private void setBatchModeOn( FileSystem fs ) {
-        Files.setAttribute( fs.getRootDirectories().iterator().next(), FileSystemState.FILE_SYSTEM_STATE_ATTR, FileSystemState.BATCH );
+        Files.setAttribute( getFirstRootDirectory( fs ), FileSystemState.FILE_SYSTEM_STATE_ATTR, FileSystemState.BATCH );
+    }
+
+    private Path getFirstRootDirectory( FileSystem fs ) {
+        checkNotNull( "fs", fs );
+        Iterable<Path> rootDirectories = checkNotNull( "fs.getRootDirectories()", fs.getRootDirectories() );
+        Iterator<Path> iterator = checkNotNull( "fs.getRootDirectories().iterator()", rootDirectories.iterator() );
+        return iterator.next();
     }
 
     void unsetBatchModeOn( FileSystem fs ) {
-        Files.setAttribute( fs.getRootDirectories().iterator().next(), FileSystemState.FILE_SYSTEM_STATE_ATTR, FileSystemState.NORMAL );
+        Files.setAttribute( getFirstRootDirectory( fs ), FileSystemState.FILE_SYSTEM_STATE_ATTR, FileSystemState.NORMAL );
     }
 
     @Override

--- a/uberfire-server/src/main/java/org/uberfire/server/cdi/UberFireGeneralFactory.java
+++ b/uberfire-server/src/main/java/org/uberfire/server/cdi/UberFireGeneralFactory.java
@@ -16,11 +16,13 @@
 
 package org.uberfire.server.cdi;
 
+import static org.jboss.errai.bus.server.api.RpcContext.getMessage;
+import static org.jboss.errai.bus.server.api.RpcContext.getQueueSession;
+
 import javax.enterprise.context.RequestScoped;
 import javax.enterprise.inject.Default;
 import javax.enterprise.inject.Produces;
 
-import org.jboss.errai.bus.server.api.RpcContext;
 import org.jboss.errai.security.shared.service.AuthenticationService;
 import org.uberfire.rpc.SessionInfo;
 import org.uberfire.rpc.impl.SessionInfoImpl;
@@ -31,7 +33,11 @@ public class UberFireGeneralFactory {
     @RequestScoped
     @Default
     public static SessionInfo getSessionInfo(AuthenticationService authenticationService) {
-        return new SessionInfoImpl( RpcContext.getQueueSession().getSessionId(), authenticationService.getUser() );
+        return new SessionInfoImpl( getSessionInfo(), authenticationService.getUser() );
+    }
+
+    private static String getSessionInfo() {
+        return (getMessage() != null && getQueueSession() != null ? getQueueSession().getSessionId() : null );
     }
 
 }


### PR DESCRIPTION
…d check for non-null filesystems in AbstractIOService.

This is a partial for UF-335. See the [issue](https://issues.jboss.org/browse/UF-335) comments for details.