### PR TITLE
Revert "upgraded jboss-ip-bom to 6.0.7.Final (#402)"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <groupId>org.jboss.integration-platform</groupId>
     <artifactId>jboss-integration-platform-parent</artifactId>
     <!-- Keep in sync with property <version.org.jboss.integration-platform> in uberfire-parent-with-dependencies -->
-    <version>6.0.7.Final</version>
+    <version>6.0.6.Final</version>
   </parent>
 
   <groupId>org.uberfire</groupId>

--- a/uberfire-parent-with-dependencies/pom.xml
+++ b/uberfire-parent-with-dependencies/pom.xml
@@ -38,7 +38,7 @@
     <!-- External dependency versions -->
     <!-- ################################################################################ -->
     <!-- Keep in sync with <parent>'s <version> in uberfire-parent-metadata -->
-    <version.org.jboss.integration-platform>6.0.7.Final</version.org.jboss.integration-platform>
+    <version.org.jboss.integration-platform>6.0.6.Final</version.org.jboss.integration-platform>
 
     <version.com.allen-sauer.gwt.dnd>3.3.3</version.com.allen-sauer.gwt.dnd>
     <version.com.thoughtworks.xstream>1.4.9</version.com.thoughtworks.xstream>


### PR DESCRIPTION
This reverts commit 879b5c40d7b576af053463da132e741053267dd0.
As ip-bom 6.0.7.Final contains an upgrade to <version.com.thoughtworks.xstream>1.4.9 and this 
contains Java 8 (*non*-backwards compatibile) code, which causes Webpshere to prevent the BPMS
webservice from deploying we have to revert this.