### PR TITLE
added new Zanata 1.0.0 project

### DIFF
--- a/src/main/config/zanata.xml
+++ b/src/main/config/zanata.xml
@@ -3,7 +3,7 @@
 <config xmlns="http://zanata.org/namespace/config/">
   <url>https://translate.jboss.org/</url>
   <project>uberfire</project>
-  <project-version>0.9.0</project-version>
+  <project-version>1.0.0</project-version>
   <project-type>utf8properties</project-type>
 
   <locales>


### PR DESCRIPTION
Created on Zanata a new project 1.0.0 (copied from the existing Zanata project 0.9.0).
Master branch should point to this new project.
The existing 0.9.0 project will be removed. New 0.9.0 Zanata projects (uberfire and uberfire-extensions) will be created based on Zanata projects 0.8.0.
The new uberfire and uberfire-extensions branches 0.9.x (will be branch tomorrow) will point to the new Zanata projects 0.9.0.