### PR TITLE
NamedPosition should be handled as a Position (instead of a CompassPosition)

### DIFF
--- a/uberfire-api/src/main/java/org/uberfire/workbench/model/CompassPosition.java
+++ b/uberfire-api/src/main/java/org/uberfire/workbench/model/CompassPosition.java
@@ -15,9 +15,8 @@
  */
 package org.uberfire.workbench.model;
 
-import org.jboss.errai.common.client.api.annotations.Portable;
-
 import jsinterop.annotations.JsType;
+import org.jboss.errai.common.client.api.annotations.Portable;
 
 /**
  * Positions to which a WorkbenchPanel can be added to the Workbench
@@ -33,5 +32,10 @@ public enum CompassPosition implements Position {
     WEST, //West internal edge of a Parent panel
     SELF, //Add to the Parent panel
     ROOT, //Add to the Workbench root
-    CENTER // Add to the panel center
+    CENTER; // Add to the panel center
+
+    @Override
+    public String getName() {
+        return name();
+    }
 }

--- a/uberfire-api/src/main/java/org/uberfire/workbench/model/NamedPosition.java
+++ b/uberfire-api/src/main/java/org/uberfire/workbench/model/NamedPosition.java
@@ -55,7 +55,8 @@ public class NamedPosition implements Position {
      * 
      * @return a non-null string. For the special {@link #ROOT} position constant, this is the empty string.
      */
-    public String getFieldName() {
+    @Override
+    public String getName() {
         return fieldName;
     }
 
@@ -83,5 +84,4 @@ public class NamedPosition implements Position {
             return false;
         return true;
     }
-
 }

--- a/uberfire-api/src/main/java/org/uberfire/workbench/model/Position.java
+++ b/uberfire-api/src/main/java/org/uberfire/workbench/model/Position.java
@@ -15,9 +15,8 @@
  */
 package org.uberfire.workbench.model;
 
-import org.jboss.errai.common.client.api.annotations.Portable;
-
 import jsinterop.annotations.JsType;
+import org.jboss.errai.common.client.api.annotations.Portable;
 
 /**
  * Tells a PanelManager implementation where to place a part within a panel. Each PanelManager has its own layout
@@ -28,4 +27,6 @@ import jsinterop.annotations.JsType;
  */
 @JsType
 public interface Position {
+
+    String getName();
 }

--- a/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/PanelManagerImpl.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/PanelManagerImpl.java
@@ -442,12 +442,11 @@ public class PanelManagerImpl implements PanelManager {
         }
 
         PanelDefinition newPanel;
-        // Position instance could come from a different script so we convert
-        // it to the local type here first in order for == to work.
-        CompassPosition cp = CompassPosition.valueOf( "" + position );
-        if ( cp == CompassPosition.ROOT ) {
+
+        // Position instance could come from a different script so we compare using position.getName
+        if ( CompassPosition.ROOT.getName().equals( position.getName() ) ) {
             newPanel = rootPanelDef;
-        } else if ( cp == CompassPosition.SELF ) {
+        } else if ( CompassPosition.SELF.getName().equals( position.getName() ) ) {
             newPanel = targetPanelPresenter.getDefinition();
         } else {
             String defaultChildType = targetPanelPresenter.getDefaultChildType();
@@ -465,7 +464,7 @@ public class PanelManagerImpl implements PanelManager {
                                                childPanelPresenter );
 
             targetPanelPresenter.addPanel( childPanelPresenter,
-                                           cp );
+                                           position );
             newPanel = childPanel;
         }
 

--- a/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/PerspectiveTest12.expected
+++ b/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/PerspectiveTest12.expected
@@ -79,7 +79,7 @@ public class PerspectiveTest12Activity extends AbstractWorkbenchPerspectiveActiv
 
     @Override
     public HasWidgets resolvePosition( NamedPosition position ) {
-        final String fieldName = position.getFieldName();
+        final String fieldName = position.getName();
         if ( fieldName.equals( "teste" ) ) {
             return realPresenter.teste;
         }

--- a/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/PerspectiveTest13.expected
+++ b/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/PerspectiveTest13.expected
@@ -79,7 +79,7 @@ public class PerspectiveTest13Activity extends AbstractWorkbenchPerspectiveActiv
 
     @Override
     public HasWidgets resolvePosition( NamedPosition position ) {
-        final String fieldName = position.getFieldName();
+        final String fieldName = position.getName();
         if ( fieldName.equals( "teste" ) ) {
             return realPresenter.teste;
         }

--- a/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/PerspectiveTest16.expected
+++ b/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/PerspectiveTest16.expected
@@ -79,7 +79,7 @@ public class PerspectiveTest16Activity extends AbstractWorkbenchPerspectiveActiv
 
     @Override
     public HasWidgets resolvePosition( NamedPosition position ) {
-        final String fieldName = position.getFieldName();
+        final String fieldName = position.getName();
         if ( fieldName.equals( "teste" ) ) {
             return realPresenter.teste;
         }

--- a/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/PerspectiveTest17.expected
+++ b/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/PerspectiveTest17.expected
@@ -79,7 +79,7 @@ public class PerspectiveTest17Activity extends AbstractWorkbenchPerspectiveActiv
 
     @Override
     public HasWidgets resolvePosition( NamedPosition position ) {
-        final String fieldName = position.getFieldName();
+        final String fieldName = position.getName();
         if ( fieldName.equals( "teste1" ) ) {
             return realPresenter.teste1;
         }

--- a/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/PerspectiveTest18.expected
+++ b/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/PerspectiveTest18.expected
@@ -79,7 +79,7 @@ public class PerspectiveTest18Activity extends AbstractWorkbenchPerspectiveActiv
 
     @Override
     public HasWidgets resolvePosition( NamedPosition position ) {
-        final String fieldName = position.getFieldName();
+        final String fieldName = position.getName();
         if ( fieldName.equals( "teste1" ) ) {
             return realPresenter.teste1;
         }

--- a/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/PerspectiveTest19.expected
+++ b/uberfire-workbench/uberfire-workbench-processors-tests/src/test/resources/org/uberfire/annotations/processors/expected/PerspectiveTest19.expected
@@ -79,7 +79,7 @@ public class PerspectiveTest19Activity extends AbstractWorkbenchPerspectiveActiv
 
     @Override
     public HasWidgets resolvePosition( NamedPosition position ) {
-        final String fieldName = position.getFieldName();
+        final String fieldName = position.getName();
         if ( fieldName.equals( "oneParameter" ) ) {
             return realPresenter.oneParameter;
         }

--- a/uberfire-workbench/uberfire-workbench-processors/src/main/resources/org/uberfire/annotations/processors/templates/perspective.ftl
+++ b/uberfire-workbench/uberfire-workbench-processors/src/main/resources/org/uberfire/annotations/processors/templates/perspective.ftl
@@ -175,7 +175,7 @@ public class ${className} extends AbstractWorkbenchPerspectiveActivity<#if isTem
 
     @Override
     public HasWidgets resolvePosition( NamedPosition position ) {
-        final String fieldName = position.getFieldName();
+        final String fieldName = position.getName();
         <#if defaultPanel??>
         if ( fieldName.equals( "${defaultPanel.fieldName}" ) ) {
             return realPresenter.${defaultPanel.fieldName};


### PR DESCRIPTION
[This approach](https://github.com/uberfire/uberfire/blob/b3cc581826e5726cbfd350ab40fa53618b554d57/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/PanelManagerImpl.java#L447) for converting the `position` will fail when it's a `NamedPosition`.

This PR solves the `kie-wb-distributions` tests. :-)