### PR TITLE
RHBRMS-2525: Business-central startup error: jGIT: Cannot run program 'bash'

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,10 @@
     <version.org.apache.tomcat>7.0.61</version.org.apache.tomcat>
     <!-- Version 1.1.0.Final which is coming from ip-bom is not compatible with GWT 2.8.0 -->
     <version.javax.validation>1.0.0.GA</version.javax.validation>
+
+    <!-- JGIT 4.4.1.201607150455-r override can be removed once we use IP BOM which includes https://github.com/jboss-integration/jboss-integration-platform-bom/pull/327 -->
+    <version.org.eclipse.jgit>4.4.1.201607150455-r</version.org.eclipse.jgit>
+
     <version.org.jboss.errai>4.0.0-SNAPSHOT</version.org.jboss.errai>
     <version.org.jboss.keycloak>1.9.0.Final</version.org.jboss.keycloak>
     <version.org.webjars.bower.org.patternfly>3.6.0</version.org.webjars.bower.org.patternfly>


### PR DESCRIPTION
See https://issues.jboss.org/browse/RHBRMS-2525

See also https://github.com/droolsjbpm/droolsjbpm-build-bootstrap/pull/267 for drools/jbpm.

This overrides the version in ip-bom until we move to a version containing jboss-integration/jboss-integration-platform-bom#327