### PR TITLE
GUVNOR-2654: Messages panel not visible

### DIFF
--- a/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/util/Layouts.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/util/Layouts.java
@@ -16,6 +16,7 @@
 
 package org.uberfire.client.util;
 
+import static org.uberfire.plugin.PluginUtil.*;
 import org.uberfire.client.workbench.panels.SplitPanel;
 import org.uberfire.debug.Debug;
 import org.uberfire.workbench.model.CompassPosition;
@@ -200,11 +201,13 @@ public class Layouts {
     }
 
     public static int heightOrDefault( PanelDefinition def ) {
-        return def.getHeight() == null ? DEFAULT_CHILD_SIZE : def.getHeight();
+        Integer height = toInteger( def.getHeightAsInt() );
+        return  height == null ? DEFAULT_CHILD_SIZE : height;
     }
 
     public static int widthOrDefault( PanelDefinition def ) {
-        return def.getWidth() == null ? DEFAULT_CHILD_SIZE : def.getWidth();
+        Integer width = toInteger (def.getWidthAsInt() );
+        return width == null ? DEFAULT_CHILD_SIZE : width;
     }
 
     /**

--- a/uberfire-workbench/uberfire-workbench-client/src/test/java/org/uberfire/client/util/LayoutsTest.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/test/java/org/uberfire/client/util/LayoutsTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.uberfire.client.util;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.when;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.uberfire.workbench.model.PanelDefinition;
+
+import com.google.gwtmockito.GwtMockitoTestRunner;
+
+@RunWith(GwtMockitoTestRunner.class)
+public class LayoutsTest {
+
+    @Mock
+    PanelDefinition panelDef;
+
+    @Test
+    public void widthOrDefault() {
+        when( panelDef.getWidthAsInt() ).thenReturn( 42  );
+        Integer width = Layouts.widthOrDefault( panelDef );
+        
+        assertEquals( 42,
+                      width.intValue() );
+        
+        when( panelDef.getWidthAsInt() ).thenReturn( -1 );
+        width = Layouts.widthOrDefault( panelDef );
+        
+        assertEquals( Layouts.DEFAULT_CHILD_SIZE,
+                      width.intValue() );
+    }
+    
+    @Test
+    public void heightOrDefault() {
+        when( panelDef.getHeightAsInt() ).thenReturn( 42 );
+        Integer height = Layouts.heightOrDefault( panelDef );
+        
+        assertEquals( 42,
+                      height.intValue() );
+        
+        when( panelDef.getHeightAsInt() ).thenReturn( -1 );
+        height = Layouts.heightOrDefault( panelDef );
+        
+        assertEquals( Layouts.DEFAULT_CHILD_SIZE,
+                      height.intValue() );
+    }
+}


### PR DESCRIPTION
@ederign @manstis  can you review/merge this please to fix the QE tests, see: https://issues.jboss.org/browse/GUVNOR-2654

Basically a panel definition could come from an external script, so I should've added this to begin with (see JavaDocs of PluginUtil). In this case (same script) it was just a mismatch of dealing with the default values (null, -1).