### PR TITLE
RHBRMS-120: Business Central's RepositoryEditor view does not reflect the correct Git/SSH port number if they have been changed while starting the server

### DIFF
--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/main/java/org/uberfire/java/nio/fs/jgit/JGitFileSystemProvider.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/main/java/org/uberfire/java/nio/fs/jgit/JGitFileSystemProvider.java
@@ -184,6 +184,7 @@ public class JGitFileSystemProvider implements SecuredFileSystemProvider,
     public static final String REPOSITORIES_CONTAINER_DIR = ".niogit";
     public static final String SSH_FILE_CERT_CONTAINER_DIR = ".security";
 
+    public static final String DEFAULT_HOST_NAME = "localhost";
     public static final String DEFAULT_HOST_ADDR = "127.0.0.1";
     public static final String DAEMON_DEFAULT_ENABLED = "true";
     public static final String DAEMON_DEFAULT_PORT = "9418";
@@ -202,10 +203,12 @@ public class JGitFileSystemProvider implements SecuredFileSystemProvider,
     private boolean daemonEnabled;
     private int daemonPort;
     private String daemonHostAddr;
+    private String daemonHostName;
 
     private boolean sshEnabled;
     private int sshPort;
     private String sshHostAddr;
+    private String sshHostName;
     private File sshFileCertDir;
     private String sshAlgorithm;
     private String sshPassphrase;
@@ -237,9 +240,11 @@ public class JGitFileSystemProvider implements SecuredFileSystemProvider,
         final ConfigProperty bareReposDirProp = config.get( "org.uberfire.nio.git.dir", currentDirectory );
         final ConfigProperty enabledProp = config.get( "org.uberfire.nio.git.daemon.enabled", DAEMON_DEFAULT_ENABLED );
         final ConfigProperty hostProp = config.get( "org.uberfire.nio.git.daemon.host", DEFAULT_HOST_ADDR );
+        final ConfigProperty hostNameProp = config.get( "org.uberfire.nio.git.daemon.hostname", hostProp.isDefault() ? DEFAULT_HOST_NAME : hostProp.getValue() );
         final ConfigProperty portProp = config.get( "org.uberfire.nio.git.daemon.port", DAEMON_DEFAULT_PORT );
         final ConfigProperty sshEnabledProp = config.get( "org.uberfire.nio.git.ssh.enabled", SSH_DEFAULT_ENABLED );
         final ConfigProperty sshHostProp = config.get( "org.uberfire.nio.git.ssh.host", DEFAULT_HOST_ADDR );
+        final ConfigProperty sshHostNameProp = config.get( "org.uberfire.nio.git.ssh.hostname", sshHostProp.isDefault() ? DEFAULT_HOST_NAME : sshHostProp.getValue() );
         final ConfigProperty sshPortProp = config.get( "org.uberfire.nio.git.ssh.port", SSH_DEFAULT_PORT );
         final ConfigProperty sshCertDirProp = config.get( "org.uberfire.nio.git.ssh.cert.dir", currentDirectory );
         final ConfigProperty sshIdleTimeoutProp = config.get( "org.uberfire.nio.git.ssh.idle.timeout", SSH_IDLE_TIMEOUT );
@@ -265,12 +270,14 @@ public class JGitFileSystemProvider implements SecuredFileSystemProvider,
         if ( daemonEnabled ) {
             daemonPort = portProp.getIntValue();
             daemonHostAddr = hostProp.getValue();
+            daemonHostName = hostNameProp.getValue();
         }
 
         sshEnabled = sshEnabledProp.getBooleanValue();
         if ( sshEnabled ) {
             sshPort = sshPortProp.getIntValue();
             sshHostAddr = sshHostProp.getValue();
+            sshHostName = sshHostNameProp.getValue();
             sshFileCertDir = new File( sshCertDirProp.getValue(), SSH_FILE_CERT_CONTAINER_DIR );
             sshAlgorithm = sshAlgorithmProp.getValue();
             sshIdleTimeout = sshIdleTimeoutProp.getValue();
@@ -418,10 +425,10 @@ public class JGitFileSystemProvider implements SecuredFileSystemProvider,
 
         //Setup daemon and service
         if ( daemonEnabled ) {
-            fullHostNames.put( "git", daemonHostAddr + ":" + daemonPort );
+            fullHostNames.put( "git", daemonHostName + ":" + daemonPort );
         }
         if ( sshEnabled ) {
-            fullHostNames.put( "ssh", sshHostAddr + ":" + sshPort );
+            fullHostNames.put( "ssh", sshHostName + ":" + sshPort );
         }
 
         rescanForExistingRepositories();
@@ -547,7 +554,7 @@ public class JGitFileSystemProvider implements SecuredFileSystemProvider,
                                                               put( "fs_id", fs.id() );
                                                               put( "fs_uri", fs.toString() );
                                                           }}
-                                );
+                                                        );
 
                                 clusterService.unlock();
                             }


### PR DESCRIPTION
See https://issues.jboss.org/browse/RHBRMS-120

Further to https://github.com/uberfire/uberfire/pull/486 this PR reinstates the System Properties for SSH and Git Host Names.