### PR TITLE
[0.9.x] RHBRMS-120: Business Central's RepositoryEditor view does not reflect the correct Git/SSH port number if they have been changed while starting the server

### DIFF
--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/main/java/org/uberfire/java/nio/fs/jgit/JGitFileSystemProvider.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/main/java/org/uberfire/java/nio/fs/jgit/JGitFileSystemProvider.java
@@ -203,13 +203,11 @@ public class JGitFileSystemProvider implements SecuredFileSystemProvider,
     private int daemonPort;
     private String daemonHostAddr;
     private String daemonHostName;
-    private int daemonHostPort;
 
     private boolean sshEnabled;
     private int sshPort;
     private String sshHostAddr;
     private String sshHostName;
-    private int sshHostPort;
     private File sshFileCertDir;
     private String sshAlgorithm;
     private String sshPassphrase;
@@ -243,13 +241,11 @@ public class JGitFileSystemProvider implements SecuredFileSystemProvider,
         final ConfigProperty hostProp = config.get( "org.uberfire.nio.git.daemon.host", DEFAULT_HOST_ADDR );
         final ConfigProperty hostNameProp = config.get( "org.uberfire.nio.git.daemon.hostname", hostProp.isDefault() ? DEFAULT_HOST_NAME : hostProp.getValue() );
         final ConfigProperty portProp = config.get( "org.uberfire.nio.git.daemon.port", DAEMON_DEFAULT_PORT );
-        final ConfigProperty hostPortProp = config.get( "org.uberfire.nio.git.daemon.hostport", DAEMON_DEFAULT_PORT );
         final ConfigProperty sshEnabledProp = config.get( "org.uberfire.nio.git.ssh.enabled", SSH_DEFAULT_ENABLED );
         final ConfigProperty sshHostProp = config.get( "org.uberfire.nio.git.ssh.host", DEFAULT_HOST_ADDR );
         final ConfigProperty sshHostNameProp = config.get( "org.uberfire.nio.git.ssh.hostname", sshHostProp.isDefault() ? DEFAULT_HOST_NAME : sshHostProp.getValue() );
         final ConfigProperty sshPortProp = config.get( "org.uberfire.nio.git.ssh.port", SSH_DEFAULT_PORT );
         final ConfigProperty sshCertDirProp = config.get( "org.uberfire.nio.git.ssh.cert.dir", currentDirectory );
-        final ConfigProperty sshHostPortProp = config.get( "org.uberfire.nio.git.ssh.hostport", SSH_DEFAULT_PORT );
         final ConfigProperty sshIdleTimeoutProp = config.get( "org.uberfire.nio.git.ssh.idle.timeout", SSH_IDLE_TIMEOUT );
         final ConfigProperty sshAlgorithmProp = config.get( "org.uberfire.nio.git.ssh.algorithm", SSH_ALGORITHM );
         final ConfigProperty sshPassphraseProp = config.get( "org.uberfire.nio.git.ssh.passphrase", SSH_CERT_PASSPHRASE );
@@ -274,7 +270,6 @@ public class JGitFileSystemProvider implements SecuredFileSystemProvider,
             daemonPort = portProp.getIntValue();
             daemonHostAddr = hostProp.getValue();
             daemonHostName = hostNameProp.getValue();
-            daemonHostPort = hostPortProp.getIntValue();
         }
 
         sshEnabled = sshEnabledProp.getBooleanValue();
@@ -282,7 +277,6 @@ public class JGitFileSystemProvider implements SecuredFileSystemProvider,
             sshPort = sshPortProp.getIntValue();
             sshHostAddr = sshHostProp.getValue();
             sshHostName = sshHostNameProp.getValue();
-            sshHostPort = sshHostPortProp.getIntValue();
             sshFileCertDir = new File( sshCertDirProp.getValue(), SSH_FILE_CERT_CONTAINER_DIR );
             sshAlgorithm = sshAlgorithmProp.getValue();
             sshIdleTimeout = sshIdleTimeoutProp.getValue();
@@ -430,10 +424,10 @@ public class JGitFileSystemProvider implements SecuredFileSystemProvider,
 
         //Setup daemon and service
         if ( daemonEnabled ) {
-            fullHostNames.put( "git", daemonHostName + ":" + daemonHostPort );
+            fullHostNames.put( "git", daemonHostName + ":" + daemonPort );
         }
         if ( sshEnabled ) {
-            fullHostNames.put( "ssh", sshHostName + ":" + sshHostPort );
+            fullHostNames.put( "ssh", sshHostName + ":" + sshPort );
         }
 
         rescanForExistingRepositories();


### PR DESCRIPTION
See https://issues.jboss.org/browse/RHBRMS-120

This is the corollary of https://github.com/uberfire/uberfire/pull/486 and https://github.com/uberfire/uberfire/pull/490 for 0.9.x; merged into a single commit.

(cherry picked from commit 733d5ea010862199f2d734be38e653fb41ffea0e)
(cherry picked from commit c111817f8c42c2eb0538d158caf7ef5435ca8f19)