### PR TITLE
Avoid resizing dock panels if they're not setup yet ( do NOT merge yet, only a possible fix suggested )

### DIFF
--- a/uberfire-extensions/uberfire-simple-docks/uberfire-simple-docks-client/src/main/java/org/uberfire/client/docks/view/bars/DocksExpandedBar.java
+++ b/uberfire-extensions/uberfire-simple-docks/uberfire-simple-docks-client/src/main/java/org/uberfire/client/docks/view/bars/DocksExpandedBar.java
@@ -20,15 +20,9 @@ import com.google.gwt.core.client.GWT;
 import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
-import com.google.gwt.event.logical.shared.ResizeEvent;
-import com.google.gwt.event.logical.shared.ResizeHandler;
 import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiField;
-import com.google.gwt.user.client.ui.Composite;
-import com.google.gwt.user.client.ui.FlowPanel;
-import com.google.gwt.user.client.ui.ProvidesResize;
-import com.google.gwt.user.client.ui.RequiresResize;
-import com.google.gwt.user.client.ui.Widget;
+import com.google.gwt.user.client.ui.*;
 import org.gwtbootstrap3.client.ui.Button;
 import org.gwtbootstrap3.client.ui.ButtonGroup;
 import org.gwtbootstrap3.client.ui.Heading;
@@ -158,18 +152,6 @@ public class DocksExpandedBar
         } );
     }
 
-    protected void resizeTargetPanel() {
-        int height = getOffsetHeight() - titlePanel.getOffsetHeight();
-        int width = getOffsetWidth();
-
-        targetPanel.setSize( width + "px", height + "px" );
-    }
-
-    public void setPanelSize( int width,
-                              int height ) {
-        targetPanel.setPixelSize( width, height );
-    }
-
     public FlowPanel targetPanel() {
         return targetPanel;
     }
@@ -182,4 +164,23 @@ public class DocksExpandedBar
     public UberfireDockPosition getPosition() {
         return position;
     }
+
+    public void setPanelSize( final int width,
+                              final int height ) {
+        targetPanel.setPixelSize( width, height );
+    }
+
+    void resizeTargetPanel() {
+
+        final int height = getOffsetHeight() - ( isTitleSet() ? titlePanel.getOffsetHeight() : 0 );
+        final int width = getOffsetWidth();
+
+        setPanelSize( width, height );
+
+    }
+
+    boolean isTitleSet() {
+        return null != title;
+    }
+
 }

--- a/uberfire-extensions/uberfire-simple-docks/uberfire-simple-docks-client/src/test/java/org/uberfire/client/docks/view/bars/DocksExpandedBarTest.java
+++ b/uberfire-extensions/uberfire-simple-docks/uberfire-simple-docks-client/src/test/java/org/uberfire/client/docks/view/bars/DocksExpandedBarTest.java
@@ -16,6 +16,8 @@
 
 package org.uberfire.client.docks.view.bars;
 
+import com.google.gwt.user.client.ui.FlowPanel;
+import com.google.gwtmockito.GwtMock;
 import com.google.gwtmockito.GwtMockitoTestRunner;
 import org.junit.Before;
 import org.junit.Test;
@@ -29,14 +31,35 @@ public class DocksExpandedBarTest {
 
     private DocksExpandedBar docksExpandedBar;
 
+    @GwtMock
+    FlowPanel titlePanel;
+
     @Before
     public void setup() {
         docksExpandedBar = spy( new DocksExpandedBar( UberfireDockPosition.WEST ) );
+        when( docksExpandedBar.getOffsetHeight() ).thenReturn( 200 );
+        when( docksExpandedBar.getOffsetWidth() ).thenReturn( 200 );
+        when( titlePanel.getOffsetHeight() ).thenReturn( 100 );
     }
 
     @Test
-    public void resizeTest() {
+    public void onResizeTest() {
         docksExpandedBar.onResize();
-        verify( docksExpandedBar ).resizeTargetPanel();
+        verify( docksExpandedBar, times( 1 ) ).resizeTargetPanel();
     }
+
+    @Test
+    public void resizeAfterTitleSetTest() {
+        when( docksExpandedBar.isTitleSet() ).thenReturn( true );
+        docksExpandedBar.resizeTargetPanel();
+        verify( docksExpandedBar, times( 1 ) ).setPanelSize( 200, 100 );
+    }
+
+    @Test
+    public void resizeBeforeTitleSetTest() {
+        when( docksExpandedBar.isTitleSet() ).thenReturn( false );
+        docksExpandedBar.resizeTargetPanel();
+        verify( docksExpandedBar, times( 1 ) ).setPanelSize( 200, 200 );
+    }
+
 }


### PR DESCRIPTION
Hi @ederign , @paulovmr !

As commented today on my IRC, just got back from PTO I tried to run the new designer's showcase (https://github.com/romartin/wirez) and I get a client error that was not present two weeks ago, I had no changes on the project, so not sure if externally something has changed on last weeks or I'm missing something from my side.

The problem is that just after loading the home it appears an error popup saying that "heights  cannot be negative", and trying to get deeper I get a negative value for "height", as you can see  here http://picpaste.com/pics/Screenshot_from_2016-09-06_23-01-53-RZ1IsYlB.1473202154.png

Not sure why yet but the method DocksExpandedBar#onResize  is called by a gwt client scheduler BEFORE the call for DocksExpandedBar#setup, so when trying to resize title is not yet set... 

This PR provides a really quick fix that solves at least my issue, not sure if makes sense at 100%, so what do you think? After this fix all works nice.

Thanks!