### PR TITLE
RHBPMS-4190 : [GSS](6.3.z) Custom changes to pom.xml are being overwritten

### DIFF
--- a/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/mvp/LockManagerImpl.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/mvp/LockManagerImpl.java
@@ -296,9 +296,7 @@ public class LockManagerImpl implements LockManager {
 
     void onResourceUpdated( @Observes ResourceUpdatedEvent res ) {
         if ( lockTarget != null && res.getPath().equals( lockTarget.getPath() ) ) {
-            if ( !res.getSessionInfo().getIdentity().equals( user ) ) {
-                reload();
-            }
+            reload();
             releaseLock();
         }
     }

--- a/uberfire-workbench/uberfire-workbench-client/src/test/java/org/uberfire/client/mvp/LockManagerTest.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/test/java/org/uberfire/client/mvp/LockManagerTest.java
@@ -249,13 +249,17 @@ public class LockManagerTest {
     }
 
     @Test
-    public void reloadEditorOnUpdateFromDifferentUser() {
+    public void reloadEditorOnUpdateFromCurrentUser() {
         lockManager.onResourceUpdated( new ResourceUpdatedEvent( path,
                                                                  "",
                                                                  new SessionInfoImpl( user ) ) );
 
-        assertEquals( 0, reloads );
+        assertEquals( 1, reloads );
 
+    }
+
+    @Test
+    public void reloadEditorOnUpdateFromDifferentUser() {
         lockManager.onResourceUpdated( new ResourceUpdatedEvent( path,
                                                                  "",
                                                                  new SessionInfoImpl( new UserImpl( "differentUser" ) ) ) );


### PR DESCRIPTION
https://issues.jboss.org/browse/RHBPMS-4190

Not sure what the identity check originally protected against. My first subject was that the reload() might reload the active editor, but this does not happen.