### PR TITLE
UF-407: Added support for proxy authentication using http[s].proxyUser

### DIFF
--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/main/java/org/uberfire/java/nio/fs/jgit/util/ProxyAuthenticator.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/main/java/org/uberfire/java/nio/fs/jgit/util/ProxyAuthenticator.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.java.nio.fs.jgit.util;
+
+import java.net.Authenticator;
+import java.net.PasswordAuthentication;
+
+public class ProxyAuthenticator extends Authenticator {
+
+    private final String httpProxyUser;
+    private final String httpProxyPassword;
+    private final String httpsProxyUser;
+    private final String httpsProxyPassword;
+
+    public ProxyAuthenticator( final String httpProxyUser,
+                               final String httpProxyPassword,
+                               final String httpsProxyUser,
+                               final String httpsProxyPassword ) {
+        this.httpProxyUser = httpProxyUser;
+        this.httpProxyPassword = httpProxyPassword;
+        this.httpsProxyUser = httpsProxyUser;
+        this.httpsProxyPassword = httpsProxyPassword;
+    }
+
+    @Override
+    protected PasswordAuthentication getPasswordAuthentication() {
+        if ( getRequestorType() == RequestorType.PROXY ) {
+            final String protocol = getRequestingProtocol();
+
+            if ( protocol.equalsIgnoreCase( "http" ) && ( httpProxyUser != null && httpProxyPassword != null ) ) {
+                return new PasswordAuthentication( httpProxyUser, httpProxyPassword.toCharArray() );
+            } else if ( protocol.equalsIgnoreCase( "https" ) && ( httpsProxyUser != null && httpsProxyPassword != null ) ) {
+                return new PasswordAuthentication( httpsProxyUser, httpsProxyPassword.toCharArray() );
+            }
+        }
+        return super.getPasswordAuthentication();
+    }
+}

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/JGitFileSystemProviderHttpProxyTest.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/JGitFileSystemProviderHttpProxyTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.java.nio.fs.jgit;
+
+import java.net.Authenticator;
+import java.net.InetAddress;
+import java.net.MalformedURLException;
+import java.net.PasswordAuthentication;
+import java.net.URL;
+import java.net.UnknownHostException;
+import java.util.HashMap;
+
+import org.junit.Test;
+
+import static java.net.Authenticator.*;
+import static org.junit.Assert.*;
+
+public class JGitFileSystemProviderHttpProxyTest {
+
+    @Test
+    public void testHttpProxy() throws MalformedURLException, UnknownHostException {
+        final String userName = "user";
+        final String passw = "passwd";
+
+        final JGitFileSystemProvider provider = new JGitFileSystemProvider( new HashMap<String, String>() {{
+            put( "http.proxyUser", "user" );
+            put( "http.proxyPassword", "passwd" );
+            put( "org.uberfire.nio.git.daemon.enabled", "false" );
+            put( "org.uberfire.nio.git.ssh.enabled", "false" );
+        }} );
+
+        final PasswordAuthentication passwdAuth = requestPasswordAuthentication( "localhost",
+                                                                                 InetAddress.getLocalHost(),
+                                                                                 8080,
+                                                                                 "http",
+                                                                                 "xxx",
+                                                                                 "http",
+                                                                                 new URL( "http://localhost" ),
+                                                                                 Authenticator.RequestorType.PROXY );
+
+        assertEquals( userName, passwdAuth.getUserName() );
+        assertEquals( passw, new String( passwdAuth.getPassword() ) );
+
+        provider.dispose();
+    }
+
+    @Test
+    public void testHttpsProxy() throws MalformedURLException, UnknownHostException {
+        final String userName = "user";
+        final String passw = "passwd";
+
+        final JGitFileSystemProvider provider = new JGitFileSystemProvider( new HashMap<String, String>() {{
+            put( "https.proxyUser", "user" );
+            put( "https.proxyPassword", "passwd" );
+            put( "org.uberfire.nio.git.daemon.enabled", "false" );
+            put( "org.uberfire.nio.git.ssh.enabled", "false" );
+        }} );
+
+        final PasswordAuthentication passwdAuth = requestPasswordAuthentication( "localhost",
+                                                                                 InetAddress.getLocalHost(),
+                                                                                 8080,
+                                                                                 "https",
+                                                                                 "xxx",
+                                                                                 "https",
+                                                                                 new URL( "https://localhost" ),
+                                                                                 Authenticator.RequestorType.PROXY );
+
+        assertEquals( userName, passwdAuth.getUserName() );
+        assertEquals( passw, new String( passwdAuth.getPassword() ) );
+
+        provider.dispose();
+    }
+
+    @Test
+    public void testNoProxyInfo() throws MalformedURLException, UnknownHostException {
+        final JGitFileSystemProvider provider = new JGitFileSystemProvider( new HashMap<String, String>() {{
+            put( "org.uberfire.nio.git.daemon.enabled", "false" );
+            put( "org.uberfire.nio.git.ssh.enabled", "false" );
+        }} );
+
+        {
+            final PasswordAuthentication passwdAuth = requestPasswordAuthentication( "localhost",
+                                                                                     InetAddress.getLocalHost(),
+                                                                                     8080,
+                                                                                     "https",
+                                                                                     "xxx",
+                                                                                     "https",
+                                                                                     new URL( "https://localhost" ),
+                                                                                     Authenticator.RequestorType.PROXY );
+
+            assertNull( passwdAuth );
+        }
+
+        {
+            final PasswordAuthentication passwdAuth = requestPasswordAuthentication( "localhost",
+                                                                                     InetAddress.getLocalHost(),
+                                                                                     8080,
+                                                                                     "http",
+                                                                                     "xxx",
+                                                                                     "http",
+                                                                                     new URL( "http://localhost" ),
+                                                                                     Authenticator.RequestorType.PROXY );
+
+            assertNull( passwdAuth );
+        }
+
+        provider.dispose();
+    }
+}


### PR DESCRIPTION
and http[s].proxyPassword