### PR TITLE
RHBPMS-4220: Added RoleRegistry and registered principals that come from Keycloak remote logins as roles.

### DIFF
--- a/uberfire-backend/uberfire-backend-server/pom.xml
+++ b/uberfire-backend/uberfire-backend-server/pom.xml
@@ -60,6 +60,11 @@
       <artifactId>prettytime</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>org.jdom</groupId>
+      <artifactId>jdom</artifactId>
+    </dependency>
+
     <!-- KIE Commons IO -->
     <dependency>
       <groupId>org.uberfire</groupId>

--- a/uberfire-backend/uberfire-backend-server/src/main/java/org/uberfire/backend/server/security/RoleLoader.java
+++ b/uberfire-backend/uberfire-backend-server/src/main/java/org/uberfire/backend/server/security/RoleLoader.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2016 JBoss, by Red Hat, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.backend.server.security;
+
+import org.apache.commons.lang3.StringUtils;
+import org.jdom.Document;
+import org.jdom.Element;
+import org.jdom.input.SAXBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.uberfire.commons.services.cdi.Startup;
+import org.uberfire.commons.services.cdi.StartupType;
+import org.uberfire.mvp.Command;
+
+import javax.annotation.PostConstruct;
+import javax.enterprise.context.ApplicationScoped;
+import java.io.File;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Startup class that read the roles declared in the webapp's web.xml and register them into the {@link RoleRegistry}.
+ */
+@Startup(StartupType.BOOTSTRAP)
+@ApplicationScoped
+public class RoleLoader {
+
+    Logger logger = LoggerFactory.getLogger(RoleLoader.class);
+
+    @PostConstruct
+    public void init() {
+        WebAppListener.registerOnStartupCommand( new Command() {
+            @Override
+            public void execute() {
+                registerRolesFromwWebXml();
+            }
+        } );
+    }
+
+    public void registerRolesFromwWebXml() {
+        try {
+            Set<String> roles = loadRolesFromwWebXml();
+            for (String role : roles) {
+                RoleRegistry.get().registerRole(role);
+            }
+            if (!roles.isEmpty()) {
+                logger.info("Roles registered from web.xml \"" + StringUtils.join(roles.toArray(), ",") + "\"");
+            }
+        }
+        catch (Exception e) {
+            logger.error("Error reading roles from web.xml", e);
+        }
+    }
+
+    protected Set<String> loadRolesFromwWebXml() throws Exception {
+        File webXml = WebAppSettings.get().getFile("WEB-INF/web.xml");
+
+        Set<String> result = new HashSet<String>();
+        SAXBuilder builder = new SAXBuilder();
+        Document doc = builder.build(webXml);
+        Element root = doc.getRootElement();
+
+        // Look for <security-role> declarations.
+        List bundleNodes = root.getChildren("security-role");
+        if (bundleNodes.isEmpty()) {
+            bundleNodes = root.getChildren("security-role", null);
+        }
+        for (Iterator iterator = bundleNodes.iterator(); iterator.hasNext();) {
+            Element el_role = (Element) iterator.next();
+            List ch_role = el_role.getChildren();
+            for (int i = 0; i < ch_role.size(); i++) {
+                Element el_child = (Element) ch_role.get(i);
+                if (el_child.getName().equals("role-name")) {
+                    String name = el_child.getValue().trim();
+                    if (!StringUtils.isBlank(name)) {
+                        result.add(name);
+                    }
+                }
+            }
+        }
+        return result;
+    }
+}

--- a/uberfire-backend/uberfire-backend-server/src/main/java/org/uberfire/backend/server/security/RoleRegistry.java
+++ b/uberfire-backend/uberfire-backend-server/src/main/java/org/uberfire/backend/server/security/RoleRegistry.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2016 JBoss, by Red Hat, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.backend.server.security;
+
+import org.jboss.errai.security.shared.api.Role;
+import org.jboss.errai.security.shared.api.RoleImpl;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * It holds the collection of Role instances that the platform security
+ * services recognize as the application available roles.
+ */
+public class RoleRegistry {
+
+    private Set<Role> roles = new HashSet<Role>();
+
+    private static RoleRegistry instance = null;
+
+    private RoleRegistry() {
+    }
+
+    /**
+     * Returns singleton instance of the registry to be able to register roles
+     */
+    public static RoleRegistry get() {
+        if ( instance == null ) {
+            instance = new RoleRegistry();
+        }
+        return instance;
+    }
+
+    /**
+     * Registers given <code>role</code> into the registry
+     */
+    public void registerRole(String role) {
+        this.roles.add(new RoleImpl(role));
+    }
+
+    /**
+     * Gets a a role instance by its name or null if not found.
+     */
+    public Role getRegisteredRole(String name) {
+        for (Role role : roles) {
+            if (role.getName().equals(name)) {
+                return role;
+            }
+        }
+        return null;
+    }
+
+    /**
+    /**
+     * Returns unmodifiable copy of all reqistered roles
+     */
+    public Set<Role> getRegisteredRoles() {
+        return Collections.unmodifiableSet( this.roles );
+    }
+
+    /**
+     * Clears the registry.
+     */
+    public void clear() {
+        this.roles.clear();
+    }
+}

--- a/uberfire-backend/uberfire-backend-server/src/main/java/org/uberfire/backend/server/security/WebAppListener.java
+++ b/uberfire-backend/uberfire-backend-server/src/main/java/org/uberfire/backend/server/security/WebAppListener.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.backend.server.security;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.uberfire.mvp.Command;
+
+import javax.servlet.ServletContext;
+import javax.servlet.ServletContextEvent;
+import javax.servlet.ServletContextListener;
+import javax.servlet.annotation.WebListener;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * It captures the webapp startup/destroy events and notifies the interested parties.
+ */
+@WebListener
+public class WebAppListener implements ServletContextListener {
+
+    private static final Logger logger = LoggerFactory.getLogger( WebAppListener.class );
+
+    private static List<Command> onStartupCommandList = new ArrayList<Command>();
+    private static List<Command> onDestroyCommandList = new ArrayList<Command>();
+    private static boolean initialized = false;
+    private static boolean destroyed = false;
+
+    @Override
+    public void contextInitialized(ServletContextEvent servletContextEvent) {
+        ServletContext servletContext = servletContextEvent.getServletContext();
+        String rootDir = servletContext.getRealPath("/");
+        setRootDir(rootDir);
+    }
+
+    @Override
+    public void contextDestroyed(ServletContextEvent servletContextEvent) {
+        resetRootDir();
+    }
+
+    public synchronized static void registerOnStartupCommand(Command command) {
+        if (initialized) {
+            command.execute();
+        } else {
+            onStartupCommandList.add(command);
+        }
+    }
+
+    public synchronized static void registerOnDestroyCommand(Command command) {
+        if (destroyed) {
+            command.execute();
+        } else {
+            onDestroyCommandList.add(command);
+        }
+    }
+
+    private synchronized static void setRootDir(String rootDir) {
+        initialized = true;
+        WebAppSettings.get().setRootDir(rootDir);
+        logger.info("Root directory = " + rootDir);
+        notifyCallbacks(onStartupCommandList);
+
+    }
+
+    private synchronized static void resetRootDir() {
+        destroyed = true;
+        WebAppSettings.get().setRootDir(null);
+        notifyCallbacks(onDestroyCommandList);
+    }
+
+    private static void notifyCallbacks(List<Command> commandList) {
+        for (Command command : commandList) {
+            command.execute();
+        }
+    }
+}

--- a/uberfire-backend/uberfire-backend-server/src/main/java/org/uberfire/backend/server/security/WebAppSettings.java
+++ b/uberfire-backend/uberfire-backend-server/src/main/java/org/uberfire/backend/server/security/WebAppSettings.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2016 JBoss, by Red Hat, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.backend.server.security;
+
+import org.apache.commons.lang3.StringUtils;
+
+import java.io.File;
+
+/**
+ * It holds some settings regarding the WebApp execution context like, for instance, the home directory where the
+ * webapp has been deployed.
+ */
+public class WebAppSettings {
+
+    private String rootDir = null;
+    private String separator = File.separator;
+
+    private static WebAppSettings instance = null;
+
+    private WebAppSettings() {
+    }
+
+    public static WebAppSettings get() {
+        if ( instance == null ) {
+            instance = new WebAppSettings();
+        }
+        return instance;
+    }
+
+    /**
+     * Overwrites the webapp's root directory.
+     *
+     * <p>This method is only intended to be called at bootstrap time by the
+     * {@link WebAppListener}. Changing the root directory may cause the webapp to severely fail.</p>
+     */
+    public void setRootDir(String dir) {
+        this.rootDir = dir != null ? dir.trim() : null;
+        if (rootDir != null) {
+            rootDir = formatDirectory(rootDir);
+        }
+    }
+
+    /**
+     * Format a directory according to the file system separator
+     */
+    protected String formatDirectory(String dir) {
+        String result = StringUtils.replace(dir, "\\", separator);
+        result = StringUtils.replace(result, "/", separator);
+
+        // Remove the latest separator
+        if (result.endsWith(separator)) {
+            result = result.substring(0, dir.length() - 1);
+        }
+        return result;
+    }
+
+    /**
+     * Retrieve the webapp's root directory => The directory where the container deploys the WAR content.
+     *
+     * @return An absolute path.
+     */
+    public String getRootDir() {
+        return rootDir;
+    }
+
+    /**
+     * Calculate the absolute path of a directory placed under the the webapp's directory structure.
+     *
+     * @param relativePath The relative path
+     * @return An absolute path
+     */
+    public File getFile( String relativePath ) {
+        if ( null != rootDir ) {
+            File root = new File( rootDir );
+            return new File( root, relativePath );
+        }
+        return null;
+    }
+}

--- a/uberfire-backend/uberfire-backend-server/src/main/java/org/uberfire/backend/server/security/adapter/GroupAdapterAuthorizationSource.java
+++ b/uberfire-backend/uberfire-backend-server/src/main/java/org/uberfire/backend/server/security/adapter/GroupAdapterAuthorizationSource.java
@@ -16,47 +16,159 @@
 
 package org.uberfire.backend.server.security.adapter;
 
-import java.util.HashSet;
-import java.util.List;
-import java.util.ServiceLoader;
-import java.util.Set;
-
-import javax.security.auth.Subject;
-
 import org.jboss.errai.security.shared.api.Group;
+import org.jboss.errai.security.shared.api.GroupImpl;
 import org.jboss.errai.security.shared.api.Role;
 import org.jboss.errai.security.shared.api.RoleImpl;
+import org.uberfire.backend.server.security.RoleRegistry;
 import org.uberfire.security.authz.adapter.GroupsAdapter;
+
+import javax.security.auth.Subject;
+import java.util.*;
 
 public class GroupAdapterAuthorizationSource {
 
     private final ServiceLoader<GroupsAdapter> groupsAdapterServiceLoader = ServiceLoader.load( GroupsAdapter.class );
 
-    public Set<Group> collectGroups(String name) {
+    protected List<String> loadEntitiesFromSubjectAndAdapters( String username,
+                                                          Subject subject,
+                                                          String[] rolePrincipleNames ) {
+        List<String> roles = new ArrayList<String>();
+        try {
 
-        Set<Group> userGroups = new HashSet<Group>();
-        for ( final GroupsAdapter adapter : groupsAdapterServiceLoader ) {
-            final List<Group> groupRoles = adapter.getGroups( name, null );
-            if ( groupRoles != null ) {
-                userGroups.addAll( groupRoles );
+            List<String> principals = collectEntitiesFromSubject( username, subject, rolePrincipleNames );
+            if ( principals != null && !principals.isEmpty() ) {
+                roles.addAll( principals );
             }
-        }
 
-        return userGroups;
+            List<String> principalsFromAdapters = collectEntitiesFromAdapters( username, subject );
+            if (principalsFromAdapters != null && !principalsFromAdapters.isEmpty()) {
+                roles.addAll( principalsFromAdapters );
+            }
+
+        } catch ( Exception e ) {
+            throw new RuntimeException( e );
+        }
+        return roles;
     }
 
-    public Set<Role> collectGroupsAsRoles(String name, final Object subject) {
-
-        Set<Role> userGroups = new HashSet<Role>();
+    protected List<String> collectEntitiesFromAdapters( String username,
+                                                Subject subject ) {
+        Set<String> userGroups = new HashSet<String>();
         for ( final GroupsAdapter adapter : groupsAdapterServiceLoader ) {
-            final List<Group> groupRoles = adapter.getGroups( name, subject );
+            final List<Group> groupRoles = adapter.getGroups( username, subject );
             if ( groupRoles != null ) {
                 for (Group group : groupRoles) {
-                    userGroups.add(new RoleImpl(group.getName()));
+                    userGroups.add( group.getName() );
                 }
             }
         }
 
-        return userGroups;
+        return new LinkedList<String>( userGroups );
     }
+
+    /**
+     * Collects the principals for a given subject.
+     */
+    protected List<String> collectEntitiesFromSubject( String username,
+                                               Subject subject,
+                                               String[] rolePrincipleNames ) {
+        if ( null == subject ) {
+            return null;
+        }
+
+        List<String> roles = new ArrayList<String>();
+        try {
+            Set<java.security.Principal> principals = subject.getPrincipals();
+            if ( principals != null ) {
+                for ( java.security.Principal p : principals ) {
+                    if ( p instanceof java.security.acl.Group ) {
+                        for ( final String rolePrincipleName : rolePrincipleNames ) {
+                            if ( rolePrincipleName.equalsIgnoreCase( p.getName() ) ) {
+                                Enumeration<? extends java.security.Principal> groups = ( ( java.security.acl.Group ) p ).members();
+                                while ( groups.hasMoreElements() ) {
+                                    final java.security.Principal groupPrincipal = groups.nextElement();
+                                    roles.add( groupPrincipal.getName() );
+                                }
+                            }
+                        }
+
+                    } else {
+                        roles.add(p.getName() );
+                    }
+                }
+            }
+        } catch ( Exception e ) {
+            throw new RuntimeException( e );
+        }
+        return roles;
+    }
+
+    /**
+     * For a given collection of principal names, return the Role instances for the ones
+     * that are considered roles, so the ones that exist on the RoleRegistry.
+     */
+    protected List<Role> getRoles( List<String> principals ) {
+
+        if ( null != principals && !principals.isEmpty() ) {
+
+            Set<Role> registeredRoles = RoleRegistry.get().getRegisteredRoles();
+
+            if ( null != registeredRoles && !registeredRoles.isEmpty() ) {
+
+                List<Role> result = new LinkedList<Role>();
+
+                for ( String role : principals ) {
+
+                    if ( null != RoleRegistry.get().getRegisteredRole( role ) ) {
+
+                        result.add( new RoleImpl( role ) );
+
+                    }
+
+                }
+
+                return result;
+
+            }
+
+        }
+
+        return null;
+    }
+
+    /**
+     * For a given collection of principal names, return the Role instances for the ones
+     * that are considered roles, so the ones that exist on the RoleRegistry.
+     */
+    protected List<Group> getGroups( List<String> principals ) {
+
+        if ( null != principals && !principals.isEmpty() ) {
+
+            Set<Role> registeredRoles = RoleRegistry.get().getRegisteredRoles();
+
+            if ( null != registeredRoles && !registeredRoles.isEmpty() ) {
+
+                List<Group> result = new LinkedList<Group>();
+
+                for ( String role : principals ) {
+
+                    if ( null == RoleRegistry.get().getRegisteredRole( role ) ) {
+
+                        result.add( new GroupImpl( role ) );
+
+                    }
+
+                }
+
+                return result;
+
+            }
+
+        }
+
+        return null;
+    }
+
+
 }

--- a/uberfire-backend/uberfire-backend-server/src/test/java/org/uberfire/backend/server/security/JAASAuthenticationServiceTest.java
+++ b/uberfire-backend/uberfire-backend-server/src/test/java/org/uberfire/backend/server/security/JAASAuthenticationServiceTest.java
@@ -1,0 +1,145 @@
+package org.uberfire.backend.server.security;
+
+import org.jboss.errai.security.shared.api.GroupImpl;
+import org.jboss.errai.security.shared.api.RoleImpl;
+import org.jboss.errai.security.shared.api.identity.User;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import javax.security.auth.Subject;
+import javax.security.auth.login.LoginContext;
+import java.security.Principal;
+import java.security.acl.Group;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class JAASAuthenticationServiceTest {
+
+    private JAASAuthenticationService tested;
+
+    @Before
+    public void setup() {
+        tested = spy( new JAASAuthenticationService( JAASAuthenticationService.DEFAULT_DOMAIN ) );
+    }
+
+    @Test
+    public void testNoLogin() throws Exception {
+        assertEquals( User.ANONYMOUS, tested.getUser() );
+    }
+
+    @Test
+    public void testGetAnnonymous() throws Exception {
+        assertFalse( tested.isLoggedIn() );
+    }
+
+    @Test
+    public void testLogin() throws Exception {
+        String username = "user1";
+        String password = "password1";
+        RoleRegistry.get().registerRole( "admin" );
+        RoleRegistry.get().registerRole( "role1" );
+        Set<Principal> principals = mockPrincipals( "admin", "role1", "group1" );
+        Subject subject = new Subject();
+        subject.getPrincipals().addAll( principals );
+        LoginContext loginContext = mock( LoginContext.class );
+        when( loginContext.getSubject() ).thenReturn( subject );
+        doReturn( loginContext ).when( tested ).createLoginContext( anyString(), anyString() );
+
+        User user = tested.login( username, password );
+
+        assertNotNull( user );
+        assertEquals( username, user.getIdentifier() );
+        assertEquals( 2, user.getRoles().size() );
+        assertTrue( user.getRoles().contains( new RoleImpl( "admin" ) ) );
+        assertTrue( user.getRoles().contains( new RoleImpl( "role1" ) ) );
+        assertEquals( 1, user.getGroups().size() );
+        assertTrue( user.getGroups().contains( new GroupImpl( "group1" ) ) );
+    }
+
+    @Test
+    public void testLoginSubjectGroups() throws Exception {
+        String username = "user1";
+        String password = "password1";
+        RoleRegistry.get().registerRole( "admin" );
+        RoleRegistry.get().registerRole( "role1" );
+        Set<Principal> principals = mockPrincipals( "admin", "role1", "group1" );
+        Group aclGroup = mock( Group.class );
+        doReturn( JAASAuthenticationService.DEFAULT_ROLE_PRINCIPLE_NAME ).when( aclGroup ).getName();
+        Set<Principal> aclGroups = mockPrincipals( "g1", "g2" );
+        Enumeration<? extends Principal> aclGroupsEnum = Collections.enumeration( aclGroups );
+        doReturn( aclGroupsEnum ).when( aclGroup ).members();
+        Subject subject = new Subject();
+        subject.getPrincipals().addAll( principals );
+        subject.getPrincipals().add( aclGroup );
+        LoginContext loginContext = mock( LoginContext.class );
+        when( loginContext.getSubject() ).thenReturn( subject );
+        doReturn( loginContext ).when( tested ).createLoginContext( anyString(), anyString() );
+
+        User user = tested.login( username, password );
+
+        assertNotNull( user );
+        assertEquals( username, user.getIdentifier() );
+        assertEquals( 2, user.getRoles().size() );
+        assertTrue( user.getRoles().contains( new RoleImpl( "admin" ) ) );
+        assertTrue( user.getRoles().contains( new RoleImpl( "role1" ) ) );
+        assertEquals( 3, user.getGroups().size() );
+        assertTrue( user.getGroups().contains( new GroupImpl( "group1" ) ) );
+        assertTrue( user.getGroups().contains( new GroupImpl( "g1" ) ) );
+        assertTrue( user.getGroups().contains( new GroupImpl( "g2" ) ) );
+    }
+
+    @Test
+    public void testLoggedIn() throws Exception {
+        String username = "user1";
+        String password = "password1";
+        RoleRegistry.get().registerRole( "admin" );
+        Set<Principal> principals = mockPrincipals( "admin" );
+        Subject subject = new Subject();
+        subject.getPrincipals().addAll( principals );
+        LoginContext loginContext = mock( LoginContext.class );
+        when( loginContext.getSubject() ).thenReturn( subject );
+        doReturn( loginContext ).when( tested ).createLoginContext( anyString(), anyString() );
+
+        tested.login( username, password );
+
+        assertTrue( tested.isLoggedIn() );
+    }
+
+    @Test
+    public void testGetUser() throws Exception {
+        String username = "user1";
+        String password = "password1";
+        RoleRegistry.get().registerRole( "admin" );
+        Set<Principal> principals = mockPrincipals( "admin" );
+        Subject subject = new Subject();
+        subject.getPrincipals().addAll( principals );
+        LoginContext loginContext = mock( LoginContext.class );
+        when( loginContext.getSubject() ).thenReturn( subject );
+        doReturn( loginContext ).when( tested ).createLoginContext( anyString(), anyString() );
+
+        User user = tested.login( username, password );
+        User user1 = tested.getUser();
+
+        assertEquals( user, user1 );
+    }
+
+    private Set<Principal> mockPrincipals( String... names ) {
+        Set<Principal> principals = new HashSet<Principal>();
+        for ( String name : names ) {
+            Principal p1 = mock( Principal.class );
+            when( p1.getName() ).thenReturn( name );
+            principals.add( p1 );
+        }
+        return principals;
+    }
+
+}

--- a/uberfire-backend/uberfire-backend-server/src/test/java/org/uberfire/backend/server/security/RoleLoaderTest.java
+++ b/uberfire-backend/uberfire-backend-server/src/test/java/org/uberfire/backend/server/security/RoleLoaderTest.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.uberfire.backend.server.security;
+
+import org.jboss.errai.security.shared.api.Role;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.net.URL;
+import java.util.Set;
+
+import static org.junit.Assert.*;
+
+public class RoleLoaderTest {
+
+    @Before
+    public void setUp() {
+        URL fileURL = Thread.currentThread().getContextClassLoader().getResource("WEB-INF/classes/security-policy.properties");
+        String homeDir = new File(fileURL.getPath()).getParentFile().getParentFile().getParent();
+        WebAppSettings.get().setRootDir(homeDir);
+        RoleRegistry.get().clear();
+        RoleLoader roleLoader = new RoleLoader();
+        roleLoader.registerRolesFromwWebXml();
+    }
+
+    @Test
+    public void testLoad() {
+        Set<Role> roles = RoleRegistry.get().getRegisteredRoles();
+        assertEquals(roles.size(), 2);
+        assertNotNull(RoleRegistry.get().getRegisteredRole("role1"));
+        assertNotNull(RoleRegistry.get().getRegisteredRole("role2"));
+        assertNull(RoleRegistry.get().getRegisteredRole("empty"));
+    }
+}

--- a/uberfire-backend/uberfire-backend-server/src/test/java/org/uberfire/backend/server/security/WebAppSettingsTest.java
+++ b/uberfire-backend/uberfire-backend-server/src/test/java/org/uberfire/backend/server/security/WebAppSettingsTest.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.uberfire.backend.server.security;
+
+import org.junit.Test;
+
+import java.io.File;
+
+import static org.junit.Assert.assertEquals;
+
+public class WebAppSettingsTest {
+
+    private String slash = File.separator;
+
+    @Test
+    public void testLastSlashIgnored() {
+        WebAppSettings.get().setRootDir("/test/");
+        String homeDir = WebAppSettings.get().getRootDir();
+        assertEquals(homeDir, slash + "test");
+
+        WebAppSettings.get().setRootDir("c:\\test\\");
+        homeDir = WebAppSettings.get().getRootDir();
+        assertEquals(homeDir, "c:" + slash + "test");
+    }
+
+    @Test
+    public void testRelativeDir() {
+        WebAppSettings.get().setRootDir("test");
+        File myFile = WebAppSettings.get().getFile("mydir/myfile");
+        assertEquals(myFile.getPath(), "test" + slash + "mydir" + slash + "myfile" );
+    }
+
+}

--- a/uberfire-backend/uberfire-backend-server/src/test/resources/WEB-INF/web.xml
+++ b/uberfire-backend/uberfire-backend-server/src/test/resources/WEB-INF/web.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2016 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<web-app version="2.5"
+         xmlns="http://java.sun.com/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd">
+
+    <security-role>
+        <description>Role 1</description>
+        <role-name>role1</role-name>
+    </security-role>
+
+    <security-role>
+        <description>Role 2</description>
+        <role-name>role2</role-name>
+    </security-role>
+
+    <security-role>
+        <description>Empty</description>
+        <role-name></role-name>
+    </security-role>
+
+</web-app>


### PR DESCRIPTION
Fixed issue that causing the security principals not being added as roles in the current user instance, so remote login (eg: keycloak) were failing due to authorizations failed, as users had no roles. In order to do this I've backported from master branch the RoleRegistry necessary stuff.

See https://issues.jboss.org/browse/RHBPMS-4220

Please @dgutierr, as commented with you this fix, can you please verify? Thanks!
