### PR TITLE
GUVNOR-2649: Asset search is broken

### DIFF
--- a/uberfire-extensions/uberfire-metadata/uberfire-metadata-backends/uberfire-metadata-backend-lucene/src/main/java/org/uberfire/ext/metadata/backend/lucene/search/LuceneSearchIndex.java
+++ b/uberfire-extensions/uberfire-metadata/uberfire-metadata-backends/uberfire-metadata-backend-lucene/src/main/java/org/uberfire/ext/metadata/backend/lucene/search/LuceneSearchIndex.java
@@ -173,9 +173,9 @@ public class LuceneSearchIndex implements SearchIndex {
                 final Long to = ( (DateRange) entry.getValue() ).before().getTime();
                 query.add( newLongRange( entry.getKey(), from, to, true, true ), MUST );
             } else if ( entry.getValue() instanceof String ) {
-                query.add( new WildcardQuery( new Term( buildTerm( entry.getKey() ), entry.getValue().toString() ) ), MUST );
+                query.add( new WildcardQuery( new Term( entry.getKey(), entry.getValue().toString() ) ), MUST );
             } else if ( entry.getValue() instanceof Boolean ) {
-                query.add( new TermQuery( new Term( buildTerm( entry.getKey() ), ( (Boolean) entry.getValue() ) ? "0" : "1" ) ), MUST );
+                query.add( new TermQuery( new Term( entry.getKey(), ( (Boolean) entry.getValue() ) ? "0" : "1" ) ), MUST );
             }
         }
         return composeQuery( query, clusterSegments );
@@ -195,17 +195,6 @@ public class LuceneSearchIndex implements SearchIndex {
         }
 
         return composeQuery( fullText, clusterSegments );
-    }
-
-    // DublinCoreView has field names containing the "[" and "]" characters.
-    // Lucene reserves use of "[" and "]" and hence we need to escape them in the Term.
-    private String buildTerm( final String term ) {
-        String _term = term;
-        _term = _term.replaceAll( "\\[",
-                                  "\\\\[" );
-        _term = _term.replaceAll( "\\]",
-                                  "\\\\]" );
-        return _term;
     }
 
     private Query composeQuery( final Query query,


### PR DESCRIPTION
See https://issues.jboss.org/browse/GUVNOR-2649

Terms do not seem to require escaping any more.. possibly changed when IP-BOM upgraded the version of Lucene (see https://github.com/jboss-integration/jboss-integration-platform-bom/commit/f5ac8e34052f5d640327515242f41dd2c4dd08ad)