### PR TITLE
RHBPMS-4220: Added RoleRegistry and registered principals that come from Keycloak remote logins as roles.

### DIFF
--- a/uberfire-backend/uberfire-backend-server/src/main/java/org/uberfire/backend/server/security/JAASAuthenticationService.java
+++ b/uberfire-backend/uberfire-backend-server/src/main/java/org/uberfire/backend/server/security/JAASAuthenticationService.java
@@ -19,10 +19,7 @@ package org.uberfire.backend.server.security;
 import java.io.IOException;
 import java.lang.reflect.Method;
 import java.security.acl.Group;
-import java.util.ArrayList;
-import java.util.Enumeration;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Alternative;
 import javax.security.auth.Subject;
@@ -56,7 +53,7 @@ public class JAASAuthenticationService extends GroupAdapterAuthorizationSource i
 
     public static final String DEFAULT_DOMAIN = "ApplicationRealm";
 
-    private static final String DEFAULT_ROLE_PRINCIPLE_NAME = "Roles";
+    static final String DEFAULT_ROLE_PRINCIPLE_NAME = "Roles";
     private final String rolePrincipleName = DEFAULT_ROLE_PRINCIPLE_NAME;
 
     private final ThreadLocal<User> userOnThisThread = new ThreadLocal<User>();
@@ -70,11 +67,13 @@ public class JAASAuthenticationService extends GroupAdapterAuthorizationSource i
     @Override
     public User login( String username, String password ) {
         try {
-            final LoginContext loginContext = new LoginContext( domain, new UsernamePasswordCallbackHandler( username, password ) );
+            final LoginContext loginContext = createLoginContext( username, password );
             loginContext.login();
-            UserImpl user = new UserImpl( username, loadRoles( username, loginContext.getSubject() ) );
+            List<String> principals = loadEntitiesFromSubjectAndAdapters( username, loginContext.getSubject(), new String[] { rolePrincipleName } );
+            Collection<Role> roles = getRoles( principals );
+            Collection<org.jboss.errai.security.shared.api.Group> groups = getGroups( principals );
+            UserImpl user = new UserImpl( username, roles, groups );
             userOnThisThread.set( user );
-
             return user;
         } catch ( final LoginException ex ) {
             throw new FailedAuthenticationException("Failed to authenticate user " + username, ex);
@@ -100,35 +99,8 @@ public class JAASAuthenticationService extends GroupAdapterAuthorizationSource i
         return userOnThisThread.get() != null;
     }
 
-    private List<Role> loadRoles( String username, Subject subject ) {
-        List<Role> roles = new ArrayList<Role>();
-        try {
-            Set<java.security.Principal> principals = subject.getPrincipals();
-
-            if ( principals != null ) {
-                for ( java.security.Principal p : principals ) {
-                    if ( p instanceof Group && rolePrincipleName.equalsIgnoreCase( p.getName() ) ) {
-                        Enumeration<? extends java.security.Principal> groups = ( (Group) p ).members();
-
-                        while ( groups.hasMoreElements() ) {
-                            final java.security.Principal groupPrincipal = groups.nextElement();
-                            roles.add( new RoleImpl( groupPrincipal.getName() ) );
-                        }
-                        break;
-
-                    }
-
-                }
-            }
-
-            Set<Role> rolesFromAdapters = collectGroupsAsRoles(username, subject);
-            if (rolesFromAdapters != null && !rolesFromAdapters.isEmpty()) {
-                roles.addAll(rolesFromAdapters);
-            }
-        } catch ( Exception e ) {
-            throw new RuntimeException( e );
-        }
-        return roles;
+    LoginContext createLoginContext( String username, String password ) throws LoginException {
+        return new LoginContext( domain, new UsernamePasswordCallbackHandler( username, password ) );
     }
 
     class UsernamePasswordCallbackHandler implements CallbackHandler {

--- a/uberfire-backend/uberfire-backend-server/src/test/java/org/uberfire/backend/server/security/JAASAuthenticationServiceTest.java
+++ b/uberfire-backend/uberfire-backend-server/src/test/java/org/uberfire/backend/server/security/JAASAuthenticationServiceTest.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.backend.server.security;
+
+import org.jboss.errai.security.shared.api.GroupImpl;
+import org.jboss.errai.security.shared.api.RoleImpl;
+import org.jboss.errai.security.shared.api.identity.User;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import javax.security.auth.Subject;
+import javax.security.auth.login.LoginContext;
+import java.security.Principal;
+import java.security.acl.Group;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class JAASAuthenticationServiceTest {
+
+    private JAASAuthenticationService tested;
+
+    @Before
+    public void setup() {
+        tested = spy( new JAASAuthenticationService( JAASAuthenticationService.DEFAULT_DOMAIN ) );
+    }
+
+    @Test
+    public void testNoLogin() throws Exception {
+        assertEquals( User.ANONYMOUS, tested.getUser() );
+    }
+
+    @Test
+    public void testGetAnnonymous() throws Exception {
+        assertFalse( tested.isLoggedIn() );
+    }
+
+    @Test
+    public void testLogin() throws Exception {
+        String username = "user1";
+        String password = "password1";
+        RoleRegistry.get().registerRole( "admin" );
+        RoleRegistry.get().registerRole( "role1" );
+        Set<Principal> principals = mockPrincipals( "admin", "role1", "group1" );
+        Subject subject = new Subject();
+        subject.getPrincipals().addAll( principals );
+        LoginContext loginContext = mock( LoginContext.class );
+        when( loginContext.getSubject() ).thenReturn( subject );
+        doReturn( loginContext ).when( tested ).createLoginContext( anyString(), anyString() );
+
+        User user = tested.login( username, password );
+
+        assertNotNull( user );
+        assertEquals( username, user.getIdentifier() );
+        assertEquals( 2, user.getRoles().size() );
+        assertTrue( user.getRoles().contains( new RoleImpl( "admin" ) ) );
+        assertTrue( user.getRoles().contains( new RoleImpl( "role1" ) ) );
+        assertEquals( 1, user.getGroups().size() );
+        assertTrue( user.getGroups().contains( new GroupImpl( "group1" ) ) );
+    }
+
+    @Test
+    public void testLoginSubjectGroups() throws Exception {
+        String username = "user1";
+        String password = "password1";
+        RoleRegistry.get().registerRole( "admin" );
+        RoleRegistry.get().registerRole( "role1" );
+        Set<Principal> principals = mockPrincipals( "admin", "role1", "group1" );
+        Group aclGroup = mock( Group.class );
+        doReturn( JAASAuthenticationService.DEFAULT_ROLE_PRINCIPLE_NAME ).when( aclGroup ).getName();
+        Set<Principal> aclGroups = mockPrincipals( "g1", "g2" );
+        Enumeration<? extends Principal> aclGroupsEnum = Collections.enumeration( aclGroups );
+        doReturn( aclGroupsEnum ).when( aclGroup ).members();
+        Subject subject = new Subject();
+        subject.getPrincipals().addAll( principals );
+        subject.getPrincipals().add( aclGroup );
+        LoginContext loginContext = mock( LoginContext.class );
+        when( loginContext.getSubject() ).thenReturn( subject );
+        doReturn( loginContext ).when( tested ).createLoginContext( anyString(), anyString() );
+
+        User user = tested.login( username, password );
+
+        assertNotNull( user );
+        assertEquals( username, user.getIdentifier() );
+        assertEquals( 2, user.getRoles().size() );
+        assertTrue( user.getRoles().contains( new RoleImpl( "admin" ) ) );
+        assertTrue( user.getRoles().contains( new RoleImpl( "role1" ) ) );
+        assertEquals( 3, user.getGroups().size() );
+        assertTrue( user.getGroups().contains( new GroupImpl( "group1" ) ) );
+        assertTrue( user.getGroups().contains( new GroupImpl( "g1" ) ) );
+        assertTrue( user.getGroups().contains( new GroupImpl( "g2" ) ) );
+    }
+
+    @Test
+    public void testLoggedIn() throws Exception {
+        String username = "user1";
+        String password = "password1";
+        RoleRegistry.get().registerRole( "admin" );
+        Set<Principal> principals = mockPrincipals( "admin" );
+        Subject subject = new Subject();
+        subject.getPrincipals().addAll( principals );
+        LoginContext loginContext = mock( LoginContext.class );
+        when( loginContext.getSubject() ).thenReturn( subject );
+        doReturn( loginContext ).when( tested ).createLoginContext( anyString(), anyString() );
+
+        tested.login( username, password );
+
+        assertTrue( tested.isLoggedIn() );
+    }
+
+    @Test
+    public void testGetUser() throws Exception {
+        String username = "user1";
+        String password = "password1";
+        RoleRegistry.get().registerRole( "admin" );
+        Set<Principal> principals = mockPrincipals( "admin" );
+        Subject subject = new Subject();
+        subject.getPrincipals().addAll( principals );
+        LoginContext loginContext = mock( LoginContext.class );
+        when( loginContext.getSubject() ).thenReturn( subject );
+        doReturn( loginContext ).when( tested ).createLoginContext( anyString(), anyString() );
+
+        User user = tested.login( username, password );
+        User user1 = tested.getUser();
+
+        assertEquals( user, user1 );
+    }
+
+    private Set<Principal> mockPrincipals( String... names ) {
+        Set<Principal> principals = new HashSet<Principal>();
+        for ( String name : names ) {
+            Principal p1 = mock( Principal.class );
+            when( p1.getName() ).thenReturn( name );
+            principals.add( p1 );
+        }
+        return principals;
+    }
+
+}

--- a/uberfire-extensions/uberfire-security/uberfire-servlet-security/src/main/java/org/uberfire/ext/security/server/SecurityIntegrationFilter.java
+++ b/uberfire-extensions/uberfire-security/uberfire-servlet-security/src/main/java/org/uberfire/ext/security/server/SecurityIntegrationFilter.java
@@ -34,7 +34,7 @@ public class SecurityIntegrationFilter implements Filter {
 
     public static final String PROBE_ROLES_INIT_PARAM = "probe-for-roles";
 
-    private static final ThreadLocal<HttpServletRequest> requests = new ThreadLocal<HttpServletRequest>();
+    static final ThreadLocal<HttpServletRequest> requests = new ThreadLocal<HttpServletRequest>();
 
     @Override
     public void init( FilterConfig filterConfig ) throws ServletException {

--- a/uberfire-extensions/uberfire-security/uberfire-servlet-security/src/test/java/org/uberfire/ext/security/server/ServletSecurityAuthenticationServiceTest.java
+++ b/uberfire-extensions/uberfire-security/uberfire-servlet-security/src/test/java/org/uberfire/ext/security/server/ServletSecurityAuthenticationServiceTest.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright 2015 JBoss, by Red Hat, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.ext.security.server;
+
+import org.jboss.errai.security.shared.api.GroupImpl;
+import org.jboss.errai.security.shared.api.RoleImpl;
+import org.jboss.errai.security.shared.api.identity.User;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.stubbing.Answer;
+import org.uberfire.backend.server.security.RoleRegistry;
+
+import javax.security.auth.Subject;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpSession;
+import java.security.Principal;
+import java.security.acl.Group;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.anyBoolean;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.*;
+import static org.uberfire.ext.security.server.ServletSecurityAuthenticationService.USER_SESSION_ATTR_NAME;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ServletSecurityAuthenticationServiceTest {
+
+    private static final String USERNAME = "user1";
+    private static final String PASSWORD = "password1";
+
+    @Mock
+    private HttpServletRequest request;
+
+    @Mock
+    private HttpSession httpSession;
+
+    private ServletSecurityAuthenticationService tested;
+
+    @Before
+    public void setup() throws Exception {
+
+        Principal p1 = mock( Principal.class );
+        when( p1.getName() ).thenReturn( USERNAME );
+        doReturn( p1 ).when( request ).getUserPrincipal();
+        doReturn( httpSession ).when( request ).getSession();
+        doReturn( null ).when( httpSession ).getAttribute( eq( USER_SESSION_ATTR_NAME ) );
+        when(request.getSession(anyBoolean())).then(new Answer<HttpSession>() {
+            @Override
+            public HttpSession answer(InvocationOnMock invocationOnMock) throws Throwable {
+                return httpSession;
+            }
+        });
+
+        tested = spy( new ServletSecurityAuthenticationService() );
+
+        // Set the request in the thread context.
+        SecurityIntegrationFilter.requests.set( request );
+
+    }
+
+    @Test
+    public void testLoggedIn() {
+        assertTrue( tested.isLoggedIn() );
+    }
+
+
+    @Test
+    public void testNotLoggedIn() {
+        doReturn( null ).when( request ).getUserPrincipal();
+        assertFalse( tested.isLoggedIn() );
+    }
+
+    @Test
+    public void testLogin() throws Exception {
+
+        RoleRegistry.get().registerRole( "admin" );
+        RoleRegistry.get().registerRole( "role1" );
+        Set<Principal> principals = mockPrincipals( "admin", "role1", "group1" );
+        Subject subject = new Subject();
+        subject.getPrincipals().addAll( principals );
+        doReturn( subject ).when( tested ).getSubjectFromPolicyContext();
+
+        User user = tested.login( USERNAME, PASSWORD );
+
+        assertNotNull( user );
+        assertEquals( USERNAME, user.getIdentifier() );
+        assertEquals( 2, user.getRoles().size() );
+        assertTrue( user.getRoles().contains( new RoleImpl( "admin" ) ) );
+        assertTrue( user.getRoles().contains( new RoleImpl( "role1" ) ) );
+        assertEquals( 1, user.getGroups().size() );
+        assertTrue( user.getGroups().contains( new GroupImpl( "group1" ) ) );
+    }
+
+    @Test
+    public void testLoginSubjectGroups() throws Exception {
+        String username = "user1";
+        String password = "password1";
+        RoleRegistry.get().registerRole( "admin" );
+        RoleRegistry.get().registerRole( "role1" );
+        Set<Principal> principals = mockPrincipals( "admin", "role1", "group1" );
+        Group aclGroup = mock( Group.class );
+        doReturn( ServletSecurityAuthenticationService.DEFAULT_ROLE_PRINCIPLE_NAME ).when( aclGroup ).getName();
+        Set<Principal> aclGroups = mockPrincipals( "g1", "g2" );
+        Enumeration<? extends Principal> aclGroupsEnum = Collections.enumeration( aclGroups );
+        doReturn( aclGroupsEnum ).when( aclGroup ).members();
+        Subject subject = new Subject();
+        subject.getPrincipals().addAll( principals );
+        subject.getPrincipals().add( aclGroup );
+        doReturn( subject ).when( tested ).getSubjectFromPolicyContext();
+
+        User user = tested.login( username, password );
+
+        assertNotNull( user );
+        assertEquals( username, user.getIdentifier() );
+        assertEquals( 2, user.getRoles().size() );
+        assertTrue( user.getRoles().contains( new RoleImpl( "admin" ) ) );
+        assertTrue( user.getRoles().contains( new RoleImpl( "role1" ) ) );
+        assertEquals( 3, user.getGroups().size() );
+        assertTrue( user.getGroups().contains( new GroupImpl( "group1" ) ) );
+        assertTrue( user.getGroups().contains( new GroupImpl( "g1" ) ) );
+        assertTrue( user.getGroups().contains( new GroupImpl( "g2" ) ) );
+    }
+
+    @Test
+    public void testLogout() throws Exception {
+        tested.logout();
+        verify( request, times( 1 ) ).logout();
+        verify( httpSession, times( 1 ) ).invalidate();
+
+    }
+
+    private Set<Principal> mockPrincipals( String... names ) {
+        Set<Principal> principals = new HashSet<Principal>();
+        for ( String name : names ) {
+            Principal p1 = mock( Principal.class );
+            when( p1.getName() ).thenReturn( name );
+            principals.add( p1 );
+        }
+        return principals;
+    }
+
+}


### PR DESCRIPTION
Hi, this is master's branch fix for : https://issues.jboss.org/browse/RHBPMS-4220. 
The fix on 0.9.x is already merged as well: 
- https://github.com/uberfire/uberfire/commit/22614cd81c6f75cfe506a0d7abd3dc8aab98e2ec
- https://github.com/uberfire/uberfire-extensions/commit/7bb84018ee778236bb203a10952c20ca8e143031

@manstis This issue caused some tests errors on 6.x/0.9.x, but this master's version commit is a reduced part of that one, as here the RoleRegistry already existis.. so only affects to a couple of login module classes. Please can you check I do not broke nothing from your side? :) Thanks!
