### PR TITLE
UF-386: Workbench Preferences Bean API - Settings Home and API evolution

### DIFF
--- a/uberfire-docs/docs/uberfireExtensions/preferencesBeansAPI.md
+++ b/uberfire-docs/docs/uberfireExtensions/preferencesBeansAPI.md
@@ -16,12 +16,15 @@ To transform a POJO in a preference, you should:
 Each of those annotations have some attributes that can be customized:
 
 * `@WorkbenchPreference`:
-    * `root`: Optional boolean attribute. It defines if a preference is a root preference, which means it will appear in the first level of the hierarchic structure printed in the configuration screen (a future feature).
+    * `identifier`: Unique text identifier, used by its children to determine their parents.
+    * `category`: If this is a root preference, this will define inside which category the preference will be shown.
+    * `iconCss`: The CSS class for the icon that represents this preference. This should be filled only for root preferences (those which have a category defined).
+    * `parents`: The preferences' identifiers which will have this preference as their child. All parents will share the same value for this preference.
     * `bundleKey`: Optional (but recommended to be customized) string attribute. It defines a bundle key that will be used to internationalize the property's label wherever its necessary. It's expected that the Errai's TranslationService will have access to the key translation.
 
 * `@Property`:
     * `formType`: Optional PropertyFormType (an enum) attribute. Defines the type of field to be used in a default provided form. The default is `TEXT`, and the other possible types are `BOOLEAN`, `NATURAL_NUMBER`, `SECRET_TEXT` and `COLOR`. You should only specify this if you are using the default form for preferences edition, otherwise it will have no effect.
-    * `inherited`: Optional boolean attribute. If false, the property will be defined specifically for this preference. If true, it will share its value with another inherited properties of the same type.
+    * `shared`: Optional boolean attribute, defaults to false. If false, the property will be defined specifically for this preference. If true, it will share its value with another shared properties of the same type.
     * `bundleKey`: Optional (but recommended to be customized) string attribute. It defines a bundle key that will be used to internationalize the property's label wherever its necessary. It's expected that the Errai's TranslationService will have access to the key translation.
 
 Observations:
@@ -38,7 +41,10 @@ import org.uberfire.ext.preferences.shared.annotations.Property;
 import org.uberfire.ext.preferences.shared.annotations.WorkbenchPreference;
 import org.uberfire.ext.preferences.shared.bean.BasePreference;
 
-@WorkbenchPreference(bundleKey = "MyPreference.Label")
+@WorkbenchPreference(identifier = "MyPreference",
+        category = "MyCategory",
+        bundleKey = "MyPreference.Label",
+        iconCss = "my-icon-css")
 public class MyPreference implements BasePreference<MyPreference> {
 
     @Property(bundleKey = "MyPreference.Text")
@@ -59,7 +65,7 @@ public class MyPreference implements BasePreference<MyPreference> {
     @Property(bundleKey = "MyPreference.MyInnerPreference")
     MyInnerPreference myInnerPreference;
 
-    @Property(inherited = true, bundleKey = "MyPreference.MyInheritedPreference")
+    @Property(shared = true, bundleKey = "MyPreference.MyInheritedPreference")
     MyInheritedPreference myInheritedPreference;
 
     @Override

--- a/uberfire-extensions/uberfire-preferences/uberfire-preferences-api/src/main/java/org/uberfire/ext/preferences/shared/annotations/Property.java
+++ b/uberfire-extensions/uberfire-preferences/uberfire-preferences-api/src/main/java/org/uberfire/ext/preferences/shared/annotations/Property.java
@@ -41,10 +41,10 @@ public @interface Property {
     PropertyFormType formType() default PropertyFormType.TEXT;
 
     /**
-     * Defines whether or not this property should be inherited by sub types. Defaults to false.
-     * @return The property inheritance strategy.
+     * Defines whether or not this property should be shared by its parents. Defaults to false.
+     * @return The property sharing strategy.
      */
-    boolean inherited() default false;
+    boolean shared() default false;
 
     /**
      * Defines a bundle key that will be used to internationalize the property's label wherever

--- a/uberfire-extensions/uberfire-preferences/uberfire-preferences-api/src/main/java/org/uberfire/ext/preferences/shared/annotations/WorkbenchPreference.java
+++ b/uberfire-extensions/uberfire-preferences/uberfire-preferences-api/src/main/java/org/uberfire/ext/preferences/shared/annotations/WorkbenchPreference.java
@@ -20,6 +20,7 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import javax.enterprise.util.Nonbinding;
 import javax.inject.Qualifier;
 
 /**
@@ -31,11 +32,31 @@ import javax.inject.Qualifier;
 public @interface WorkbenchPreference {
 
     /**
-     * Defines if a preference is a root preference, which means it will appear in the first
-     * level of the hierarchic structure printed in the configuration screen.
-     * @return True if it is a root preference, and false otherwise.
+     * A unique identifier used to reference parent nodes (see #parents).
+     * @return A unique identifier for the preference bean.
      */
-    boolean root() default true;
+    String identifier();
+
+    /**
+     * If this is a root preference, this will define inside which category the preference
+     * will be shown.
+     * @return The preference's category.
+     */
+    String category() default "";
+
+    /**
+     * The CSS class for the icon that represents this preference. This should be filled only for
+     * root preferences (those which have a category defined).
+     * @return The css class for the preference tile.
+     */
+    String iconCss() default "";
+
+    /**
+     * The identifiers of all parents of this preference.
+     * @return The parents of this preference. Empty if there is not one.
+     */
+    @Nonbinding
+    String[] parents() default {};
 
     /**
      * Defines a bundle key that will be used to internationalize the property's label wherever

--- a/uberfire-extensions/uberfire-preferences/uberfire-preferences-api/src/main/java/org/uberfire/ext/preferences/shared/bean/BasePreferencePortable.java
+++ b/uberfire-extensions/uberfire-preferences/uberfire-preferences-api/src/main/java/org/uberfire/ext/preferences/shared/bean/BasePreferencePortable.java
@@ -35,16 +35,38 @@ public interface BasePreferencePortable<T> extends BasePreference<T> {
     Class<T> getPojoClass();
 
     /**
+     * Unique identifier, used by this preference children to determine their parents.
+     * Also used to name the file containing its value.
+     * @return A unique identifier for the preference bean.
+     */
+    String identifier();
+
+    /**
+     * If this is a root preference, this will define inside which category the preference
+     * will be shown.
+     * @return The preference's category.
+     */
+    String category();
+
+    /**
+     * The css class for the icon that represents this preference. This should be filled only for
+     * root preferences (those who belong to a category).
+     * @return The css class for the preference tile.
+     */
+    String iconCss();
+
+    /**
+     * The preferences which will have this preference as their child.
+     * All parents will share the same preference value.
+     * @return The parents of this preference. Empty if there is not one.
+     */
+    String[] parents();
+
+    /**
      * Returns the bundle key registered in the {@link WorkbenchPreference} annotation.
      * @return The preference bundle key.
      */
     String bundleKey();
-
-    /**
-     * Returns the preference key, used to name the file containing its value.
-     * @return The preference key.
-     */
-    String key();
 
     /**
      * Sets a property value by its name.

--- a/uberfire-extensions/uberfire-preferences/uberfire-preferences-api/src/main/java/org/uberfire/ext/preferences/shared/bean/PreferenceBeanServerStore.java
+++ b/uberfire-extensions/uberfire-preferences/uberfire-preferences-api/src/main/java/org/uberfire/ext/preferences/shared/bean/PreferenceBeanServerStore.java
@@ -18,6 +18,7 @@ package org.uberfire.ext.preferences.shared.bean;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 
 import org.jboss.errai.bus.server.annotations.Remote;
 
@@ -59,9 +60,16 @@ public interface PreferenceBeanServerStore extends PreferenceBeanStore {
     void save( Collection<BasePreferencePortable<? extends BasePreference<?>>> portablePreferences );
 
     /**
-     * Builds a tree hierarchy that begins with the root preference beans and grows based on their
-     * sub-preferences.
+     * Builds a map that contains all root preferences for each category.
+     * @return A map containing all root preferences for each category. Empty if none exists.
+     */
+    Map<String, List<PreferenceRootElement>> buildCategoryStructure();
+
+    /**
+     * Builds a tree hierarchy that begins with the root preference bean which identifier was passed and
+     * grows based on their sub-preferences.
+     * @param identifier Root preference identifier. Must not be null.
      * @return A tree hierarchy between all preference beans.
      */
-    List<PreferenceHierarchyElement<?>> buildHierarchyStructure();
+    PreferenceHierarchyElement<?> buildHierarchyStructureForRootPreference( String identifier );
 }

--- a/uberfire-extensions/uberfire-preferences/uberfire-preferences-api/src/main/java/org/uberfire/ext/preferences/shared/bean/PreferenceHierarchyElement.java
+++ b/uberfire-extensions/uberfire-preferences/uberfire-preferences-api/src/main/java/org/uberfire/ext/preferences/shared/bean/PreferenceHierarchyElement.java
@@ -37,7 +37,7 @@ public class PreferenceHierarchyElement<T> {
 
     private List<PreferenceHierarchyElement<?>> children;
 
-    private boolean inherited;
+    private boolean shared;
 
     private boolean root;
 
@@ -51,24 +51,24 @@ public class PreferenceHierarchyElement<T> {
 
     public PreferenceHierarchyElement( final String id,
                                        final BasePreferencePortable<T> portablePreference,
-                                       final boolean inherited,
+                                       final boolean shared,
                                        final boolean root,
                                        final String bundleKey ) {
 
-        this( id, portablePreference, new ArrayList<>(), inherited, root, bundleKey, new HashMap<>() );
+        this( id, portablePreference, new ArrayList<>(), shared, root, bundleKey, new HashMap<>() );
     }
 
     public PreferenceHierarchyElement( @MapsTo( "id" ) final String id,
                                        @MapsTo( "portablePreference" ) final BasePreferencePortable<T> portablePreference,
                                        @MapsTo( "children" ) final List<PreferenceHierarchyElement<?>> children,
-                                       @MapsTo( "inherited" ) final boolean inherited,
+                                       @MapsTo( "shared" ) final boolean shared,
                                        @MapsTo( "root" ) final boolean root,
                                        @MapsTo( "bundleKey" ) final String bundleKey,
                                        @MapsTo( "bundleKeyByProperty" ) final Map<String, String> bundleKeyByProperty ) {
         this.id = id;
         this.portablePreference = portablePreference;
         this.children = children;
-        this.inherited = inherited;
+        this.shared = shared;
         this.root = root;
         this.bundleKey = bundleKey;
         this.bundleKeyByProperty = bundleKeyByProperty;
@@ -102,12 +102,12 @@ public class PreferenceHierarchyElement<T> {
         this.children = children;
     }
 
-    public boolean isInherited() {
-        return inherited;
+    public boolean isShared() {
+        return shared;
     }
 
-    public void setInherited( final boolean inherited ) {
-        this.inherited = inherited;
+    public void setShared( final boolean shared ) {
+        this.shared = shared;
     }
 
     public boolean isRoot() {
@@ -145,7 +145,7 @@ public class PreferenceHierarchyElement<T> {
 
         final PreferenceHierarchyElement<?> that = (PreferenceHierarchyElement<?>) o;
 
-        if ( inherited != that.inherited ) {
+        if ( shared != that.shared ) {
             return false;
         }
         if ( root != that.root ) {
@@ -175,7 +175,7 @@ public class PreferenceHierarchyElement<T> {
         result = ~~result;
         result = 31 * result + ( children != null ? children.hashCode() : 0 );
         result = ~~result;
-        result = 31 * result + ( inherited ? 1 : 0 );
+        result = 31 * result + ( shared ? 1 : 0 );
         result = ~~result;
         result = 31 * result + ( root ? 1 : 0 );
         result = ~~result;

--- a/uberfire-extensions/uberfire-preferences/uberfire-preferences-api/src/main/java/org/uberfire/ext/preferences/shared/bean/PreferenceRootElement.java
+++ b/uberfire-extensions/uberfire-preferences/uberfire-preferences-api/src/main/java/org/uberfire/ext/preferences/shared/bean/PreferenceRootElement.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.ext.preferences.shared.bean;
+
+import org.jboss.errai.common.client.api.annotations.MapsTo;
+import org.jboss.errai.common.client.api.annotations.Portable;
+
+@Portable
+public class PreferenceRootElement {
+
+    private String identifier;
+
+    private String category;
+
+    private String iconCss;
+
+    private String bundleKey;
+
+    public PreferenceRootElement() {
+    }
+
+    public PreferenceRootElement( @MapsTo( "identifier" ) final String identifier,
+                                  @MapsTo( "category" ) final String category,
+                                  @MapsTo( "iconCss" ) final String iconCss,
+                                  @MapsTo( "bundleKey" ) final String bundleKey ) {
+        this.identifier = identifier;
+        this.category = category;
+        this.iconCss = iconCss;
+        this.bundleKey = bundleKey;
+    }
+
+    public String getIdentifier() {
+        return identifier;
+    }
+
+    public String getCategory() {
+        return category;
+    }
+
+    public String getIconCss() {
+        return iconCss;
+    }
+
+    public String getBundleKey() {
+        return bundleKey;
+    }
+
+    @Override
+    public boolean equals( final Object o ) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( !( o instanceof PreferenceRootElement ) ) {
+            return false;
+        }
+
+        final PreferenceRootElement that = (PreferenceRootElement) o;
+
+        if ( identifier != null ? !identifier.equals( that.identifier ) : that.identifier != null ) {
+            return false;
+        }
+        if ( category != null ? !category.equals( that.category ) : that.category != null ) {
+            return false;
+        }
+        if ( iconCss != null ? !iconCss.equals( that.iconCss ) : that.iconCss != null ) {
+            return false;
+        }
+        return !( bundleKey != null ? !bundleKey.equals( that.bundleKey ) : that.bundleKey != null );
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = identifier != null ? identifier.hashCode() : 0;
+        result = ~~result;
+        result = 31 * result + ( category != null ? category.hashCode() : 0 );
+        result = ~~result;
+        result = 31 * result + ( iconCss != null ? iconCss.hashCode() : 0 );
+        result = ~~result;
+        result = 31 * result + ( bundleKey != null ? bundleKey.hashCode() : 0 );
+        result = ~~result;
+        return result;
+    }
+}

--- a/uberfire-extensions/uberfire-preferences/uberfire-preferences-backend/src/test/java/org/uberfire/ext/preferences/backend/InvalidDefaultPreference.java
+++ b/uberfire-extensions/uberfire-preferences/uberfire-preferences-backend/src/test/java/org/uberfire/ext/preferences/backend/InvalidDefaultPreference.java
@@ -19,7 +19,7 @@ package org.uberfire.ext.preferences.backend;
 import org.uberfire.ext.preferences.shared.annotations.WorkbenchPreference;
 import org.uberfire.ext.preferences.shared.bean.BasePreference;
 
-@WorkbenchPreference
+@WorkbenchPreference(identifier = "InvalidDefaultPreference")
 public class InvalidDefaultPreference implements BasePreference<InvalidDefaultPreference> {
 
     String text;

--- a/uberfire-extensions/uberfire-preferences/uberfire-preferences-backend/src/test/java/org/uberfire/ext/preferences/backend/InvalidDefaultPreferencePortableGeneratedImpl.java
+++ b/uberfire-extensions/uberfire-preferences/uberfire-preferences-backend/src/test/java/org/uberfire/ext/preferences/backend/InvalidDefaultPreferencePortableGeneratedImpl.java
@@ -54,8 +54,23 @@ public class InvalidDefaultPreferencePortableGeneratedImpl extends InvalidDefaul
     }
 
     @Override
-    public String key() {
-        return "org.uberfire.ext.preferences.backend.InvalidDefaultPreference";
+    public String identifier() {
+        return "InvalidDefaultPreference";
+    }
+
+    @Override
+    public String category() {
+        return null;
+    }
+
+    @Override
+    public String iconCss() {
+        return null;
+    }
+
+    @Override
+    public String[] parents() {
+        return new String[ 0 ];
     }
 
     @Override

--- a/uberfire-extensions/uberfire-preferences/uberfire-preferences-backend/src/test/java/org/uberfire/ext/preferences/backend/MyInnerPreference.java
+++ b/uberfire-extensions/uberfire-preferences/uberfire-preferences-backend/src/test/java/org/uberfire/ext/preferences/backend/MyInnerPreference.java
@@ -20,7 +20,8 @@ import org.uberfire.ext.preferences.shared.annotations.Property;
 import org.uberfire.ext.preferences.shared.annotations.WorkbenchPreference;
 import org.uberfire.ext.preferences.shared.bean.BasePreference;
 
-@WorkbenchPreference(root = false, bundleKey = "MyInnerPreference.Label")
+@WorkbenchPreference(identifier = "MyInnerPreference",
+        bundleKey = "MyInnerPreference.Label")
 public class MyInnerPreference implements BasePreference<MyInnerPreference> {
 
     @Property(bundleKey = "MyInnerPreference.Text")

--- a/uberfire-extensions/uberfire-preferences/uberfire-preferences-backend/src/test/java/org/uberfire/ext/preferences/backend/MyInnerPreference2.java
+++ b/uberfire-extensions/uberfire-preferences/uberfire-preferences-backend/src/test/java/org/uberfire/ext/preferences/backend/MyInnerPreference2.java
@@ -20,12 +20,10 @@ import org.uberfire.ext.preferences.shared.annotations.Property;
 import org.uberfire.ext.preferences.shared.annotations.WorkbenchPreference;
 import org.uberfire.ext.preferences.shared.bean.BasePreference;
 
-@WorkbenchPreference(root = false, bundleKey = "MyInnerPreference2.Label")
+@WorkbenchPreference(identifier = "MyInnerPreference2",
+        bundleKey = "MyInnerPreference2.Label")
 public class MyInnerPreference2 implements BasePreference<MyInnerPreference2> {
 
     @Property(bundleKey = "MyInnerPreference2.Text")
     String text;
-
-    @Property(inherited = true, bundleKey = "MyInnerPreference2.MyInheritedPreference2")
-    MyInheritedPreference2 myInheritedPreference2;
 }

--- a/uberfire-extensions/uberfire-preferences/uberfire-preferences-backend/src/test/java/org/uberfire/ext/preferences/backend/MyInnerPreference2BeanGeneratedImpl.java
+++ b/uberfire-extensions/uberfire-preferences/uberfire-preferences-backend/src/test/java/org/uberfire/ext/preferences/backend/MyInnerPreference2BeanGeneratedImpl.java
@@ -69,7 +69,6 @@ public class MyInnerPreference2BeanGeneratedImpl extends MyInnerPreference2 impl
     private void copy( final MyInnerPreference2 from,
                        final MyInnerPreference2 to ) {
         to.text = from.text;
-        to.myInheritedPreference2 = from.myInheritedPreference2;
     }
 
     @Override
@@ -95,7 +94,7 @@ public class MyInnerPreference2BeanGeneratedImpl extends MyInnerPreference2 impl
 
     @Override
     public void saveDefaultValue( final ParameterizedCommand<Throwable> errorCallback ) {
-        saveDefaultValue( null, errorCallback );
+        saveDefaultValue( null, errorCallback);
     }
 
     @Override

--- a/uberfire-extensions/uberfire-preferences/uberfire-preferences-backend/src/test/java/org/uberfire/ext/preferences/backend/MyInnerPreference2PortableGeneratedImpl.java
+++ b/uberfire-extensions/uberfire-preferences/uberfire-preferences-backend/src/test/java/org/uberfire/ext/preferences/backend/MyInnerPreference2PortableGeneratedImpl.java
@@ -26,7 +26,7 @@ import org.uberfire.ext.preferences.shared.PropertyFormType;
 import org.uberfire.ext.preferences.shared.annotations.PortablePreference;
 import org.uberfire.ext.preferences.shared.bean.BasePreferencePortable;
 
-@Portable(mapSuperTypes = true)
+@Portable( mapSuperTypes = true )
 @PortablePreference
 @Generated("org.uberfire.ext.preferences.processors.WorkbenchPreferenceProcessor")
 /*
@@ -35,13 +35,10 @@ import org.uberfire.ext.preferences.shared.bean.BasePreferencePortable;
 public class MyInnerPreference2PortableGeneratedImpl extends MyInnerPreference2 implements BasePreferencePortable<MyInnerPreference2> {
 
     public MyInnerPreference2PortableGeneratedImpl() {
-        this.myInheritedPreference2 = new org.uberfire.ext.preferences.backend.MyInheritedPreference2PortableGeneratedImpl();
     }
 
-    public MyInnerPreference2PortableGeneratedImpl( @MapsTo("text") String text,
-                                                    @MapsTo("myInheritedPreference2") org.uberfire.ext.preferences.backend.MyInheritedPreference2 myInheritedPreference2 ) {
+    public MyInnerPreference2PortableGeneratedImpl( @MapsTo("text") String text ) {
         this.text = text;
-        this.myInheritedPreference2 = myInheritedPreference2;
     }
 
     @Override
@@ -50,21 +47,36 @@ public class MyInnerPreference2PortableGeneratedImpl extends MyInnerPreference2 
     }
 
     @Override
+    public String identifier() {
+        return "MyInnerPreference2";
+    }
+
+    @Override
+    public String category() {
+        return "";
+    }
+
+    @Override
+    public String iconCss() {
+        return "";
+    }
+
+    @Override
+    public String[] parents() {
+        return new String[] { "" };
+    }
+
+    @Override
     public String bundleKey() {
         return "MyInnerPreference2.Label";
     }
 
     @Override
-    public String key() {
-        return "org.uberfire.ext.preferences.backend.MyInnerPreference2";
-    }
-
-    @Override
-    public void set( String property,
-                     Object value ) {
+    public void set( String property, Object value ) {
         if ( property.equals( "text" ) ) {
             text = (String) value;
-        } else {
+        } else
+        {
             throw new RuntimeException( "Unknown property: " + property );
         }
     }
@@ -73,7 +85,8 @@ public class MyInnerPreference2PortableGeneratedImpl extends MyInnerPreference2 
     public Object get( String property ) {
         if ( property.equals( "text" ) ) {
             return text;
-        } else {
+        } else
+        {
             throw new RuntimeException( "Unknown property: " + property );
         }
     }
@@ -82,7 +95,7 @@ public class MyInnerPreference2PortableGeneratedImpl extends MyInnerPreference2 
     public Map<String, PropertyFormType> getPropertiesTypes() {
         Map<String, PropertyFormType> propertiesTypes = new HashMap<>();
 
-        propertiesTypes.put( "text", PropertyFormType.TEXT );
+        propertiesTypes.put( "text", PropertyFormType.TEXT);
 
         return propertiesTypes;
     }
@@ -101,9 +114,6 @@ public class MyInnerPreference2PortableGeneratedImpl extends MyInnerPreference2 
         if ( text != null ? !text.equals( that.text ) : that.text != null ) {
             return false;
         }
-        if ( myInheritedPreference2 != null ? !myInheritedPreference2.equals( that.myInheritedPreference2 ) : that.myInheritedPreference2 != null ) {
-            return false;
-        }
 
         return true;
     }
@@ -113,8 +123,6 @@ public class MyInnerPreference2PortableGeneratedImpl extends MyInnerPreference2 
         int result = 0;
 
         result = 31 * result + ( text != null ? text.hashCode() : 0 );
-        result = ~~result;
-        result = 31 * result + ( myInheritedPreference2 != null ? myInheritedPreference2.hashCode() : 0 );
         result = ~~result;
 
         return result;

--- a/uberfire-extensions/uberfire-preferences/uberfire-preferences-backend/src/test/java/org/uberfire/ext/preferences/backend/MyInnerPreferenceBeanGeneratedImpl.java
+++ b/uberfire-extensions/uberfire-preferences/uberfire-preferences-backend/src/test/java/org/uberfire/ext/preferences/backend/MyInnerPreferenceBeanGeneratedImpl.java
@@ -94,7 +94,7 @@ public class MyInnerPreferenceBeanGeneratedImpl extends MyInnerPreference implem
 
     @Override
     public void saveDefaultValue( final ParameterizedCommand<Throwable> errorCallback ) {
-        saveDefaultValue( null, errorCallback );
+        saveDefaultValue( null, errorCallback);
     }
 
     @Override

--- a/uberfire-extensions/uberfire-preferences/uberfire-preferences-backend/src/test/java/org/uberfire/ext/preferences/backend/MyInnerPreferencePortableGeneratedImpl.java
+++ b/uberfire-extensions/uberfire-preferences/uberfire-preferences-backend/src/test/java/org/uberfire/ext/preferences/backend/MyInnerPreferencePortableGeneratedImpl.java
@@ -26,7 +26,7 @@ import org.uberfire.ext.preferences.shared.PropertyFormType;
 import org.uberfire.ext.preferences.shared.annotations.PortablePreference;
 import org.uberfire.ext.preferences.shared.bean.BasePreferencePortable;
 
-@Portable(mapSuperTypes = true)
+@Portable( mapSuperTypes = true )
 @PortablePreference
 @Generated("org.uberfire.ext.preferences.processors.WorkbenchPreferenceProcessor")
 /*
@@ -47,21 +47,36 @@ public class MyInnerPreferencePortableGeneratedImpl extends MyInnerPreference im
     }
 
     @Override
+    public String identifier() {
+        return "MyInnerPreference";
+    }
+
+    @Override
+    public String category() {
+        return "";
+    }
+
+    @Override
+    public String iconCss() {
+        return "";
+    }
+
+    @Override
+    public String[] parents() {
+        return new String[] { "" };
+    }
+
+    @Override
     public String bundleKey() {
         return "MyInnerPreference.Label";
     }
 
     @Override
-    public String key() {
-        return "org.uberfire.ext.preferences.backend.MyInnerPreference";
-    }
-
-    @Override
-    public void set( String property,
-                     Object value ) {
+    public void set( String property, Object value ) {
         if ( property.equals( "text" ) ) {
             text = (String) value;
-        } else {
+        } else
+        {
             throw new RuntimeException( "Unknown property: " + property );
         }
     }
@@ -70,7 +85,8 @@ public class MyInnerPreferencePortableGeneratedImpl extends MyInnerPreference im
     public Object get( String property ) {
         if ( property.equals( "text" ) ) {
             return text;
-        } else {
+        } else
+        {
             throw new RuntimeException( "Unknown property: " + property );
         }
     }
@@ -79,7 +95,7 @@ public class MyInnerPreferencePortableGeneratedImpl extends MyInnerPreference im
     public Map<String, PropertyFormType> getPropertiesTypes() {
         Map<String, PropertyFormType> propertiesTypes = new HashMap<>();
 
-        propertiesTypes.put( "text", PropertyFormType.TEXT );
+        propertiesTypes.put( "text", PropertyFormType.TEXT);
 
         return propertiesTypes;
     }

--- a/uberfire-extensions/uberfire-preferences/uberfire-preferences-backend/src/test/java/org/uberfire/ext/preferences/backend/MyPreference.java
+++ b/uberfire-extensions/uberfire-preferences/uberfire-preferences-backend/src/test/java/org/uberfire/ext/preferences/backend/MyPreference.java
@@ -21,7 +21,10 @@ import org.uberfire.ext.preferences.shared.annotations.Property;
 import org.uberfire.ext.preferences.shared.annotations.WorkbenchPreference;
 import org.uberfire.ext.preferences.shared.bean.BasePreference;
 
-@WorkbenchPreference(bundleKey = "MyPreference.Label")
+@WorkbenchPreference(identifier = "MyPreference",
+        category = "MyCategory",
+        bundleKey = "MyPreference.Label",
+        iconCss = "fa-gear")
 public class MyPreference implements BasePreference<MyPreference> {
 
     @Property(bundleKey = "MyPreference.Text")
@@ -42,8 +45,8 @@ public class MyPreference implements BasePreference<MyPreference> {
     @Property(bundleKey = "MyPreference.MyInnerPreference")
     MyInnerPreference myInnerPreference;
 
-    @Property(inherited = true, bundleKey = "MyPreference.MyInheritedPreference")
-    MyInheritedPreference myInheritedPreference;
+    @Property(shared = true, bundleKey = "MyPreference.MySharedPreference")
+    MySharedPreference mySharedPreference;
 
     @Override
     public MyPreference defaultValue( final MyPreference defaultValue ) {
@@ -53,9 +56,8 @@ public class MyPreference implements BasePreference<MyPreference> {
         defaultValue.age = 27;
         defaultValue.password = "password";
         defaultValue.myInnerPreference.text = "text";
-        defaultValue.myInheritedPreference.text = "text";
-        defaultValue.myInheritedPreference.myInnerPreference2.text = "text";
-        defaultValue.myInheritedPreference.myInnerPreference2.myInheritedPreference2.text = "text";
+        defaultValue.mySharedPreference.text = "text";
+        defaultValue.mySharedPreference.myInnerPreference2.text = "text";
 
         return defaultValue;
     }

--- a/uberfire-extensions/uberfire-preferences/uberfire-preferences-backend/src/test/java/org/uberfire/ext/preferences/backend/MyPreferenceBeanGeneratedImpl.java
+++ b/uberfire-extensions/uberfire-preferences/uberfire-preferences-backend/src/test/java/org/uberfire/ext/preferences/backend/MyPreferenceBeanGeneratedImpl.java
@@ -74,7 +74,7 @@ public class MyPreferenceBeanGeneratedImpl extends MyPreference implements BaseP
         to.age = from.age;
         to.password = from.password;
         to.myInnerPreference = from.myInnerPreference;
-        to.myInheritedPreference = from.myInheritedPreference;
+        to.mySharedPreference = from.mySharedPreference;
     }
 
     @Override
@@ -100,7 +100,7 @@ public class MyPreferenceBeanGeneratedImpl extends MyPreference implements BaseP
 
     @Override
     public void saveDefaultValue( final ParameterizedCommand<Throwable> errorCallback ) {
-        saveDefaultValue( null, errorCallback );
+        saveDefaultValue( null, errorCallback);
     }
 
     @Override

--- a/uberfire-extensions/uberfire-preferences/uberfire-preferences-backend/src/test/java/org/uberfire/ext/preferences/backend/MyPreferencePortableGeneratedImpl.java
+++ b/uberfire-extensions/uberfire-preferences/uberfire-preferences-backend/src/test/java/org/uberfire/ext/preferences/backend/MyPreferencePortableGeneratedImpl.java
@@ -27,7 +27,7 @@ import org.uberfire.ext.preferences.shared.annotations.PortablePreference;
 import org.uberfire.ext.preferences.shared.annotations.RootPreference;
 import org.uberfire.ext.preferences.shared.bean.BasePreferencePortable;
 
-@Portable(mapSuperTypes = true)
+@Portable( mapSuperTypes = true )
 @PortablePreference
 @RootPreference
 @Generated("org.uberfire.ext.preferences.processors.WorkbenchPreferenceProcessor")
@@ -38,23 +38,17 @@ public class MyPreferencePortableGeneratedImpl extends MyPreference implements B
 
     public MyPreferencePortableGeneratedImpl() {
         this.myInnerPreference = new org.uberfire.ext.preferences.backend.MyInnerPreferencePortableGeneratedImpl();
-        this.myInheritedPreference = new org.uberfire.ext.preferences.backend.MyInheritedPreferencePortableGeneratedImpl();
+        this.mySharedPreference = new org.uberfire.ext.preferences.backend.MySharedPreferencePortableGeneratedImpl();
     }
 
-    public MyPreferencePortableGeneratedImpl( @MapsTo("text") String text,
-                                              @MapsTo("sendReports") boolean sendReports,
-                                              @MapsTo("backgroundColor") String backgroundColor,
-                                              @MapsTo("age") int age,
-                                              @MapsTo("password") String password,
-                                              @MapsTo("myInnerPreference") org.uberfire.ext.preferences.backend.MyInnerPreference myInnerPreference,
-                                              @MapsTo("myInheritedPreference") org.uberfire.ext.preferences.backend.MyInheritedPreference myInheritedPreference ) {
+    public MyPreferencePortableGeneratedImpl( @MapsTo("text") String text, @MapsTo("sendReports") boolean sendReports, @MapsTo("backgroundColor") String backgroundColor, @MapsTo("age") int age, @MapsTo("password") String password, @MapsTo("myInnerPreference") org.uberfire.ext.preferences.backend.MyInnerPreference myInnerPreference, @MapsTo("mySharedPreference") org.uberfire.ext.preferences.backend.MySharedPreference mySharedPreference ) {
         this.text = text;
         this.sendReports = sendReports;
         this.backgroundColor = backgroundColor;
         this.age = age;
         this.password = password;
         this.myInnerPreference = myInnerPreference;
-        this.myInheritedPreference = myInheritedPreference;
+        this.mySharedPreference = mySharedPreference;
     }
 
     @Override
@@ -63,29 +57,48 @@ public class MyPreferencePortableGeneratedImpl extends MyPreference implements B
     }
 
     @Override
+    public String identifier() {
+        return "MyPreference";
+    }
+
+    @Override
+    public String category() {
+        return "MyCategory";
+    }
+
+    @Override
+    public String iconCss() {
+        return "fa-gear";
+    }
+
+    @Override
+    public String[] parents() {
+        return new String[] { "" };
+    }
+
+    @Override
     public String bundleKey() {
         return "MyPreference.Label";
     }
 
     @Override
-    public String key() {
-        return "org.uberfire.ext.preferences.backend.MyPreference";
-    }
-
-    @Override
-    public void set( String property,
-                     Object value ) {
+    public void set( String property, Object value ) {
         if ( property.equals( "text" ) ) {
             text = (String) value;
-        } else if ( property.equals( "sendReports" ) ) {
+        } else
+        if ( property.equals( "sendReports" ) ) {
             sendReports = (boolean) value;
-        } else if ( property.equals( "backgroundColor" ) ) {
+        } else
+        if ( property.equals( "backgroundColor" ) ) {
             backgroundColor = (String) value;
-        } else if ( property.equals( "age" ) ) {
+        } else
+        if ( property.equals( "age" ) ) {
             age = (int) value;
-        } else if ( property.equals( "password" ) ) {
+        } else
+        if ( property.equals( "password" ) ) {
             password = (String) value;
-        } else {
+        } else
+        {
             throw new RuntimeException( "Unknown property: " + property );
         }
     }
@@ -94,15 +107,20 @@ public class MyPreferencePortableGeneratedImpl extends MyPreference implements B
     public Object get( String property ) {
         if ( property.equals( "text" ) ) {
             return text;
-        } else if ( property.equals( "sendReports" ) ) {
+        } else
+        if ( property.equals( "sendReports" ) ) {
             return sendReports;
-        } else if ( property.equals( "backgroundColor" ) ) {
+        } else
+        if ( property.equals( "backgroundColor" ) ) {
             return backgroundColor;
-        } else if ( property.equals( "age" ) ) {
+        } else
+        if ( property.equals( "age" ) ) {
             return age;
-        } else if ( property.equals( "password" ) ) {
+        } else
+        if ( property.equals( "password" ) ) {
             return password;
-        } else {
+        } else
+        {
             throw new RuntimeException( "Unknown property: " + property );
         }
     }
@@ -111,11 +129,11 @@ public class MyPreferencePortableGeneratedImpl extends MyPreference implements B
     public Map<String, PropertyFormType> getPropertiesTypes() {
         Map<String, PropertyFormType> propertiesTypes = new HashMap<>();
 
-        propertiesTypes.put( "text", PropertyFormType.TEXT );
-        propertiesTypes.put( "sendReports", PropertyFormType.BOOLEAN );
-        propertiesTypes.put( "backgroundColor", PropertyFormType.COLOR );
-        propertiesTypes.put( "age", PropertyFormType.NATURAL_NUMBER );
-        propertiesTypes.put( "password", PropertyFormType.SECRET_TEXT );
+        propertiesTypes.put( "text", PropertyFormType.TEXT);
+        propertiesTypes.put( "sendReports", PropertyFormType.BOOLEAN);
+        propertiesTypes.put( "backgroundColor", PropertyFormType.COLOR);
+        propertiesTypes.put( "age", PropertyFormType.NATURAL_NUMBER);
+        propertiesTypes.put( "password", PropertyFormType.SECRET_TEXT);
 
         return propertiesTypes;
     }
@@ -149,7 +167,7 @@ public class MyPreferencePortableGeneratedImpl extends MyPreference implements B
         if ( myInnerPreference != null ? !myInnerPreference.equals( that.myInnerPreference ) : that.myInnerPreference != null ) {
             return false;
         }
-        if ( myInheritedPreference != null ? !myInheritedPreference.equals( that.myInheritedPreference ) : that.myInheritedPreference != null ) {
+        if ( mySharedPreference != null ? !mySharedPreference.equals( that.mySharedPreference ) : that.mySharedPreference != null ) {
             return false;
         }
 
@@ -172,7 +190,7 @@ public class MyPreferencePortableGeneratedImpl extends MyPreference implements B
         result = ~~result;
         result = 31 * result + ( myInnerPreference != null ? myInnerPreference.hashCode() : 0 );
         result = ~~result;
-        result = 31 * result + ( myInheritedPreference != null ? myInheritedPreference.hashCode() : 0 );
+        result = 31 * result + ( mySharedPreference != null ? mySharedPreference.hashCode() : 0 );
         result = ~~result;
 
         return result;

--- a/uberfire-extensions/uberfire-preferences/uberfire-preferences-backend/src/test/java/org/uberfire/ext/preferences/backend/MySharedPreference.java
+++ b/uberfire-extensions/uberfire-preferences/uberfire-preferences-backend/src/test/java/org/uberfire/ext/preferences/backend/MySharedPreference.java
@@ -14,15 +14,19 @@
  * limitations under the License.
  */
 
-package org.uberfire.ext.wires.shared.preferences.bean;
+package org.uberfire.ext.preferences.backend;
 
 import org.uberfire.ext.preferences.shared.annotations.Property;
 import org.uberfire.ext.preferences.shared.annotations.WorkbenchPreference;
 import org.uberfire.ext.preferences.shared.bean.BasePreference;
 
-@WorkbenchPreference(bundleKey = "MyInheritedPreference2.Label")
-public class MyInheritedPreference2 implements BasePreference<MyInheritedPreference2> {
+@WorkbenchPreference(identifier = "MySharedPreference",
+        bundleKey = "MySharedPreference.Label")
+public class MySharedPreference implements BasePreference<MySharedPreference> {
 
-    @Property(bundleKey = "MyInheritedPreference2.Text")
+    @Property(bundleKey = "MySharedPreference.Text")
     String text;
+
+    @Property(bundleKey = "MySharedPreference.MyInnerPreference2")
+    MyInnerPreference2 myInnerPreference2;
 }

--- a/uberfire-extensions/uberfire-preferences/uberfire-preferences-backend/src/test/java/org/uberfire/ext/preferences/backend/MySharedPreference2.java
+++ b/uberfire-extensions/uberfire-preferences/uberfire-preferences-backend/src/test/java/org/uberfire/ext/preferences/backend/MySharedPreference2.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.ext.preferences.backend;
+
+import org.uberfire.ext.preferences.shared.annotations.Property;
+import org.uberfire.ext.preferences.shared.annotations.WorkbenchPreference;
+import org.uberfire.ext.preferences.shared.bean.BasePreference;
+
+@WorkbenchPreference(identifier = "MySharedPreference2",
+        parents = "MyInnerPreference2",
+        bundleKey = "MySharedPreference2.Label",
+        category = "MyCategory",
+        iconCss = "fa-pie-chart")
+public class MySharedPreference2 implements BasePreference<MySharedPreference2> {
+
+    @Property(bundleKey = "MySharedPreference2.Text")
+    String text;
+
+    @Override
+    public MySharedPreference2 defaultValue( final MySharedPreference2 defaultValue ) {
+        defaultValue.text = "text";
+
+        return defaultValue;
+    }
+}

--- a/uberfire-extensions/uberfire-preferences/uberfire-preferences-backend/src/test/java/org/uberfire/ext/preferences/backend/MySharedPreference2BeanGeneratedImpl.java
+++ b/uberfire-extensions/uberfire-preferences/uberfire-preferences-backend/src/test/java/org/uberfire/ext/preferences/backend/MySharedPreference2BeanGeneratedImpl.java
@@ -31,12 +31,12 @@ import org.uberfire.mvp.ParameterizedCommand;
 /*
 * WARNING! This class is generated. Do not modify.
 */
-public class MyInheritedPreference2BeanGeneratedImpl extends MyInheritedPreference2 implements BasePreferenceBean<MyInheritedPreference2> {
+public class MySharedPreference2BeanGeneratedImpl extends MySharedPreference2 implements BasePreferenceBean<MySharedPreference2> {
 
     private PreferenceBeanStore store;
 
     @Inject
-    public MyInheritedPreference2BeanGeneratedImpl( final PreferenceBeanStore store ) {
+    public MySharedPreference2BeanGeneratedImpl( final PreferenceBeanStore store ) {
         this.store = store;
     }
 
@@ -51,14 +51,14 @@ public class MyInheritedPreference2BeanGeneratedImpl extends MyInheritedPreferen
     }
 
     @Override
-    public void load( final ParameterizedCommand<MyInheritedPreference2> successCallback,
+    public void load( final ParameterizedCommand<MySharedPreference2> successCallback,
                       final ParameterizedCommand<Throwable> errorCallback ) {
-        final MyInheritedPreference2BeanGeneratedImpl preferenceBean = this;
+        final MySharedPreference2BeanGeneratedImpl preferenceBean = this;
 
-        store.load( new MyInheritedPreference2PortableGeneratedImpl(), new ParameterizedCommand<BasePreferencePortable<MyInheritedPreference2>>() {
+        store.load( new MySharedPreference2PortableGeneratedImpl(), new ParameterizedCommand<BasePreferencePortable<MySharedPreference2>>() {
             @Override
-            public void execute( final BasePreferencePortable<MyInheritedPreference2> portablePreference ) {
-                copy( (MyInheritedPreference2PortableGeneratedImpl) portablePreference, preferenceBean );
+            public void execute( final BasePreferencePortable<MySharedPreference2> portablePreference ) {
+                copy( (MySharedPreference2PortableGeneratedImpl) portablePreference, preferenceBean );
                 if ( successCallback != null ) {
                     successCallback.execute( preferenceBean );
                 }
@@ -66,8 +66,8 @@ public class MyInheritedPreference2BeanGeneratedImpl extends MyInheritedPreferen
         }, errorCallback );
     }
 
-    private void copy( final MyInheritedPreference2 from,
-                       final MyInheritedPreference2 to ) {
+    private void copy( final MySharedPreference2 from,
+                       final MySharedPreference2 to ) {
         to.text = from.text;
     }
 
@@ -94,25 +94,25 @@ public class MyInheritedPreference2BeanGeneratedImpl extends MyInheritedPreferen
 
     @Override
     public void saveDefaultValue( final ParameterizedCommand<Throwable> errorCallback ) {
-        saveDefaultValue( null, errorCallback );
+        saveDefaultValue( null, errorCallback);
     }
 
     @Override
     public void saveDefaultValue( final Command successCallback,
                                   final ParameterizedCommand<Throwable> errorCallback ) {
-        final MyInheritedPreference2 defaultValue = defaultValue( new MyInheritedPreference2PortableGeneratedImpl() );
+        final MySharedPreference2 defaultValue = defaultValue( new MySharedPreference2PortableGeneratedImpl() );
 
         if ( defaultValue != null ) {
-            if ( defaultValue instanceof MyInheritedPreference2PortableGeneratedImpl ) {
-                store.saveDefaultValue( (MyInheritedPreference2PortableGeneratedImpl) defaultValue, successCallback, errorCallback );
+            if ( defaultValue instanceof MySharedPreference2PortableGeneratedImpl ) {
+                store.saveDefaultValue( (MySharedPreference2PortableGeneratedImpl) defaultValue, successCallback, errorCallback );
             } else {
-                throw new RuntimeException( "Your MyInheritedPreference2.defaultValue( MyInheritedPreference2 emptyPreference ) implementation must return the emptyPreference parameter, only with its attributes modified." );
+                throw new RuntimeException( "Your MySharedPreference2.defaultValue( MySharedPreference2 emptyPreference ) implementation must return the emptyPreference parameter, only with its attributes modified." );
             }
         }
     }
 
-    private BasePreferencePortable<MyInheritedPreference2> createPortableCopy() {
-        MyInheritedPreference2PortableGeneratedImpl portablePreference = new MyInheritedPreference2PortableGeneratedImpl();
+    private BasePreferencePortable<MySharedPreference2> createPortableCopy() {
+        MySharedPreference2PortableGeneratedImpl portablePreference = new MySharedPreference2PortableGeneratedImpl();
 
         copy( this, portablePreference );
 

--- a/uberfire-extensions/uberfire-preferences/uberfire-preferences-backend/src/test/java/org/uberfire/ext/preferences/backend/MySharedPreference2PortableGeneratedImpl.java
+++ b/uberfire-extensions/uberfire-preferences/uberfire-preferences-backend/src/test/java/org/uberfire/ext/preferences/backend/MySharedPreference2PortableGeneratedImpl.java
@@ -27,43 +27,58 @@ import org.uberfire.ext.preferences.shared.annotations.PortablePreference;
 import org.uberfire.ext.preferences.shared.annotations.RootPreference;
 import org.uberfire.ext.preferences.shared.bean.BasePreferencePortable;
 
-@Portable(mapSuperTypes = true)
+@Portable( mapSuperTypes = true )
 @PortablePreference
 @RootPreference
 @Generated("org.uberfire.ext.preferences.processors.WorkbenchPreferenceProcessor")
 /*
 * WARNING! This class is generated. Do not modify.
 */
-public class MyInheritedPreference2PortableGeneratedImpl extends MyInheritedPreference2 implements BasePreferencePortable<MyInheritedPreference2> {
+public class MySharedPreference2PortableGeneratedImpl extends MySharedPreference2 implements BasePreferencePortable<MySharedPreference2> {
 
-    public MyInheritedPreference2PortableGeneratedImpl() {
+    public MySharedPreference2PortableGeneratedImpl() {
     }
 
-    public MyInheritedPreference2PortableGeneratedImpl( @MapsTo("text") String text ) {
+    public MySharedPreference2PortableGeneratedImpl( @MapsTo("text") String text ) {
         this.text = text;
     }
 
     @Override
-    public Class<MyInheritedPreference2> getPojoClass() {
-        return MyInheritedPreference2.class;
+    public Class<MySharedPreference2> getPojoClass() {
+        return MySharedPreference2.class;
+    }
+
+    @Override
+    public String identifier() {
+        return "MySharedPreference2";
+    }
+
+    @Override
+    public String category() {
+        return "MyCategory";
+    }
+
+    @Override
+    public String iconCss() {
+        return "fa-pie-chart";
+    }
+
+    @Override
+    public String[] parents() {
+        return new String[] { "MyInnerPreference2" };
     }
 
     @Override
     public String bundleKey() {
-        return "MyInheritedPreference2.Label";
+        return "MySharedPreference2.Label";
     }
 
     @Override
-    public String key() {
-        return "org.uberfire.ext.preferences.backend.MyInheritedPreference2";
-    }
-
-    @Override
-    public void set( String property,
-                     Object value ) {
+    public void set( String property, Object value ) {
         if ( property.equals( "text" ) ) {
             text = (String) value;
-        } else {
+        } else
+        {
             throw new RuntimeException( "Unknown property: " + property );
         }
     }
@@ -72,7 +87,8 @@ public class MyInheritedPreference2PortableGeneratedImpl extends MyInheritedPref
     public Object get( String property ) {
         if ( property.equals( "text" ) ) {
             return text;
-        } else {
+        } else
+        {
             throw new RuntimeException( "Unknown property: " + property );
         }
     }
@@ -81,7 +97,7 @@ public class MyInheritedPreference2PortableGeneratedImpl extends MyInheritedPref
     public Map<String, PropertyFormType> getPropertiesTypes() {
         Map<String, PropertyFormType> propertiesTypes = new HashMap<>();
 
-        propertiesTypes.put( "text", PropertyFormType.TEXT );
+        propertiesTypes.put( "text", PropertyFormType.TEXT);
 
         return propertiesTypes;
     }
@@ -95,7 +111,7 @@ public class MyInheritedPreference2PortableGeneratedImpl extends MyInheritedPref
             return false;
         }
 
-        final MyInheritedPreference2PortableGeneratedImpl that = (MyInheritedPreference2PortableGeneratedImpl) o;
+        final MySharedPreference2PortableGeneratedImpl that = (MySharedPreference2PortableGeneratedImpl) o;
 
         if ( text != null ? !text.equals( that.text ) : that.text != null ) {
             return false;

--- a/uberfire-extensions/uberfire-preferences/uberfire-preferences-backend/src/test/java/org/uberfire/ext/preferences/backend/MySharedPreferenceBeanGeneratedImpl.java
+++ b/uberfire-extensions/uberfire-preferences/uberfire-preferences-backend/src/test/java/org/uberfire/ext/preferences/backend/MySharedPreferenceBeanGeneratedImpl.java
@@ -31,12 +31,12 @@ import org.uberfire.mvp.ParameterizedCommand;
 /*
 * WARNING! This class is generated. Do not modify.
 */
-public class MyInheritedPreferenceBeanGeneratedImpl extends MyInheritedPreference implements BasePreferenceBean<MyInheritedPreference> {
+public class MySharedPreferenceBeanGeneratedImpl extends MySharedPreference implements BasePreferenceBean<MySharedPreference> {
 
     private PreferenceBeanStore store;
 
     @Inject
-    public MyInheritedPreferenceBeanGeneratedImpl( final PreferenceBeanStore store ) {
+    public MySharedPreferenceBeanGeneratedImpl( final PreferenceBeanStore store ) {
         this.store = store;
     }
 
@@ -51,14 +51,14 @@ public class MyInheritedPreferenceBeanGeneratedImpl extends MyInheritedPreferenc
     }
 
     @Override
-    public void load( final ParameterizedCommand<MyInheritedPreference> successCallback,
+    public void load( final ParameterizedCommand<MySharedPreference> successCallback,
                       final ParameterizedCommand<Throwable> errorCallback ) {
-        final MyInheritedPreferenceBeanGeneratedImpl preferenceBean = this;
+        final MySharedPreferenceBeanGeneratedImpl preferenceBean = this;
 
-        store.load( new MyInheritedPreferencePortableGeneratedImpl(), new ParameterizedCommand<BasePreferencePortable<MyInheritedPreference>>() {
+        store.load( new MySharedPreferencePortableGeneratedImpl(), new ParameterizedCommand<BasePreferencePortable<MySharedPreference>>() {
             @Override
-            public void execute( final BasePreferencePortable<MyInheritedPreference> portablePreference ) {
-                copy( (MyInheritedPreferencePortableGeneratedImpl) portablePreference, preferenceBean );
+            public void execute( final BasePreferencePortable<MySharedPreference> portablePreference ) {
+                copy( (MySharedPreferencePortableGeneratedImpl) portablePreference, preferenceBean );
                 if ( successCallback != null ) {
                     successCallback.execute( preferenceBean );
                 }
@@ -66,8 +66,8 @@ public class MyInheritedPreferenceBeanGeneratedImpl extends MyInheritedPreferenc
         }, errorCallback );
     }
 
-    private void copy( final MyInheritedPreference from,
-                       final MyInheritedPreference to ) {
+    private void copy( final MySharedPreference from,
+                       final MySharedPreference to ) {
         to.text = from.text;
         to.myInnerPreference2 = from.myInnerPreference2;
     }
@@ -95,25 +95,25 @@ public class MyInheritedPreferenceBeanGeneratedImpl extends MyInheritedPreferenc
 
     @Override
     public void saveDefaultValue( final ParameterizedCommand<Throwable> errorCallback ) {
-        saveDefaultValue( null, errorCallback );
+        saveDefaultValue( null, errorCallback);
     }
 
     @Override
     public void saveDefaultValue( final Command successCallback,
                                   final ParameterizedCommand<Throwable> errorCallback ) {
-        final MyInheritedPreference defaultValue = defaultValue( new MyInheritedPreferencePortableGeneratedImpl() );
+        final MySharedPreference defaultValue = defaultValue( new MySharedPreferencePortableGeneratedImpl() );
 
         if ( defaultValue != null ) {
-            if ( defaultValue instanceof MyInheritedPreferencePortableGeneratedImpl ) {
-                store.saveDefaultValue( (MyInheritedPreferencePortableGeneratedImpl) defaultValue, successCallback, errorCallback );
+            if ( defaultValue instanceof MySharedPreferencePortableGeneratedImpl ) {
+                store.saveDefaultValue( (MySharedPreferencePortableGeneratedImpl) defaultValue, successCallback, errorCallback );
             } else {
-                throw new RuntimeException( "Your MyInheritedPreference.defaultValue( MyInheritedPreference emptyPreference ) implementation must return the emptyPreference parameter, only with its attributes modified." );
+                throw new RuntimeException( "Your MySharedPreference.defaultValue( MySharedPreference emptyPreference ) implementation must return the emptyPreference parameter, only with its attributes modified." );
             }
         }
     }
 
-    private BasePreferencePortable<MyInheritedPreference> createPortableCopy() {
-        MyInheritedPreferencePortableGeneratedImpl portablePreference = new MyInheritedPreferencePortableGeneratedImpl();
+    private BasePreferencePortable<MySharedPreference> createPortableCopy() {
+        MySharedPreferencePortableGeneratedImpl portablePreference = new MySharedPreferencePortableGeneratedImpl();
 
         copy( this, portablePreference );
 

--- a/uberfire-extensions/uberfire-preferences/uberfire-preferences-backend/src/test/java/org/uberfire/ext/preferences/backend/MySharedPreferencePortableGeneratedImpl.java
+++ b/uberfire-extensions/uberfire-preferences/uberfire-preferences-backend/src/test/java/org/uberfire/ext/preferences/backend/MySharedPreferencePortableGeneratedImpl.java
@@ -26,45 +26,59 @@ import org.uberfire.ext.preferences.shared.PropertyFormType;
 import org.uberfire.ext.preferences.shared.annotations.PortablePreference;
 import org.uberfire.ext.preferences.shared.bean.BasePreferencePortable;
 
-@Portable(mapSuperTypes = true)
+@Portable( mapSuperTypes = true )
 @PortablePreference
 @Generated("org.uberfire.ext.preferences.processors.WorkbenchPreferenceProcessor")
 /*
 * WARNING! This class is generated. Do not modify.
 */
-public class MyInheritedPreferencePortableGeneratedImpl extends MyInheritedPreference implements BasePreferencePortable<MyInheritedPreference> {
+public class MySharedPreferencePortableGeneratedImpl extends MySharedPreference implements BasePreferencePortable<MySharedPreference> {
 
-    public MyInheritedPreferencePortableGeneratedImpl() {
+    public MySharedPreferencePortableGeneratedImpl() {
         this.myInnerPreference2 = new org.uberfire.ext.preferences.backend.MyInnerPreference2PortableGeneratedImpl();
     }
 
-    public MyInheritedPreferencePortableGeneratedImpl( @MapsTo("text") String text,
-                                                       @MapsTo("myInnerPreference2") org.uberfire.ext.preferences.backend.MyInnerPreference2 myInnerPreference2 ) {
+    public MySharedPreferencePortableGeneratedImpl( @MapsTo("text") String text, @MapsTo("myInnerPreference2") org.uberfire.ext.preferences.backend.MyInnerPreference2 myInnerPreference2 ) {
         this.text = text;
         this.myInnerPreference2 = myInnerPreference2;
     }
 
     @Override
-    public Class<MyInheritedPreference> getPojoClass() {
-        return MyInheritedPreference.class;
+    public Class<MySharedPreference> getPojoClass() {
+        return MySharedPreference.class;
+    }
+
+    @Override
+    public String identifier() {
+        return "MySharedPreference";
+    }
+
+    @Override
+    public String category() {
+        return "";
+    }
+
+    @Override
+    public String iconCss() {
+        return "";
+    }
+
+    @Override
+    public String[] parents() {
+        return new String[] { "" };
     }
 
     @Override
     public String bundleKey() {
-        return "MyInheritedPreference.Label";
+        return "MySharedPreference.Label";
     }
 
     @Override
-    public String key() {
-        return "org.uberfire.ext.preferences.backend.MyInheritedPreference";
-    }
-
-    @Override
-    public void set( String property,
-                     Object value ) {
+    public void set( String property, Object value ) {
         if ( property.equals( "text" ) ) {
             text = (String) value;
-        } else {
+        } else
+        {
             throw new RuntimeException( "Unknown property: " + property );
         }
     }
@@ -73,7 +87,8 @@ public class MyInheritedPreferencePortableGeneratedImpl extends MyInheritedPrefe
     public Object get( String property ) {
         if ( property.equals( "text" ) ) {
             return text;
-        } else {
+        } else
+        {
             throw new RuntimeException( "Unknown property: " + property );
         }
     }
@@ -82,7 +97,7 @@ public class MyInheritedPreferencePortableGeneratedImpl extends MyInheritedPrefe
     public Map<String, PropertyFormType> getPropertiesTypes() {
         Map<String, PropertyFormType> propertiesTypes = new HashMap<>();
 
-        propertiesTypes.put( "text", PropertyFormType.TEXT );
+        propertiesTypes.put( "text", PropertyFormType.TEXT);
 
         return propertiesTypes;
     }
@@ -96,7 +111,7 @@ public class MyInheritedPreferencePortableGeneratedImpl extends MyInheritedPrefe
             return false;
         }
 
-        final MyInheritedPreferencePortableGeneratedImpl that = (MyInheritedPreferencePortableGeneratedImpl) o;
+        final MySharedPreferencePortableGeneratedImpl that = (MySharedPreferencePortableGeneratedImpl) o;
 
         if ( text != null ? !text.equals( that.text ) : that.text != null ) {
             return false;

--- a/uberfire-extensions/uberfire-preferences/uberfire-preferences-backend/src/test/java/org/uberfire/ext/preferences/backend/PreferenceBeanStoreImplTest.java
+++ b/uberfire-extensions/uberfire-preferences/uberfire-preferences-backend/src/test/java/org/uberfire/ext/preferences/backend/PreferenceBeanStoreImplTest.java
@@ -19,6 +19,7 @@ package org.uberfire.ext.preferences.backend;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -29,6 +30,7 @@ import org.uberfire.ext.preferences.shared.bean.BasePreference;
 import org.uberfire.ext.preferences.shared.bean.BasePreferencePortable;
 import org.uberfire.ext.preferences.shared.bean.PreferenceHierarchyElement;
 import org.uberfire.ext.preferences.shared.impl.PreferenceScopeResolutionStrategyInfo;
+import org.uberfire.ext.preferences.shared.bean.PreferenceRootElement;
 
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
@@ -41,13 +43,18 @@ public class PreferenceBeanStoreImplTest {
 
     private PreferenceScopeResolutionStrategy preferenceScopeResolutionStrategy;
 
+    private PreferenceScopeResolutionStrategyInfo scopeInfo;
+
+    private PreferenceScope lastScope;
+
     @Before
     public void setup() {
         preferenceScopeResolutionStrategy = mock( PreferenceScopeResolutionStrategy.class );
         preferenceStore = mock( PreferenceStore.class );
         preferenceBeanStoreImpl = spy( new PreferenceBeanStoreImpl( preferenceStore, preferenceScopeResolutionStrategy, null ) );
 
-        PreferenceScopeResolutionStrategyInfo scopeInfo = new PreferenceScopeResolutionStrategyInfo( Arrays.asList( mock( PreferenceScope.class ) ), mock( PreferenceScope.class ) );
+        lastScope = mock( PreferenceScope.class );
+        scopeInfo = new PreferenceScopeResolutionStrategyInfo( Arrays.asList( lastScope ), mock( PreferenceScope.class ) );
         doReturn( scopeInfo ).when( preferenceScopeResolutionStrategy ).getInfo();
 
         doAnswer( invocationOnMock -> {
@@ -60,24 +67,25 @@ public class PreferenceBeanStoreImplTest {
     @Test
     public void loadTest() {
         MyPreference myPreference = new MyPreferencePortableGeneratedImpl();
-        MyInheritedPreference myInheritedPreference = new MyInheritedPreferencePortableGeneratedImpl();
-        MyInheritedPreference2 myInheritedPreference2 = new MyInheritedPreference2PortableGeneratedImpl();
+        MySharedPreference mySharedPreference = new MySharedPreferencePortableGeneratedImpl();
+        MySharedPreference2 mySharedPreference2 = new MySharedPreference2PortableGeneratedImpl();
 
-        doReturn( myPreference ).when( preferenceStore ).get( MyPreference.class.getName() );
-        doReturn( myInheritedPreference ).when( preferenceStore ).get( MyInheritedPreference.class.getName() );
-        doReturn( myInheritedPreference2 ).when( preferenceStore ).get( MyInheritedPreference2.class.getName() );
+        doReturn( myPreference ).when( preferenceStore ).get( MyPreference.class.getSimpleName() );
+        doReturn( mySharedPreference ).when( preferenceStore ).get( MySharedPreference.class.getSimpleName() );
+        doReturn( mySharedPreference2 ).when( preferenceStore ).get( MySharedPreference2.class.getSimpleName() );
 
         final MyPreferencePortableGeneratedImpl loadedMyPreference = preferenceBeanStoreImpl.load( new MyPreferencePortableGeneratedImpl() );
+        final MySharedPreference2PortableGeneratedImpl loadedMySharedPreference2 = preferenceBeanStoreImpl.load( new MySharedPreference2PortableGeneratedImpl() );
 
         verify( preferenceStore, times( 3 ) ).get( anyString() );
 
-        verify( preferenceStore ).get( MyPreference.class.getName() );
-        verify( preferenceStore ).get( MyInheritedPreference.class.getName() );
-        verify( preferenceStore ).get( MyInheritedPreference2.class.getName() );
+        verify( preferenceStore ).get( MyPreference.class.getSimpleName() );
+        verify( preferenceStore ).get( MySharedPreference.class.getSimpleName() );
+        verify( preferenceStore ).get( MySharedPreference2.class.getSimpleName() );
 
         assertSame( myPreference, loadedMyPreference );
-        assertSame( myInheritedPreference, loadedMyPreference.myInheritedPreference );
-        assertSame( myInheritedPreference2, loadedMyPreference.myInheritedPreference.myInnerPreference2.myInheritedPreference2 );
+        assertSame( mySharedPreference, loadedMyPreference.mySharedPreference );
+        assertSame( mySharedPreference2, loadedMySharedPreference2 );
     }
 
     @Test
@@ -86,11 +94,10 @@ public class PreferenceBeanStoreImplTest {
 
         preferenceBeanStoreImpl.save( myPreference );
 
-        verify( preferenceStore, times( 3 ) ).put( anyString(), any( Object.class ) );
+        verify( preferenceStore, times( 2 ) ).put( any( PreferenceScope.class ), anyString(), any( Object.class ) );
 
-        verify( preferenceStore ).put( MyPreference.class.getName(), myPreference );
-        verify( preferenceStore ).put( MyInheritedPreference.class.getName(), myPreference.myInheritedPreference );
-        verify( preferenceStore ).put( MyInheritedPreference2.class.getName(), myPreference.myInheritedPreference.myInnerPreference2.myInheritedPreference2 );
+        verify( preferenceStore ).put( eq( scopeInfo.defaultScope() ), eq( MyPreference.class.getSimpleName() ), eq( myPreference ) );
+        verify( preferenceStore ).put( eq( scopeInfo.defaultScope() ), eq( MySharedPreference.class.getSimpleName() ), eq( myPreference.mySharedPreference ) );
     }
 
     @Test
@@ -99,85 +106,108 @@ public class PreferenceBeanStoreImplTest {
 
         preferenceBeanStoreImpl.saveDefaultValue( (MyPreferencePortableGeneratedImpl) myPreference.defaultValue( myPreference ) );
 
-        verify( preferenceStore, times( 1 ) ).put( any( PreferenceScope.class ), anyString(), any( Object.class ) );
+        verify( preferenceStore, times( 2 ) ).put( any( PreferenceScope.class ), anyString(), any( Object.class ) );
 
-        verify( preferenceStore ).put( any( PreferenceScope.class ), eq( MyPreference.class.getName() ), eq( myPreference ) );
+        verify( preferenceStore ).put( eq( lastScope ), eq( MyPreference.class.getSimpleName() ), eq( myPreference ) );
+        verify( preferenceStore ).put( eq( lastScope ), eq( MySharedPreference.class.getSimpleName() ), eq( myPreference.mySharedPreference ) );
     }
 
     @Test
     public void saveCollectionTest() {
         final List<BasePreferencePortable<? extends BasePreference<?>>> preferencesToSave = getRootPortablePreferences();
         final MyPreference myPreference = (MyPreference) preferencesToSave.get( 0 );
-        final MyInheritedPreference2 myInheritedPreference2 = (MyInheritedPreference2) preferencesToSave.get( 1 );
+        final MySharedPreference2 mySharedPreference2 = (MySharedPreference2) preferencesToSave.get( 1 );
 
         preferenceBeanStoreImpl.save( preferencesToSave );
 
-        verify( preferenceStore, times( 4 ) ).put( anyString(), any( Object.class ) );
+        verify( preferenceStore, times( 3 ) ).put( any( PreferenceScope.class ), anyString(), any( Object.class ) );
 
-        verify( preferenceStore ).put( MyPreference.class.getName(), myPreference );
-        verify( preferenceStore ).put( MyInheritedPreference.class.getName(), myPreference.myInheritedPreference );
-        verify( preferenceStore ).put( eq( MyInheritedPreference2.class.getName() ), same( myPreference.myInheritedPreference.myInnerPreference2.myInheritedPreference2 ) );
-        verify( preferenceStore ).put( eq( MyInheritedPreference2.class.getName() ), same( myInheritedPreference2 ) );
+        verify( preferenceStore ).put( scopeInfo.defaultScope(), MyPreference.class.getSimpleName(), myPreference );
+        verify( preferenceStore ).put( scopeInfo.defaultScope(), MySharedPreference.class.getSimpleName(), myPreference.mySharedPreference );
+        verify( preferenceStore ).put( eq( scopeInfo.defaultScope() ), eq( MySharedPreference2.class.getSimpleName() ), same( mySharedPreference2 ) );
     }
 
     @Test
     public void buildHierarchyStructureTest() {
         final List<BasePreferencePortable<? extends BasePreference<?>>> rootPreferences = getRootPortablePreferences();
         final MyPreferencePortableGeneratedImpl myPreference = (MyPreferencePortableGeneratedImpl) rootPreferences.get( 0 );
-        final MyInheritedPreference2PortableGeneratedImpl myInheritedPreference2 = (MyInheritedPreference2PortableGeneratedImpl) rootPreferences.get( 1 );
 
         doReturn( rootPreferences ).when( preferenceBeanStoreImpl ).getRootPortablePreferences();
+        doReturn( getPortablePreferences() ).when( preferenceBeanStoreImpl ).getPortablePreferences();
 
-        final List<PreferenceHierarchyElement<?>> preferenceHierarchyElements = preferenceBeanStoreImpl.buildHierarchyStructure();
+        final PreferenceHierarchyElement<?> preferenceHierarchyElement = preferenceBeanStoreImpl.buildHierarchyStructureForRootPreference( myPreference.identifier() );
 
-        assertEquals( 2, preferenceHierarchyElements.size() );
-
-        final PreferenceHierarchyElement<?> firstElement = preferenceHierarchyElements.get( 0 );
-        assertEquals( myPreference.key(), firstElement.getPortablePreference().key() );
+        final PreferenceHierarchyElement<?> firstElement = preferenceHierarchyElement;
+        assertEquals( myPreference.identifier(), firstElement.getPortablePreference().identifier() );
         assertTrue( firstElement.isRoot() );
-        assertFalse( firstElement.isInherited() );
+        assertFalse( firstElement.isShared() );
         assertEquals( 2, firstElement.getChildren().size() );
 
         final PreferenceHierarchyElement<?> firstElementFirstChild = firstElement.getChildren().get( 0 );
-        assertEquals( ( (MyInnerPreferencePortableGeneratedImpl) myPreference.myInnerPreference ).key(), firstElementFirstChild.getPortablePreference().key() );
+        assertEquals( ( ( MyInnerPreferencePortableGeneratedImpl ) myPreference.myInnerPreference ).identifier(), firstElementFirstChild.getPortablePreference().identifier() );
         assertFalse( firstElementFirstChild.isRoot() );
-        assertFalse( firstElementFirstChild.isInherited() );
+        assertFalse( firstElementFirstChild.isShared() );
         assertEquals( 0, firstElementFirstChild.getChildren().size() );
 
         final PreferenceHierarchyElement<?> firstElementSecondChild = firstElement.getChildren().get( 1 );
-        assertEquals( ( (MyInheritedPreferencePortableGeneratedImpl) myPreference.myInheritedPreference ).key(), firstElementSecondChild.getPortablePreference().key() );
+        assertEquals( ( ( MySharedPreferencePortableGeneratedImpl ) myPreference.mySharedPreference ).identifier(), firstElementSecondChild.getPortablePreference().identifier() );
         assertFalse( firstElementSecondChild.isRoot() );
-        assertTrue( firstElementSecondChild.isInherited() );
+        assertTrue( firstElementSecondChild.isShared() );
         assertEquals( 1, firstElementSecondChild.getChildren().size() );
 
         final PreferenceHierarchyElement<?> firstElementSecondChildFirstChild = firstElementSecondChild.getChildren().get( 0 );
-        assertEquals( ( (MyInnerPreference2PortableGeneratedImpl) myPreference.myInheritedPreference.myInnerPreference2 ).key(), firstElementSecondChildFirstChild.getPortablePreference().key() );
+        assertEquals( ( ( MyInnerPreference2PortableGeneratedImpl ) myPreference.mySharedPreference.myInnerPreference2 ).identifier(), firstElementSecondChildFirstChild.getPortablePreference().identifier() );
         assertFalse( firstElementSecondChildFirstChild.isRoot() );
-        assertFalse( firstElementSecondChildFirstChild.isInherited() );
+        assertFalse( firstElementSecondChildFirstChild.isShared() );
         assertEquals( 1, firstElementSecondChildFirstChild.getChildren().size() );
 
         final PreferenceHierarchyElement<?> firstElementSecondChildFirstChildFirstChild = firstElementSecondChildFirstChild.getChildren().get( 0 );
-        assertEquals( ( (MyInheritedPreference2PortableGeneratedImpl) myPreference.myInheritedPreference.myInnerPreference2.myInheritedPreference2 ).key(), firstElementSecondChildFirstChildFirstChild.getPortablePreference().key() );
-        assertFalse( firstElementSecondChildFirstChildFirstChild.isRoot() );
-        assertTrue( firstElementSecondChildFirstChildFirstChild.isInherited() );
+        assertEquals( "MySharedPreference2", firstElementSecondChildFirstChildFirstChild.getPortablePreference().identifier() );
+        assertTrue( firstElementSecondChildFirstChildFirstChild.isRoot() );
+        assertFalse( firstElementSecondChildFirstChildFirstChild.isShared() );
         assertEquals( 0, firstElementSecondChildFirstChildFirstChild.getChildren().size() );
+    }
 
-        final PreferenceHierarchyElement<?> secondElement = preferenceHierarchyElements.get( 1 );
-        assertEquals( myInheritedPreference2.key(), secondElement.getPortablePreference().key() );
-        assertTrue( secondElement.isRoot() );
-        assertFalse( secondElement.isInherited() );
-        assertEquals( 0, secondElement.getChildren().size() );
+    @Test
+    public void buildCategoryStructureTest() {
+        final List<BasePreferencePortable<? extends BasePreference<?>>> rootPreferences = getRootPortablePreferences();
+        final MyPreferencePortableGeneratedImpl myPreference = (MyPreferencePortableGeneratedImpl) rootPreferences.get( 0 );
+        final MySharedPreference2PortableGeneratedImpl mySharedPreference2 = (MySharedPreference2PortableGeneratedImpl) rootPreferences.get( 1 );
+
+        doReturn( rootPreferences ).when( preferenceBeanStoreImpl ).getRootPortablePreferences();
+
+        final Map<String, List<PreferenceRootElement>> rootPreferencesByCategory = preferenceBeanStoreImpl.buildCategoryStructure();
+
+        assertEquals( 1, rootPreferencesByCategory.size() );
+
+        final List<PreferenceRootElement> myCategoryPreferences = rootPreferencesByCategory.get( "MyCategory" );
+        assertNotNull( myCategoryPreferences );
+
+        assertEquals( myPreference.identifier(), myCategoryPreferences.get( 0 ).getIdentifier() );
+        assertEquals( mySharedPreference2.identifier(), myCategoryPreferences.get( 1 ).getIdentifier() );
     }
 
     private List<BasePreferencePortable<? extends BasePreference<?>>> getRootPortablePreferences() {
         final MyPreferencePortableGeneratedImpl myPreference = preferenceBeanStoreImpl.load( new MyPreferencePortableGeneratedImpl() );
-        final MyInheritedPreference2PortableGeneratedImpl myInheritedPreference2 = preferenceBeanStoreImpl.load( new MyInheritedPreference2PortableGeneratedImpl() );
+        final MySharedPreference2PortableGeneratedImpl mySharedPreference2 = preferenceBeanStoreImpl.load( new MySharedPreference2PortableGeneratedImpl() );
 
         List<BasePreferencePortable<? extends BasePreference<?>>> rootPreferences = new ArrayList<>();
         rootPreferences.add( myPreference );
-        rootPreferences.add( myInheritedPreference2 );
+        rootPreferences.add( mySharedPreference2 );
 
         return rootPreferences;
+    }
+
+    private List<BasePreferencePortable<?>> getPortablePreferences() {
+        List<BasePreferencePortable<?>> portablePreferences = new ArrayList<>();
+
+        portablePreferences.add( getPortablePreferenceByClass( MyPreference.class ) );
+        portablePreferences.add( getPortablePreferenceByClass( MyInnerPreference.class ) );
+        portablePreferences.add( getPortablePreferenceByClass( MyInnerPreference2.class ) );
+        portablePreferences.add( getPortablePreferenceByClass( MySharedPreference.class ) );
+        portablePreferences.add( getPortablePreferenceByClass( MySharedPreference2.class ) );
+
+        return portablePreferences;
     }
 
     private BasePreferencePortable<?> getPortablePreferenceByClass( final Class<?> clazz ) {
@@ -187,10 +217,10 @@ public class PreferenceBeanStoreImplTest {
             return new MyInnerPreferencePortableGeneratedImpl();
         } else if ( MyInnerPreference2.class.equals( clazz ) ) {
             return new MyInnerPreference2PortableGeneratedImpl();
-        } else if ( MyInheritedPreference.class.equals( clazz ) ) {
-            return new MyInheritedPreferencePortableGeneratedImpl();
-        } else if ( MyInheritedPreference2.class.equals( clazz ) ) {
-            return new MyInheritedPreference2PortableGeneratedImpl();
+        } else if ( MySharedPreference.class.equals( clazz ) ) {
+            return new MySharedPreferencePortableGeneratedImpl();
+        } else if ( MySharedPreference2.class.equals( clazz ) ) {
+            return new MySharedPreference2PortableGeneratedImpl();
         }
 
         return null;

--- a/uberfire-extensions/uberfire-preferences/uberfire-preferences-client/src/test/java/org/uberfire/ext/preferences/client/store/PreferenceBeanStoreImplTest.java
+++ b/uberfire-extensions/uberfire-preferences/uberfire-preferences-client/src/test/java/org/uberfire/ext/preferences/client/store/PreferenceBeanStoreImplTest.java
@@ -134,12 +134,27 @@ public class PreferenceBeanStoreImplTest {
         }
 
         @Override
-        public String bundleKey() {
+        public String identifier() {
             return null;
         }
 
         @Override
-        public String key() {
+        public String category() {
+            return null;
+        }
+
+        @Override
+        public String iconCss() {
+            return null;
+        }
+
+        @Override
+        public String[] parents() {
+            return new String[ 0 ];
+        }
+
+        @Override
+        public String bundleKey() {
             return null;
         }
 

--- a/uberfire-extensions/uberfire-preferences/uberfire-preferences-processors/src/main/java/org/uberfire/ext/preferences/processors/PropertyData.java
+++ b/uberfire-extensions/uberfire-preferences/uberfire-preferences-processors/src/main/java/org/uberfire/ext/preferences/processors/PropertyData.java
@@ -37,7 +37,7 @@ public class PropertyData {
 
     private String typeFullName;
 
-    private boolean inherited;
+    private boolean shared;
 
     private boolean subPreference;
 
@@ -59,7 +59,7 @@ public class PropertyData {
         final String nameWithoutFirstLetter = fieldName.substring( 1 );
         capitalizedFieldName = elementNameCapitalizedFirstLetter + nameWithoutFirstLetter;
 
-        inherited = propertyAnnotation.inherited();
+        shared = propertyAnnotation.shared();
 
         final TypeElement typeElement = elementUtils.getTypeElement( element.asType().toString() );
         subPreference = typeElement != null && typeElement.getAnnotation( WorkbenchPreference.class ) != null;
@@ -83,8 +83,8 @@ public class PropertyData {
         return typeFullName;
     }
 
-    public boolean isInherited() {
-        return inherited;
+    public boolean isShared() {
+        return shared;
     }
 
     public boolean isSubPreference() {

--- a/uberfire-extensions/uberfire-preferences/uberfire-preferences-processors/src/main/java/org/uberfire/ext/preferences/processors/WorkbenchPreferenceGeneratedImplGenerator.java
+++ b/uberfire-extensions/uberfire-preferences/uberfire-preferences-processors/src/main/java/org/uberfire/ext/preferences/processors/WorkbenchPreferenceGeneratedImplGenerator.java
@@ -67,12 +67,15 @@ public class WorkbenchPreferenceGeneratedImplGenerator extends AbstractGenerator
 
         final WorkbenchPreference annotation = element.getAnnotation( WorkbenchPreference.class );
 
-        boolean rootPreference = annotation.root();
-        String preferenceBundleKey = annotation.bundleKey();
         String sourcePackage = packageName;
         String sourceClassName = className;
-        String preferenceKey = packageName + "." + className;
         String targetPackage = packageName;
+
+        String identifier = annotation.identifier();
+        String category = annotation.category();
+        String iconCss = annotation.iconCss();
+        String[] parents = annotation.parents();
+        String bundleKey = annotation.bundleKey();
 
         if ( GeneratorContext.BEAN.equals( generatorContext ) ) {
             targetClassName = className + "BeanGeneratedImpl";
@@ -98,12 +101,12 @@ public class WorkbenchPreferenceGeneratedImplGenerator extends AbstractGenerator
                 .filter( p -> p.isSubPreference() )
                 .collect( Collectors.toList() );
 
-        final List<PropertyData> nonInheritedSubPreferences = subPreferences.stream()
-                .filter( p -> !p.isInherited() )
+        final List<PropertyData> nonSharedSubPreferences = subPreferences.stream()
+                .filter( p -> !p.isShared() )
                 .collect( Collectors.toList() );
 
-        final List<PropertyData> inheritedSubPreferences = subPreferences.stream()
-                .filter( p -> p.isInherited() )
+        final List<PropertyData> sharedSubPreferences = subPreferences.stream()
+                .filter( p -> p.isShared() )
                 .collect( Collectors.toList() );
 
         final List<String> constructorParams = properties.stream()
@@ -116,6 +119,8 @@ public class WorkbenchPreferenceGeneratedImplGenerator extends AbstractGenerator
                 .collect( Collectors.toList() );
         final String propertyFieldsText = String.join( ", ", propertyFields );
 
+        final String parentsIdentifiers = String.join( ", ", parents );
+
         if ( GeneratorUtils.debugLoggingEnabled() ) {
             final List<String> simplePropertiesNames = simpleProperties.stream()
                     .map( PropertyData::getFieldName )
@@ -127,26 +132,29 @@ public class WorkbenchPreferenceGeneratedImplGenerator extends AbstractGenerator
                     .collect( Collectors.toList() );
             final String subPreferencesText = String.join( ", ", subPreferencesNames );
 
-            final List<String> inheritedSubPreferencesNames = inheritedSubPreferences.stream()
+            final List<String> sharedSubPreferencesNames = sharedSubPreferences.stream()
                     .map( PropertyData::getFieldName )
                     .collect( Collectors.toList() );
-            final String inheritedSubPreferencesText = String.join( ", ", inheritedSubPreferencesNames );
+            final String sharedSubPreferencesText = String.join( ", ", sharedSubPreferencesNames );
 
-            final List<String> nonInheritedSubPreferencesNames = nonInheritedSubPreferences.stream()
+            final List<String> nonSharedSubPreferencesNames = nonSharedSubPreferences.stream()
                     .map( PropertyData::getFieldName )
                     .collect( Collectors.toList() );
-            final String nonInheritedSubPreferencesText = String.join( ", ", nonInheritedSubPreferencesNames );
+            final String nonSharedSubPreferencesText = String.join( ", ", nonSharedSubPreferencesNames );
 
             messager.printMessage( Kind.NOTE, "Source package name: " + sourcePackage );
             messager.printMessage( Kind.NOTE, "Source class name: " + sourceClassName );
             messager.printMessage( Kind.NOTE, "Target package name: " + targetPackage );
             messager.printMessage( Kind.NOTE, "Target class name: " + targetClassName );
-            messager.printMessage( Kind.NOTE, "Preference key: " + preferenceKey );
+            messager.printMessage( Kind.NOTE, "Identifier: " + identifier );
+            messager.printMessage( Kind.NOTE, "Category: " + category );
+            messager.printMessage( Kind.NOTE, "Icon css: " + iconCss );
+            messager.printMessage( Kind.NOTE, "Parents: " + parentsIdentifiers );
             messager.printMessage( Kind.NOTE, "Property fields: " + propertyFieldsText );
             messager.printMessage( Kind.NOTE, "Simple properties fields: " + simplePropertiesText );
             messager.printMessage( Kind.NOTE, "Sub-preferences fields: " + subPreferencesText );
-            messager.printMessage( Kind.NOTE, "Inherited subPreferences fields: " + inheritedSubPreferencesText );
-            messager.printMessage( Kind.NOTE, "Non-inherited subPreferences fields: " + nonInheritedSubPreferencesText );
+            messager.printMessage( Kind.NOTE, "Shared subPreferences fields: " + sharedSubPreferencesText );
+            messager.printMessage( Kind.NOTE, "Non-shared subPreferences fields: " + nonSharedSubPreferencesText );
             messager.printMessage( Kind.NOTE, "Constructor parameters: " + constructorParamsText );
         }
 
@@ -159,22 +167,26 @@ public class WorkbenchPreferenceGeneratedImplGenerator extends AbstractGenerator
                   targetPackage );
         root.put( "targetClassName",
                   targetClassName );
-        root.put( "preferenceKey",
-                  preferenceKey );
-        root.put( "rootPreference",
-                  rootPreference );
-        root.put( "preferenceBundleKey",
-                  preferenceBundleKey );
+        root.put( "identifier",
+                  identifier );
+        root.put( "category",
+                  category );
+        root.put( "iconCss",
+                  iconCss );
+        root.put( "parentsIdentifiers",
+                  parentsIdentifiers );
+        root.put( "bundleKey",
+                  bundleKey );
         root.put( "properties",
                   properties );
         root.put( "simpleProperties",
                   simpleProperties );
         root.put( "subPreferences",
                   subPreferences );
-        root.put( "inheritedSubPreferences",
-                  inheritedSubPreferences );
-        root.put( "nonInheritedSubPreferences",
-                  nonInheritedSubPreferences );
+        root.put( "sharedSubPreferences",
+                  sharedSubPreferences );
+        root.put( "nonSharedSubPreferences",
+                  nonSharedSubPreferences );
         root.put( "constructorParamsText",
                   constructorParamsText );
         root.put( "propertyFieldsText",

--- a/uberfire-extensions/uberfire-preferences/uberfire-preferences-processors/src/main/resources/org/uberfire/ext/preferences/processors/templates/workbenchPreferencePortable.ftl
+++ b/uberfire-extensions/uberfire-preferences/uberfire-preferences-processors/src/main/resources/org/uberfire/ext/preferences/processors/templates/workbenchPreferencePortable.ftl
@@ -24,7 +24,7 @@ import javax.annotation.Generated;
 import org.jboss.errai.common.client.api.annotations.MapsTo;
 import org.jboss.errai.common.client.api.annotations.Portable;
 import org.uberfire.ext.preferences.shared.annotations.PortablePreference;
-<#if rootPreference>
+<#if category != "">
 import org.uberfire.ext.preferences.shared.annotations.RootPreference;
 </#if>
 import org.uberfire.ext.preferences.shared.bean.BasePreferencePortable;
@@ -34,7 +34,7 @@ import org.uberfire.mvp.ParameterizedCommand;
 
 @Portable( mapSuperTypes = true )
 @PortablePreference
-<#if rootPreference>
+<#if category != "">
 @RootPreference
 </#if>
 @Generated("org.uberfire.ext.preferences.processors.WorkbenchPreferenceProcessor")
@@ -69,17 +69,32 @@ public class ${targetClassName} extends ${sourceClassName} implements BasePrefer
     }
 
     @Override
-    public String bundleKey() {
-    <#if preferenceBundleKey == "">
-        return "${sourceClassName}";
-    <#else>
-        return "${preferenceBundleKey}";
-    </#if>
+    public String identifier() {
+        return "${identifier}";
     }
 
     @Override
-    public String key() {
-        return "${preferenceKey}";
+    public String category() {
+        return "${category}";
+    }
+
+    @Override
+    public String iconCss() {
+        return "${iconCss}";
+    }
+
+    @Override
+    public String[] parents() {
+        return new String[] { "${parentsIdentifiers}" };
+    }
+
+    @Override
+    public String bundleKey() {
+    <#if bundleKey == "">
+        return "${identifier}";
+    <#else>
+        return "${bundleKey}";
+    </#if>
     }
 
     @Override

--- a/uberfire-extensions/uberfire-preferences/uberfire-preferences-processors/src/test/java/org/uberfire/ext/preferences/processors/MyInnerPreference.java
+++ b/uberfire-extensions/uberfire-preferences/uberfire-preferences-processors/src/test/java/org/uberfire/ext/preferences/processors/MyInnerPreference.java
@@ -20,7 +20,8 @@ import org.uberfire.ext.preferences.shared.annotations.Property;
 import org.uberfire.ext.preferences.shared.annotations.WorkbenchPreference;
 import org.uberfire.ext.preferences.shared.bean.BasePreference;
 
-@WorkbenchPreference(root = false, bundleKey = "MyInnerPreference.Label")
+@WorkbenchPreference(identifier = "MyInnerPreference",
+        bundleKey = "MyInnerPreference.Label")
 public class MyInnerPreference implements BasePreference<MyInnerPreference> {
 
     @Property(bundleKey = "MyInnerPreference.Text")

--- a/uberfire-extensions/uberfire-preferences/uberfire-preferences-processors/src/test/java/org/uberfire/ext/preferences/processors/MyInnerPreference2.java
+++ b/uberfire-extensions/uberfire-preferences/uberfire-preferences-processors/src/test/java/org/uberfire/ext/preferences/processors/MyInnerPreference2.java
@@ -20,12 +20,10 @@ import org.uberfire.ext.preferences.shared.annotations.Property;
 import org.uberfire.ext.preferences.shared.annotations.WorkbenchPreference;
 import org.uberfire.ext.preferences.shared.bean.BasePreference;
 
-@WorkbenchPreference(root = false, bundleKey = "MyInnerPreference2.Label")
+@WorkbenchPreference(identifier = "MyInnerPreference2",
+        bundleKey = "MyInnerPreference2.Label")
 public class MyInnerPreference2 implements BasePreference<MyInnerPreference2> {
 
     @Property(bundleKey = "MyInnerPreference2.Text")
     String text;
-
-    @Property(inherited = true, bundleKey = "MyInnerPreference2.MyInheritedPreference2")
-    MyInheritedPreference2 myInheritedPreference2;
 }

--- a/uberfire-extensions/uberfire-preferences/uberfire-preferences-processors/src/test/java/org/uberfire/ext/preferences/processors/MySharedPreference.java
+++ b/uberfire-extensions/uberfire-preferences/uberfire-preferences-processors/src/test/java/org/uberfire/ext/preferences/processors/MySharedPreference.java
@@ -20,9 +20,13 @@ import org.uberfire.ext.preferences.shared.annotations.Property;
 import org.uberfire.ext.preferences.shared.annotations.WorkbenchPreference;
 import org.uberfire.ext.preferences.shared.bean.BasePreference;
 
-@WorkbenchPreference(bundleKey = "MyInheritedPreference2.Label")
-public class MyInheritedPreference2 implements BasePreference<MyInheritedPreference2> {
+@WorkbenchPreference(identifier = "MySharedPreference",
+        bundleKey = "MySharedPreference.Label")
+public class MySharedPreference implements BasePreference<MySharedPreference> {
 
-    @Property(bundleKey = "MyInheritedPreference2.Text")
+    @Property(bundleKey = "MySharedPreference.Text")
     String text;
+
+    @Property(bundleKey = "MySharedPreference.MyInnerPreference2")
+    MyInnerPreference2 myInnerPreference2;
 }

--- a/uberfire-extensions/uberfire-preferences/uberfire-preferences-processors/src/test/java/org/uberfire/ext/preferences/processors/MySharedPreference2.java
+++ b/uberfire-extensions/uberfire-preferences/uberfire-preferences-processors/src/test/java/org/uberfire/ext/preferences/processors/MySharedPreference2.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.ext.preferences.processors;
+
+import org.uberfire.ext.preferences.shared.annotations.Property;
+import org.uberfire.ext.preferences.shared.annotations.WorkbenchPreference;
+import org.uberfire.ext.preferences.shared.bean.BasePreference;
+
+@WorkbenchPreference(identifier = "MySharedPreference2",
+        parents = "MyInnerPreference2",
+        bundleKey = "MySharedPreference2.Label",
+        category = "MyCategory",
+        iconCss = "fa-pie-chart")
+public class MySharedPreference2 implements BasePreference<MySharedPreference2> {
+
+    @Property(bundleKey = "MySharedPreference2.Text")
+    String text;
+
+    @Override
+    public MySharedPreference2 defaultValue( final MySharedPreference2 defaultValue ) {
+        defaultValue.text = "text";
+
+        return defaultValue;
+    }
+}

--- a/uberfire-extensions/uberfire-preferences/uberfire-preferences-processors/src/test/resources/org/uberfire/ext/preferences/processors/MyPreference.java
+++ b/uberfire-extensions/uberfire-preferences/uberfire-preferences-processors/src/test/resources/org/uberfire/ext/preferences/processors/MyPreference.java
@@ -21,7 +21,10 @@ import org.uberfire.ext.preferences.shared.annotations.Property;
 import org.uberfire.ext.preferences.shared.annotations.WorkbenchPreference;
 import org.uberfire.ext.preferences.shared.bean.BasePreference;
 
-@WorkbenchPreference(bundleKey = "MyPreference.Label")
+@WorkbenchPreference(identifier = "MyPreference",
+        category = "MyCategory",
+        bundleKey = "MyPreference.Label",
+        iconCss = "fa-gear")
 public class MyPreference implements BasePreference<MyPreference> {
 
     @Property(bundleKey = "MyPreference.Text")
@@ -42,8 +45,8 @@ public class MyPreference implements BasePreference<MyPreference> {
     @Property(bundleKey = "MyPreference.MyInnerPreference")
     MyInnerPreference myInnerPreference;
 
-    @Property(inherited = true, bundleKey = "MyPreference.MyInheritedPreference")
-    MyInheritedPreference myInheritedPreference;
+    @Property(shared = true, bundleKey = "MyPreference.MySharedPreference")
+    MySharedPreference mySharedPreference;
 
     @Override
     public MyPreference defaultValue( final MyPreference defaultValue ) {
@@ -53,9 +56,8 @@ public class MyPreference implements BasePreference<MyPreference> {
         defaultValue.age = 27;
         defaultValue.password = "password";
         defaultValue.myInnerPreference.text = "text";
-        defaultValue.myInheritedPreference.text = "text";
-        defaultValue.myInheritedPreference.myInnerPreference2.text = "text";
-        defaultValue.myInheritedPreference.myInnerPreference2.myInheritedPreference2.text = "text";
+        defaultValue.mySharedPreference.text = "text";
+        defaultValue.mySharedPreference.myInnerPreference2.text = "text";
 
         return defaultValue;
     }

--- a/uberfire-extensions/uberfire-preferences/uberfire-preferences-processors/src/test/resources/org/uberfire/ext/preferences/processors/expected/MyPreferenceBeanGeneratedImpl.expected
+++ b/uberfire-extensions/uberfire-preferences/uberfire-preferences-processors/src/test/resources/org/uberfire/ext/preferences/processors/expected/MyPreferenceBeanGeneratedImpl.expected
@@ -74,7 +74,7 @@ public class MyPreferenceBeanGeneratedImpl extends MyPreference implements BaseP
         to.age = from.age;
         to.password = from.password;
         to.myInnerPreference = from.myInnerPreference;
-        to.myInheritedPreference = from.myInheritedPreference;
+        to.mySharedPreference = from.mySharedPreference;
     }
 
     @Override

--- a/uberfire-extensions/uberfire-preferences/uberfire-preferences-processors/src/test/resources/org/uberfire/ext/preferences/processors/expected/MyPreferencePortableGeneratedImpl.expected
+++ b/uberfire-extensions/uberfire-preferences/uberfire-preferences-processors/src/test/resources/org/uberfire/ext/preferences/processors/expected/MyPreferencePortableGeneratedImpl.expected
@@ -41,17 +41,17 @@ public class MyPreferencePortableGeneratedImpl extends MyPreference implements B
 
     public MyPreferencePortableGeneratedImpl() {
         this.myInnerPreference = new org.uberfire.ext.preferences.processors.MyInnerPreferencePortableGeneratedImpl();
-        this.myInheritedPreference = new org.uberfire.ext.preferences.processors.MyInheritedPreferencePortableGeneratedImpl();
+        this.mySharedPreference = new org.uberfire.ext.preferences.processors.MySharedPreferencePortableGeneratedImpl();
     }
 
-    public MyPreferencePortableGeneratedImpl( @MapsTo("text") java.lang.String text, @MapsTo("sendReports") boolean sendReports, @MapsTo("backgroundColor") java.lang.String backgroundColor, @MapsTo("age") int age, @MapsTo("password") java.lang.String password, @MapsTo("myInnerPreference") org.uberfire.ext.preferences.processors.MyInnerPreference myInnerPreference, @MapsTo("myInheritedPreference") org.uberfire.ext.preferences.processors.MyInheritedPreference myInheritedPreference ) {
+    public MyPreferencePortableGeneratedImpl( @MapsTo("text") java.lang.String text, @MapsTo("sendReports") boolean sendReports, @MapsTo("backgroundColor") java.lang.String backgroundColor, @MapsTo("age") int age, @MapsTo("password") java.lang.String password, @MapsTo("myInnerPreference") org.uberfire.ext.preferences.processors.MyInnerPreference myInnerPreference, @MapsTo("mySharedPreference") org.uberfire.ext.preferences.processors.MySharedPreference mySharedPreference ) {
         this.text = text;
         this.sendReports = sendReports;
         this.backgroundColor = backgroundColor;
         this.age = age;
         this.password = password;
         this.myInnerPreference = myInnerPreference;
-        this.myInheritedPreference = myInheritedPreference;
+        this.mySharedPreference = mySharedPreference;
     }
 
     @Override
@@ -60,13 +60,28 @@ public class MyPreferencePortableGeneratedImpl extends MyPreference implements B
     }
 
     @Override
-    public String bundleKey() {
-        return "MyPreference.Label";
+    public String identifier() {
+        return "MyPreference";
     }
 
     @Override
-    public String key() {
-        return "org.uberfire.ext.preferences.processors.MyPreference";
+    public String category() {
+        return "MyCategory";
+    }
+
+    @Override
+    public String iconCss() {
+        return "fa-gear";
+    }
+
+    @Override
+    public String[] parents() {
+        return new String[] { "" };
+    }
+
+    @Override
+    public String bundleKey() {
+        return "MyPreference.Label";
     }
 
     @Override
@@ -155,7 +170,7 @@ public class MyPreferencePortableGeneratedImpl extends MyPreference implements B
         if ( myInnerPreference != null ? !myInnerPreference.equals( that.myInnerPreference ) : that.myInnerPreference != null ) {
             return false;
         }
-        if ( myInheritedPreference != null ? !myInheritedPreference.equals( that.myInheritedPreference ) : that.myInheritedPreference != null ) {
+        if ( mySharedPreference != null ? !mySharedPreference.equals( that.mySharedPreference ) : that.mySharedPreference != null ) {
             return false;
         }
 
@@ -178,7 +193,7 @@ public class MyPreferencePortableGeneratedImpl extends MyPreference implements B
         result = ~~result;
         result = 31 * result + ( myInnerPreference != null ? myInnerPreference.hashCode() : 0 );
         result = ~~result;
-        result = 31 * result + ( myInheritedPreference != null ? myInheritedPreference.hashCode() : 0 );
+        result = 31 * result + ( mySharedPreference != null ? mySharedPreference.hashCode() : 0 );
         result = ~~result;
 
         return result;

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-webapp/src/main/java/org/uberfire/ext/wires/client/ShowcaseEntryPoint.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-webapp/src/main/java/org/uberfire/ext/wires/client/ShowcaseEntryPoint.java
@@ -28,6 +28,8 @@ import org.uberfire.client.mvp.ActivityManager;
 import org.uberfire.client.mvp.PlaceManager;
 import org.uberfire.client.workbench.widgets.menu.WorkbenchMenuBarPresenter;
 import org.uberfire.ext.wires.client.preferences.central.PreferencesCentralPerspective;
+import org.uberfire.ext.wires.client.preferences.settings.SettingsPerspective;
+import org.uberfire.ext.wires.client.preferences.settings.home.register.WorkbenchSettings;
 import org.uberfire.mvp.Command;
 import org.uberfire.mvp.impl.DefaultPlaceRequest;
 import org.uberfire.workbench.model.menu.MenuPosition;
@@ -48,12 +50,20 @@ public class ShowcaseEntryPoint {
     private WorkbenchMenuBarPresenter menubar;
 
     @Inject
+    private WorkbenchSettings settings;
+
+    @Inject
     private ActivityManager activityManager;
 
     @AfterInitialization
     public void startApp() {
         setupMenu();
+        setupSettings();
         hideLoadingPopup();
+    }
+
+    private void setupSettings() {
+        settings.addItem( "Apps", "fa-map", "Other", () -> placeManager.goTo( new DefaultPlaceRequest( "AppsPerspective" ) ) );
     }
 
     private void setupMenu() {
@@ -97,10 +107,10 @@ public class ShowcaseEntryPoint {
             public void execute() {
                 placeManager.goTo( new DefaultPlaceRequest( "UFWidgets" ) );
             }
-        } ).endMenu().newTopLevelMenu( "Preferences" ).respondsWith( new Command() {
+        } ).endMenu().newTopLevelMenu( "Settings" ).respondsWith( new Command() {
             @Override
             public void execute() {
-                placeManager.goTo( new DefaultPlaceRequest( PreferencesCentralPerspective.IDENTIFIER ) );
+                placeManager.goTo( new DefaultPlaceRequest( SettingsPerspective.IDENTIFIER ) );
             }
         } ).endMenu().newTopLevelMenu( "Logout" ).position( MenuPosition.RIGHT ).respondsWith( new Command() {
             @Override

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-webapp/src/main/java/org/uberfire/ext/wires/client/preferences/central/PreferencesCentralNavBarScreen.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-webapp/src/main/java/org/uberfire/ext/wires/client/preferences/central/PreferencesCentralNavBarScreen.java
@@ -16,25 +16,48 @@
 
 package org.uberfire.ext.wires.client.preferences.central;
 
+import javax.enterprise.event.Event;
 import javax.inject.Inject;
 
+import org.jboss.errai.common.client.api.Caller;
+import org.uberfire.client.annotations.DefaultPosition;
 import org.uberfire.client.annotations.WorkbenchPartTitle;
 import org.uberfire.client.annotations.WorkbenchPartView;
 import org.uberfire.client.annotations.WorkbenchScreen;
+import org.uberfire.ext.preferences.shared.bean.PreferenceBeanServerStore;
 import org.uberfire.ext.wires.client.preferences.central.hierarchy.HierarchyStructurePresenter;
 import org.uberfire.ext.wires.client.preferences.central.hierarchy.HierarchyStructureView;
+import org.uberfire.ext.wires.client.preferences.central.tree.TreeHierarchyStructurePresenter;
 import org.uberfire.ext.wires.client.preferences.central.tree.TreeView;
+import org.uberfire.lifecycle.OnStartup;
+import org.uberfire.mvp.PlaceRequest;
+import org.uberfire.workbench.events.NotificationEvent;
+import org.uberfire.workbench.model.CompassPosition;
 
 @WorkbenchScreen(identifier = PreferencesCentralNavBarScreen.IDENTIFIER)
 public class PreferencesCentralNavBarScreen {
 
     public static final String IDENTIFIER = "PreferencesCentralNavBarScreen";
 
-    private HierarchyStructurePresenter presenter;
+    private final HierarchyStructurePresenter hierarchyStructurePresenter;
+
+    private final Caller<PreferenceBeanServerStore> preferenceBeanServerStoreCaller;
+
+    private final Event<NotificationEvent> notification;
 
     @Inject
-    public PreferencesCentralNavBarScreen( @TreeView final HierarchyStructurePresenter presenter ) {
-        this.presenter = presenter;
+    public PreferencesCentralNavBarScreen( @TreeView final HierarchyStructurePresenter treePresenter,
+                                           final Caller<PreferenceBeanServerStore> preferenceBeanServerStoreCaller,
+                                           final Event<NotificationEvent> notification ) {
+        this.hierarchyStructurePresenter = treePresenter;
+        this.preferenceBeanServerStoreCaller = preferenceBeanServerStoreCaller;
+        this.notification = notification;
+    }
+
+    @OnStartup
+    public void onStartup( final PlaceRequest placeRequest ) {
+        final String preferenceIdentifier = placeRequest.getParameter( "identifier", null );
+        hierarchyStructurePresenter.init( preferenceIdentifier );
     }
 
     @WorkbenchPartTitle
@@ -44,6 +67,11 @@ public class PreferencesCentralNavBarScreen {
 
     @WorkbenchPartView
     public HierarchyStructureView getView() {
-        return presenter.getView();
+        return hierarchyStructurePresenter.getView();
+    }
+
+    @DefaultPosition
+    public CompassPosition getDefaultPosition() {
+        return CompassPosition.WEST;
     }
 }

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-webapp/src/main/java/org/uberfire/ext/wires/client/preferences/central/PreferencesCentralPerspective.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-webapp/src/main/java/org/uberfire/ext/wires/client/preferences/central/PreferencesCentralPerspective.java
@@ -17,13 +17,21 @@
 package org.uberfire.ext.wires.client.preferences.central;
 
 import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.context.Dependent;
+import javax.enterprise.event.Observes;
+import javax.inject.Inject;
 
 import org.uberfire.client.annotations.Perspective;
 import org.uberfire.client.annotations.WorkbenchPerspective;
+import org.uberfire.client.workbench.docks.UberfireDock;
+import org.uberfire.client.workbench.docks.UberfireDockPosition;
+import org.uberfire.client.workbench.docks.UberfireDockReadyEvent;
+import org.uberfire.client.workbench.docks.UberfireDocks;
 import org.uberfire.client.workbench.panels.impl.MultiListWorkbenchPanelPresenter;
-import org.uberfire.client.workbench.panels.impl.SimpleWorkbenchPanelPresenter;
 import org.uberfire.client.workbench.panels.impl.StaticWorkbenchPanelPresenter;
 import org.uberfire.ext.wires.client.preferences.central.actions.PreferencesCentralActionsScreen;
+import org.uberfire.lifecycle.OnStartup;
+import org.uberfire.mvp.PlaceRequest;
 import org.uberfire.mvp.impl.DefaultPlaceRequest;
 import org.uberfire.workbench.model.CompassPosition;
 import org.uberfire.workbench.model.PanelDefinition;
@@ -38,26 +46,53 @@ public class PreferencesCentralPerspective {
 
     public static final String IDENTIFIER = "PreferencesCentralPerspective";
 
+    @Inject
+    private UberfireDocks uberfireDocks;
+
+    private UberfireDock dock;
+
     private PerspectiveDefinition perspective;
+
+    private void setupNavBarDock( final PlaceRequest placeRequest ) {
+        final String title = placeRequest.getParameter( "title", null );
+
+        if ( dock != null ) {
+            uberfireDocks.remove( dock );
+        }
+
+        dock = new UberfireDock( UberfireDockPosition.WEST,
+                                 "ADJUST",
+                                 placeRequest,
+                                 IDENTIFIER )
+                .withSize( 420 )
+                .withLabel( title );
+
+        uberfireDocks.add( dock );
+    }
+
+    public void perspectiveChangeEvent( @Observes UberfireDockReadyEvent dockReadyEvent ) {
+        if ( dockReadyEvent.getCurrentPerspective().equals( IDENTIFIER ) ) {
+            uberfireDocks.expand( dock );
+        }
+    }
 
     @Perspective
     public PerspectiveDefinition getPerspective() {
-        perspective = new PerspectiveDefinitionImpl( MultiListWorkbenchPanelPresenter.class.getName() );
-        perspective.setName( "Preferences Central" );
+        return perspective;
+    }
 
-        final PanelDefinition navBar = new PanelDefinitionImpl( SimpleWorkbenchPanelPresenter.class.getName() );
-        navBar.setWidth( 400 );
-        navBar.addPart( new PartDefinitionImpl( new DefaultPlaceRequest( PreferencesCentralNavBarScreen.IDENTIFIER ) ) );
+    @OnStartup
+    public void onStartup( final PlaceRequest placeRequest ) {
+        perspective = new PerspectiveDefinitionImpl( MultiListWorkbenchPanelPresenter.class.getName() );
+        perspective.setName( "Preferences" );
 
         final PanelDefinition actionsBar = new PanelDefinitionImpl( StaticWorkbenchPanelPresenter.class.getName() );
         actionsBar.setHeight( 80 );
-        actionsBar.addPart( new PartDefinitionImpl( new DefaultPlaceRequest( PreferencesCentralActionsScreen.IDENTIFIER ) ) );
+        actionsBar.addPart( new PartDefinitionImpl( new DefaultPlaceRequest( PreferencesCentralActionsScreen.IDENTIFIER, placeRequest.getParameters() ) ) );
 
-        perspective.getRoot().insertChild( CompassPosition.WEST,
-                                           navBar );
         perspective.getRoot().insertChild( CompassPosition.SOUTH,
                                            actionsBar );
 
-        return perspective;
+        setupNavBarDock( new DefaultPlaceRequest( PreferencesCentralNavBarScreen.IDENTIFIER, placeRequest.getParameters() ) );
     }
 }

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-webapp/src/main/java/org/uberfire/ext/wires/client/preferences/central/actions/PreferencesCentralActionsScreen.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-webapp/src/main/java/org/uberfire/ext/wires/client/preferences/central/actions/PreferencesCentralActionsScreen.java
@@ -20,14 +20,19 @@ import javax.annotation.PostConstruct;
 import javax.enterprise.event.Event;
 import javax.inject.Inject;
 
+import org.uberfire.client.annotations.DefaultPosition;
 import org.uberfire.client.annotations.WorkbenchPartTitle;
 import org.uberfire.client.annotations.WorkbenchPartView;
 import org.uberfire.client.annotations.WorkbenchScreen;
+import org.uberfire.client.mvp.PlaceManager;
 import org.uberfire.client.mvp.UberElement;
 import org.uberfire.ext.preferences.client.event.PreferencesCentralPreSaveEvent;
 import org.uberfire.ext.preferences.client.event.PreferencesCentralSaveEvent;
 import org.uberfire.ext.preferences.client.event.PreferencesCentralUndoChangesEvent;
 import org.uberfire.ext.wires.client.preferences.central.hierarchy.HierarchyStructureView;
+import org.uberfire.ext.wires.client.preferences.settings.SettingsPerspective;
+import org.uberfire.workbench.events.NotificationEvent;
+import org.uberfire.workbench.model.CompassPosition;
 
 @WorkbenchScreen( identifier = PreferencesCentralActionsScreen.IDENTIFIER )
 public class PreferencesCentralActionsScreen {
@@ -41,21 +46,29 @@ public class PreferencesCentralActionsScreen {
 
     private final View view;
 
+    private final PlaceManager placeManager;
+
     private final Event<PreferencesCentralPreSaveEvent> preSaveEvent;
 
     private final Event<PreferencesCentralSaveEvent> saveEvent;
 
     private final Event<PreferencesCentralUndoChangesEvent> undoChangesEvent;
 
+    private final Event<NotificationEvent> notification;
+
     @Inject
     public PreferencesCentralActionsScreen( final View view,
+                                            final PlaceManager placeManager,
                                             final Event<PreferencesCentralPreSaveEvent> preSaveEvent,
                                             final Event<PreferencesCentralSaveEvent> saveEvent,
-                                            final Event<PreferencesCentralUndoChangesEvent> undoChangesEvent ) {
+                                            final Event<PreferencesCentralUndoChangesEvent> undoChangesEvent,
+                                            final Event<NotificationEvent> notification ) {
         this.view = view;
+        this.placeManager = placeManager;
         this.preSaveEvent = preSaveEvent;
         this.saveEvent = saveEvent;
         this.undoChangesEvent = undoChangesEvent;
+        this.notification = notification;
     }
 
     @PostConstruct
@@ -66,10 +79,17 @@ public class PreferencesCentralActionsScreen {
     public void fireSaveEvent() {
         preSaveEvent.fire( new PreferencesCentralPreSaveEvent() );
         saveEvent.fire( new PreferencesCentralSaveEvent() );
+        goBackToHome();
     }
 
-    public void fireUndoChangesEvent() {
+    public void fireCancelEvent() {
         undoChangesEvent.fire( new PreferencesCentralUndoChangesEvent() );
+        notification.fire( new NotificationEvent( "Changes undone successfully!", NotificationEvent.NotificationType.SUCCESS ) );
+        goBackToHome();
+    }
+
+    private void goBackToHome() {
+        placeManager.goTo( SettingsPerspective.IDENTIFIER );
     }
 
     @WorkbenchPartTitle
@@ -80,5 +100,10 @@ public class PreferencesCentralActionsScreen {
     @WorkbenchPartView
     public HierarchyStructureView getView() {
         return view;
+    }
+
+    @DefaultPosition
+    public CompassPosition getDefaultPosition() {
+        return CompassPosition.SOUTH;
     }
 }

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-webapp/src/main/java/org/uberfire/ext/wires/client/preferences/central/actions/PreferencesCentralActionsView.css
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-webapp/src/main/java/org/uberfire/ext/wires/client/preferences/central/actions/PreferencesCentralActionsView.css
@@ -17,4 +17,5 @@
 .preference-actions {
     text-align: right;
     padding: 20px;
+    background-color: #F5F5F5;
 }

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-webapp/src/main/java/org/uberfire/ext/wires/client/preferences/central/actions/PreferencesCentralActionsView.html
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-webapp/src/main/java/org/uberfire/ext/wires/client/preferences/central/actions/PreferencesCentralActionsView.html
@@ -16,5 +16,5 @@
 
 <div class="preference-actions">
     <button data-field="preference-actions-save" class="btn btn-primary btn-lg">Save</button>
-    <button data-field="preference-actions-undo" class="btn btn-lg">Undo changes</button>
+    <button data-field="preference-actions-cancel" class="btn btn-lg">Cancel</button>
 </div>

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-webapp/src/main/java/org/uberfire/ext/wires/client/preferences/central/actions/PreferencesCentralActionsView.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-webapp/src/main/java/org/uberfire/ext/wires/client/preferences/central/actions/PreferencesCentralActionsView.java
@@ -38,8 +38,8 @@ public class PreferencesCentralActionsView implements IsElement,
     Button saveButton;
 
     @Inject
-    @DataField( "preference-actions-undo" )
-    Button undoButton;
+    @DataField( "preference-actions-cancel" )
+    Button cancelButton;
 
     @Override
     public void init( final PreferencesCentralActionsScreen presenter ) {
@@ -51,8 +51,8 @@ public class PreferencesCentralActionsView implements IsElement,
         presenter.fireSaveEvent();
     }
 
-    @EventHandler("preference-actions-undo")
+    @EventHandler("preference-actions-cancel")
     public void undo( ClickEvent event ) {
-        presenter.fireUndoChangesEvent();
+        presenter.fireCancelEvent();
     }
 }

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-webapp/src/main/java/org/uberfire/ext/wires/client/preferences/central/hierarchy/HierarchyItemPresenter.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-webapp/src/main/java/org/uberfire/ext/wires/client/preferences/central/hierarchy/HierarchyItemPresenter.java
@@ -23,5 +23,7 @@ public interface HierarchyItemPresenter {
 
     <T> void init( PreferenceHierarchyElement<T> preference );
 
+    void fireSelect();
+
     HierarchyItemView getView();
 }

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-webapp/src/main/java/org/uberfire/ext/wires/client/preferences/central/hierarchy/HierarchyStructurePresenter.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-webapp/src/main/java/org/uberfire/ext/wires/client/preferences/central/hierarchy/HierarchyStructurePresenter.java
@@ -18,5 +18,7 @@ package org.uberfire.ext.wires.client.preferences.central.hierarchy;
 
 public interface HierarchyStructurePresenter {
 
+    void init( String rootIdentifier );
+
     HierarchyStructureView getView();
 }

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-webapp/src/main/java/org/uberfire/ext/wires/client/preferences/central/tree/TreeHierarchyInternalItemPresenter.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-webapp/src/main/java/org/uberfire/ext/wires/client/preferences/central/tree/TreeHierarchyInternalItemPresenter.java
@@ -35,6 +35,7 @@ public class TreeHierarchyInternalItemPresenter implements HierarchyInternalItem
     public interface View extends HierarchyItemView,
                                   UberElement<TreeHierarchyInternalItemPresenter> {
 
+        void select();
     }
 
     private final View view;
@@ -80,6 +81,11 @@ public class TreeHierarchyInternalItemPresenter implements HierarchyInternalItem
         } );
 
         view.init( this );
+    }
+
+    @Override
+    public void fireSelect() {
+        view.select();
     }
 
     public void select() {

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-webapp/src/main/java/org/uberfire/ext/wires/client/preferences/central/tree/TreeHierarchyInternalItemView.html
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-webapp/src/main/java/org/uberfire/ext/wires/client/preferences/central/tree/TreeHierarchyInternalItemView.html
@@ -16,8 +16,8 @@
 
 <div class="preference-tree-internal-item">
     <div class="preference-tree-internal-item-node">
-        <i class="fa fa-caret-right" aria-hidden="true" data-field="preference-tree-internal-item-expand-icon"></i>
-        <i class="fa fa-caret-down hidden" aria-hidden="true" data-field="preference-tree-internal-item-contract-icon"></i>
+        <i class="fa fa-caret-right hidden" aria-hidden="true" data-field="preference-tree-internal-item-expand-icon"></i>
+        <i class="fa fa-caret-down" aria-hidden="true" data-field="preference-tree-internal-item-contract-icon"></i>
         <label data-field="preference-tree-internal-item-label"></label>
     </div>
     <div class="preference-tree-internal-item-children" data-field="preference-tree-internal-item-children"></div>

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-webapp/src/main/java/org/uberfire/ext/wires/client/preferences/central/tree/TreeHierarchyInternalItemView.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-webapp/src/main/java/org/uberfire/ext/wires/client/preferences/central/tree/TreeHierarchyInternalItemView.java
@@ -63,7 +63,6 @@ public class TreeHierarchyInternalItemView implements IsElement,
 
         final String preferenceLabel = getPreferenceLabel( presenter.getHierarchyElement().getBundleKey() );
         label.setInnerHTML( preferenceLabel );
-        children.setHidden( true );
 
         presenter.getHierarchyItems().forEach( hierarchyItem -> {
             children.appendChild( hierarchyItem.getView().getElement() );
@@ -86,11 +85,8 @@ public class TreeHierarchyInternalItemView implements IsElement,
     }
 
     @EventHandler("preference-tree-internal-item-label")
-    public void contractExpand( final ClickEvent event ) {
-        if ( !label.hasClassName( "selected" ) ) {
-            presenter.select();
-            label.addClassName( "selected" );
-        }
+    public void select( final ClickEvent event ) {
+        select();
     }
 
     @EventHandler("preference-tree-internal-item-label")
@@ -112,6 +108,14 @@ public class TreeHierarchyInternalItemView implements IsElement,
         expandIcon.removeClassName( "hidden" );
         contractIcon.addClassName( "hidden" );
         children.setHidden( true );
+    }
+
+    @Override
+    public void select() {
+        if ( !label.hasClassName( "selected" ) ) {
+            presenter.select();
+            label.addClassName( "selected" );
+        }
     }
 
     private String getPreferenceLabel( String bundleKey ) {

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-webapp/src/main/java/org/uberfire/ext/wires/client/preferences/central/tree/TreeHierarchyLeafItemPresenter.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-webapp/src/main/java/org/uberfire/ext/wires/client/preferences/central/tree/TreeHierarchyLeafItemPresenter.java
@@ -31,6 +31,7 @@ public class TreeHierarchyLeafItemPresenter implements HierarchyLeafItemPresente
     public interface View extends HierarchyItemView,
                                   UberElement<TreeHierarchyLeafItemPresenter> {
 
+        void select();
     }
 
     private final View view;
@@ -50,6 +51,11 @@ public class TreeHierarchyLeafItemPresenter implements HierarchyLeafItemPresente
     public <T> void init( final PreferenceHierarchyElement<T> preference ) {
         hierarchyElement = preference;
         view.init( this );
+    }
+
+    @Override
+    public void fireSelect() {
+        view.select();
     }
 
     public void select() {

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-webapp/src/main/java/org/uberfire/ext/wires/client/preferences/central/tree/TreeHierarchyLeafItemView.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-webapp/src/main/java/org/uberfire/ext/wires/client/preferences/central/tree/TreeHierarchyLeafItemView.java
@@ -59,7 +59,12 @@ public class TreeHierarchyLeafItemView implements IsElement,
     }
 
     @EventHandler("preference-tree-leaf-item-label")
-    public void contractExpand( final ClickEvent event ) {
+    public void select( final ClickEvent event ) {
+        select();
+    }
+
+    @Override
+    public void select() {
         if ( !label.hasClassName( "selected" ) ) {
             presenter.select();
             label.addClassName( "selected" );

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-webapp/src/main/java/org/uberfire/ext/wires/client/preferences/central/tree/TreeHierarchyStructureView.html
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-webapp/src/main/java/org/uberfire/ext/wires/client/preferences/central/tree/TreeHierarchyStructureView.html
@@ -16,6 +16,7 @@
 
 <div class="preference-tree-root full-height">
     <div class="full-height">
-        <div class="preference-tree-root-children" data-field="preference-tree"></div>
+        <div class="preference-tree-root-children" data-field="preference-tree">
+        </div>
     </div>
 </div>

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-webapp/src/main/java/org/uberfire/ext/wires/client/preferences/central/tree/TreeHierarchyStructureView.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-webapp/src/main/java/org/uberfire/ext/wires/client/preferences/central/tree/TreeHierarchyStructureView.java
@@ -21,6 +21,7 @@ import javax.inject.Inject;
 
 import org.jboss.errai.common.client.dom.Div;
 import org.jboss.errai.ui.client.local.api.IsElement;
+import org.jboss.errai.ui.client.local.spi.TranslationService;
 import org.jboss.errai.ui.shared.api.annotations.DataField;
 import org.jboss.errai.ui.shared.api.annotations.Templated;
 
@@ -29,19 +30,29 @@ import org.jboss.errai.ui.shared.api.annotations.Templated;
 public class TreeHierarchyStructureView implements IsElement,
                                                    TreeHierarchyStructurePresenter.View {
 
+    private final TranslationService translationService;
+
     private TreeHierarchyStructurePresenter presenter;
 
     @Inject
     @DataField("preference-tree")
     Div tree;
 
+    @Inject
+    public TreeHierarchyStructureView( final TranslationService translationService ) {
+        this.translationService = translationService;
+    }
+
     @Override
     public void init( final TreeHierarchyStructurePresenter presenter ) {
         this.presenter = presenter;
 
         tree.setInnerHTML( "" );
-        presenter.getHierarchyItems().forEach( hierarchyItem -> {
-            tree.appendChild( hierarchyItem.getView().getElement() );
-        } );
+        tree.appendChild( presenter.getHierarchyItem().getView().getElement() );
+    }
+
+    @Override
+    public String getTranslation( final String key ) {
+        return translationService.format( key );
     }
 }

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-webapp/src/main/java/org/uberfire/ext/wires/client/preferences/resources/i18n/PreferencesConstants.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-webapp/src/main/java/org/uberfire/ext/wires/client/preferences/resources/i18n/PreferencesConstants.java
@@ -21,19 +21,19 @@ import org.jboss.errai.ui.shared.api.annotations.TranslationKey;
 public class PreferencesConstants {
 
     @TranslationKey(defaultValue = "")
-    public static final String MyInheritedPreference_Label = "MyInheritedPreference.Label";
+    public static final String MySharedPreference_Label = "MySharedPreference.Label";
 
     @TranslationKey(defaultValue = "")
-    public static final String MyInheritedPreference_Text = "MyInheritedPreference.Text";
+    public static final String MySharedPreference_Text = "MySharedPreference.Text";
 
     @TranslationKey(defaultValue = "")
-    public static final String MyInheritedPreference_MyInnerPreference2 = "MyInheritedPreference.MyInnerPreference2";
+    public static final String MySharedPreference_MyInnerPreference2 = "MySharedPreference.MyInnerPreference2";
 
     @TranslationKey(defaultValue = "")
-    public static final String MyInheritedPreference2_Label = "MyInheritedPreference2.Label";
+    public static final String MySharedPreference2_Label = "MySharedPreference2.Label";
 
     @TranslationKey(defaultValue = "")
-    public static final String MyInheritedPreference2_Text = "MyInheritedPreference2.Text";
+    public static final String MySharedPreference2_Text = "MySharedPreference2.Text";
 
     @TranslationKey(defaultValue = "")
     public static final String MyInnerPreference_Label = "MyInnerPreference.Label";
@@ -48,7 +48,7 @@ public class PreferencesConstants {
     public static final String MyInnerPreference2_Text = "MyInnerPreference2.Text";
 
     @TranslationKey(defaultValue = "")
-    public static final String MyInnerPreference2_MyInheritedPreference2 = "MyInnerPreference2.MyInheritedPreference2";
+    public static final String MyInnerPreference2_MySharedPreference2 = "MyInnerPreference2.MySharedPreference2";
 
     @TranslationKey(defaultValue = "")
     public static final String MyPreference_Label = "MyPreference.Label";
@@ -72,5 +72,5 @@ public class PreferencesConstants {
     public static final String MyPreference_MyInnerPreference = "MyPreference.MyInnerPreference";
 
     @TranslationKey(defaultValue = "")
-    public static final String MyPreference_MyInheritedPreference = "MyPreference.MyInheritedPreference";
+    public static final String MyPreference_MySharedPreference = "MyPreference.MySharedPreference";
 }

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-webapp/src/main/java/org/uberfire/ext/wires/client/preferences/settings/SettingsPerspective.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-webapp/src/main/java/org/uberfire/ext/wires/client/preferences/settings/SettingsPerspective.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.ext.wires.client.preferences.settings;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.uberfire.client.annotations.Perspective;
+import org.uberfire.client.annotations.WorkbenchPerspective;
+import org.uberfire.client.workbench.panels.impl.MultiListWorkbenchPanelPresenter;
+import org.uberfire.ext.wires.client.preferences.settings.home.SettingsHomePresenter;
+import org.uberfire.mvp.impl.DefaultPlaceRequest;
+import org.uberfire.workbench.model.PerspectiveDefinition;
+import org.uberfire.workbench.model.impl.PartDefinitionImpl;
+import org.uberfire.workbench.model.impl.PerspectiveDefinitionImpl;
+
+@ApplicationScoped
+@WorkbenchPerspective(identifier = SettingsPerspective.IDENTIFIER)
+public class SettingsPerspective {
+
+    public static final String IDENTIFIER = "SettingsPerspective";
+
+    private PerspectiveDefinition perspective;
+
+    @Perspective
+    public PerspectiveDefinition getPerspective() {
+        perspective = new PerspectiveDefinitionImpl( MultiListWorkbenchPanelPresenter.class.getName() );
+        perspective.setName( "Settings" );
+
+        perspective.getRoot().addPart( new PartDefinitionImpl( new DefaultPlaceRequest( SettingsHomePresenter.IDENTIFIER ) ) );
+
+        return perspective;
+    }
+}

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-webapp/src/main/java/org/uberfire/ext/wires/client/preferences/settings/home/SettingsHomePresenter.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-webapp/src/main/java/org/uberfire/ext/wires/client/preferences/settings/home/SettingsHomePresenter.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.ext.wires.client.preferences.settings.home;
+
+import javax.annotation.PostConstruct;
+import javax.enterprise.event.Event;
+import javax.inject.Inject;
+
+import org.jboss.errai.ioc.client.api.ManagedInstance;
+import org.uberfire.client.annotations.WorkbenchPartTitle;
+import org.uberfire.client.annotations.WorkbenchPartView;
+import org.uberfire.client.annotations.WorkbenchScreen;
+import org.uberfire.client.mvp.UberElement;
+import org.uberfire.ext.wires.client.preferences.settings.home.category.SettingsHomeCategoryPresenter;
+import org.uberfire.ext.wires.client.preferences.settings.home.register.WorkbenchSettings;
+import org.uberfire.workbench.events.NotificationEvent;
+
+@WorkbenchScreen(identifier = SettingsHomePresenter.IDENTIFIER)
+public class SettingsHomePresenter {
+
+    public static final String IDENTIFIER = "PreferencesCentralHomePresenter";
+
+    public interface View extends UberElement<SettingsHomePresenter> {
+
+        void add( final SettingsHomeCategoryPresenter.View categoryView );
+    }
+
+    private final View view;
+
+    private final WorkbenchSettings workbenchSettings;
+
+    private final ManagedInstance<SettingsHomeCategoryPresenter> categoryPresenterProvider;
+
+    private final Event<NotificationEvent> notification;
+
+    @Inject
+    public SettingsHomePresenter( final View view,
+                                  final WorkbenchSettings workbenchSettings,
+                                  final ManagedInstance<SettingsHomeCategoryPresenter> categoryPresenterProvider,
+                                  final Event<NotificationEvent> notification ) {
+        this.view = view;
+        this.workbenchSettings = workbenchSettings;
+        this.categoryPresenterProvider = categoryPresenterProvider;
+        this.notification = notification;
+    }
+
+    @PostConstruct
+    public void init() {
+        view.init( this );
+
+        workbenchSettings.getSettingsByCategory().forEach( ( category, settings ) -> {
+            SettingsHomeCategoryPresenter categoryPresenter = categoryPresenterProvider.get();
+            categoryPresenter.setup( settings );
+            view.add( categoryPresenter.getView() );
+        } );
+    }
+
+    @WorkbenchPartTitle
+    public String getTitle() {
+        return "Settings";
+    }
+
+    @WorkbenchPartView
+    public View getView() {
+        return view;
+    }
+}

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-webapp/src/main/java/org/uberfire/ext/wires/client/preferences/settings/home/SettingsHomeView.css
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-webapp/src/main/java/org/uberfire/ext/wires/client/preferences/settings/home/SettingsHomeView.css
@@ -14,18 +14,6 @@
  * limitations under the License.
  */
 
-package org.uberfire.ext.wires.shared.preferences.bean;
-
-import org.uberfire.ext.preferences.shared.annotations.Property;
-import org.uberfire.ext.preferences.shared.annotations.WorkbenchPreference;
-import org.uberfire.ext.preferences.shared.bean.BasePreference;
-
-@WorkbenchPreference(root = false, bundleKey = "MyInheritedPreference.Label")
-public class MyInheritedPreference implements BasePreference<MyInheritedPreference> {
-
-    @Property(bundleKey = "MyInheritedPreference.Text")
-    String text;
-
-    @Property(bundleKey = "MyInheritedPreference.MyInnerPreference2")
-    MyInnerPreference2 myInnerPreference2;
+.full-height {
+    height: 100%;
 }

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-webapp/src/main/java/org/uberfire/ext/wires/client/preferences/settings/home/SettingsHomeView.html
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-webapp/src/main/java/org/uberfire/ext/wires/client/preferences/settings/home/SettingsHomeView.html
@@ -1,0 +1,18 @@
+<!--
+  ~ Copyright 2016 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~       http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<div id="content" class="preferences-central-home full-height">
+</div>

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-webapp/src/main/java/org/uberfire/ext/wires/client/preferences/settings/home/SettingsHomeView.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-webapp/src/main/java/org/uberfire/ext/wires/client/preferences/settings/home/SettingsHomeView.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.ext.wires.client.preferences.settings.home;
+
+import javax.enterprise.context.Dependent;
+import javax.inject.Inject;
+
+import org.jboss.errai.common.client.dom.Div;
+import org.jboss.errai.ui.client.local.api.IsElement;
+import org.jboss.errai.ui.shared.api.annotations.DataField;
+import org.jboss.errai.ui.shared.api.annotations.Templated;
+import org.uberfire.ext.wires.client.preferences.settings.home.category.SettingsHomeCategoryPresenter;
+
+@Dependent
+@Templated
+public class SettingsHomeView implements IsElement,
+                                         SettingsHomePresenter.View {
+
+    @Inject
+    @DataField("content")
+    Div content;
+
+    private SettingsHomePresenter presenter;
+
+    @Override
+    public void init( final SettingsHomePresenter presenter ) {
+        this.presenter = presenter;
+    }
+
+    @Override
+    public void add( final SettingsHomeCategoryPresenter.View categoryView ) {
+        content.appendChild( categoryView.getElement() );
+    }
+}

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-webapp/src/main/java/org/uberfire/ext/wires/client/preferences/settings/home/category/SettingsHomeCategoryPresenter.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-webapp/src/main/java/org/uberfire/ext/wires/client/preferences/settings/home/category/SettingsHomeCategoryPresenter.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.ext.wires.client.preferences.settings.home.category;
+
+import java.util.List;
+import javax.inject.Inject;
+
+import org.jboss.errai.ioc.client.api.ManagedInstance;
+import org.uberfire.client.mvp.UberElement;
+import org.uberfire.ext.preferences.shared.bean.PreferenceRootElement;
+import org.uberfire.ext.wires.client.preferences.settings.home.item.SettingsHomeItemPresenter;
+import org.uberfire.ext.wires.client.preferences.settings.home.register.SettingShortcut;
+
+public class SettingsHomeCategoryPresenter {
+
+    public interface View extends UberElement<SettingsHomeCategoryPresenter> {
+
+        void add( SettingsHomeItemPresenter.View rootItemView );
+    }
+
+    private final View view;
+
+    private final ManagedInstance<SettingsHomeItemPresenter> settingsHomeItemPresenterProvider;
+
+    @Inject
+    public SettingsHomeCategoryPresenter( final View view,
+                                          final ManagedInstance<SettingsHomeItemPresenter> settingsHomeItemPresenterProvider ) {
+        this.view = view;
+        this.settingsHomeItemPresenterProvider = settingsHomeItemPresenterProvider;
+    }
+
+    public void setup( final List<SettingShortcut> settingsShortcuts ) {
+        settingsShortcuts.forEach( settingShortcut -> {
+            final SettingsHomeItemPresenter itemPresenter = settingsHomeItemPresenterProvider.get();
+            itemPresenter.setup( settingShortcut );
+            view.add( itemPresenter.getView() );
+        });
+    }
+
+    public View getView() {
+        return view;
+    }
+}

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-webapp/src/main/java/org/uberfire/ext/wires/client/preferences/settings/home/category/SettingsHomeCategoryView.css
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-webapp/src/main/java/org/uberfire/ext/wires/client/preferences/settings/home/category/SettingsHomeCategoryView.css
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+.preferences-central-category {
+    list-style: none;
+    vertical-align: top;
+    width: 100%;
+    padding: 0;
+    border-bottom: 1px solid #DDD;
+}

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-webapp/src/main/java/org/uberfire/ext/wires/client/preferences/settings/home/category/SettingsHomeCategoryView.html
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-webapp/src/main/java/org/uberfire/ext/wires/client/preferences/settings/home/category/SettingsHomeCategoryView.html
@@ -1,0 +1,18 @@
+<!--
+  ~ Copyright 2016 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~       http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<div data-field="content" class="preferences-central-category">
+</div>

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-webapp/src/main/java/org/uberfire/ext/wires/client/preferences/settings/home/category/SettingsHomeCategoryView.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-webapp/src/main/java/org/uberfire/ext/wires/client/preferences/settings/home/category/SettingsHomeCategoryView.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.ext.wires.client.preferences.settings.home.category;
+
+import javax.enterprise.context.Dependent;
+import javax.inject.Inject;
+
+import org.jboss.errai.common.client.dom.Div;
+import org.jboss.errai.ui.client.local.api.IsElement;
+import org.jboss.errai.ui.shared.api.annotations.DataField;
+import org.jboss.errai.ui.shared.api.annotations.Templated;
+import org.uberfire.ext.wires.client.preferences.settings.home.item.SettingsHomeItemPresenter;
+
+@Dependent
+@Templated
+public class SettingsHomeCategoryView implements IsElement,
+                                                 SettingsHomeCategoryPresenter.View {
+
+    private SettingsHomeCategoryPresenter presenter;
+
+    @Inject
+    @DataField("content")
+    private Div content;
+
+    @Override
+    public void init( final SettingsHomeCategoryPresenter presenter ) {
+        this.presenter = presenter;
+    }
+
+    @Override
+    public void add( final SettingsHomeItemPresenter.View rootItemView ) {
+        content.appendChild( rootItemView.getElement() );
+    }
+}

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-webapp/src/main/java/org/uberfire/ext/wires/client/preferences/settings/home/item/SettingsHomeItemPresenter.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-webapp/src/main/java/org/uberfire/ext/wires/client/preferences/settings/home/item/SettingsHomeItemPresenter.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.ext.wires.client.preferences.settings.home.item;
+
+import java.util.HashMap;
+import java.util.Map;
+import javax.inject.Inject;
+
+import org.uberfire.client.mvp.PlaceManager;
+import org.uberfire.client.mvp.UberElement;
+import org.uberfire.ext.preferences.shared.bean.PreferenceRootElement;
+import org.uberfire.ext.wires.client.preferences.central.PreferencesCentralPerspective;
+import org.uberfire.ext.wires.client.preferences.settings.home.register.SettingShortcut;
+import org.uberfire.mvp.impl.DefaultPlaceRequest;
+
+public class SettingsHomeItemPresenter {
+
+    public interface View extends UberElement<SettingsHomeItemPresenter> {
+
+    }
+
+    private final View view;
+
+    private final PlaceManager placeManager;
+
+    private SettingShortcut settingShortcut;
+
+    @Inject
+    public SettingsHomeItemPresenter( final View view,
+                                      final PlaceManager placeManager ) {
+        this.view = view;
+        this.placeManager = placeManager;
+    }
+
+    public void setup( final SettingShortcut settingShortcut ) {
+        this.settingShortcut = settingShortcut;
+        view.init( this );
+    }
+
+    public void enter() {
+        settingShortcut.getCommand().execute();
+    }
+
+    public SettingShortcut getSettingShortcut() {
+        return settingShortcut;
+    }
+
+    public View getView() {
+        return view;
+    }
+}

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-webapp/src/main/java/org/uberfire/ext/wires/client/preferences/settings/home/item/SettingsHomeItemView.css
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-webapp/src/main/java/org/uberfire/ext/wires/client/preferences/settings/home/item/SettingsHomeItemView.css
@@ -14,15 +14,25 @@
  * limitations under the License.
  */
 
-package org.uberfire.ext.preferences.backend;
+.preference-central-root-item {
+    display: inline-block;
+    text-align: center;
+    padding: 20px 20px;
+    vertical-align: top;
+    width: 180px;
+    height: 170px;
+}
 
-import org.uberfire.ext.preferences.shared.annotations.Property;
-import org.uberfire.ext.preferences.shared.annotations.WorkbenchPreference;
-import org.uberfire.ext.preferences.shared.bean.BasePreference;
+.preference-central-root-item:hover {
+    background-color: #EEEEEE;
+}
 
-@WorkbenchPreference(bundleKey = "MyInheritedPreference2.Label")
-public class MyInheritedPreference2 implements BasePreference<MyInheritedPreference2> {
+.preference-central-root-item > span {
+    width: 50px;
+    height: 50px;
+    font-size: 50px;
+}
 
-    @Property(bundleKey = "MyInheritedPreference2.Text")
-    String text;
+.preference-central-root-item > div {
+    font-size: 14px;
 }

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-webapp/src/main/java/org/uberfire/ext/wires/client/preferences/settings/home/item/SettingsHomeItemView.html
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-webapp/src/main/java/org/uberfire/ext/wires/client/preferences/settings/home/item/SettingsHomeItemView.html
@@ -1,0 +1,20 @@
+<!--
+  ~ Copyright 2016 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~       http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<div data-field="item" class="preference-central-root-item">
+    <span><i data-field="item-icon" class="fa" aria-hidden="true"></i></span>
+    <div data-field="item-text"></div>
+</div>

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-webapp/src/main/java/org/uberfire/ext/wires/client/preferences/settings/home/item/SettingsHomeItemView.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-webapp/src/main/java/org/uberfire/ext/wires/client/preferences/settings/home/item/SettingsHomeItemView.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.ext.wires.client.preferences.settings.home.item;
+
+import javax.enterprise.context.Dependent;
+import javax.inject.Inject;
+
+import com.google.gwt.dom.client.Element;
+import com.google.gwt.event.dom.client.ClickEvent;
+import com.google.gwt.user.client.DOM;
+import org.jboss.errai.common.client.dom.Div;
+import org.jboss.errai.ui.client.local.api.IsElement;
+import org.jboss.errai.ui.client.local.spi.TranslationService;
+import org.jboss.errai.ui.shared.api.annotations.DataField;
+import org.jboss.errai.ui.shared.api.annotations.EventHandler;
+import org.jboss.errai.ui.shared.api.annotations.Templated;
+
+@Dependent
+@Templated
+public class SettingsHomeItemView implements IsElement,
+                                             SettingsHomeItemPresenter.View {
+
+    private final TranslationService translationService;
+
+    private SettingsHomeItemPresenter presenter;
+
+    @Inject
+    @DataField("item")
+    Div item;
+
+    @DataField("item-icon")
+    Element icon = DOM.createElement( "i" );
+
+    @Inject
+    @DataField("item-text")
+    Div text;
+
+    @Inject
+    public SettingsHomeItemView( final TranslationService translationService ) {
+        this.translationService = translationService;
+    }
+
+    @Override
+    public void init( final SettingsHomeItemPresenter presenter ) {
+        this.presenter = presenter;
+
+        final String iconCss = presenter.getSettingShortcut().getIconCss();
+        if ( !iconCss.isEmpty() ) {
+            icon.addClassName( iconCss );
+        }
+
+        text.setTextContent( presenter.getSettingShortcut().getTitle() );
+    }
+
+    @EventHandler("item")
+    public void enter( ClickEvent event ) {
+        presenter.enter();
+    }
+}

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-webapp/src/main/java/org/uberfire/ext/wires/client/preferences/settings/home/register/SettingShortcut.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-webapp/src/main/java/org/uberfire/ext/wires/client/preferences/settings/home/register/SettingShortcut.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.ext.wires.client.preferences.settings.home.register;
+
+import org.uberfire.mvp.Command;
+
+public class SettingShortcut {
+
+    private String identifier;
+
+    private String title;
+
+    private String iconCss;
+
+    private String category;
+
+    private Command command;
+
+    public SettingShortcut() {
+    }
+
+    public SettingShortcut( final String identifier,
+                            final String title,
+                            final String iconCss,
+                            final String category,
+                            final Command command ) {
+        this.identifier = identifier;
+        this.title = title;
+        this.iconCss = iconCss;
+        this.category = category;
+        this.command = command;
+    }
+
+    public String getIdentifier() {
+        return identifier;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public String getIconCss() {
+        return iconCss;
+    }
+
+    public String getCategory() {
+        return category;
+    }
+
+    public Command getCommand() {
+        return command;
+    }
+}

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-webapp/src/main/java/org/uberfire/ext/wires/client/preferences/settings/home/register/WorkbenchSettings.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-webapp/src/main/java/org/uberfire/ext/wires/client/preferences/settings/home/register/WorkbenchSettings.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.ext.wires.client.preferences.settings.home.register;
+
+import java.util.List;
+import java.util.Map;
+
+import org.uberfire.mvp.Command;
+
+/**
+ * Used to customize the settings perspective.
+ */
+public interface WorkbenchSettings {
+
+    /**
+     * Adds a new shortcut item to the settings perspective.
+     * @param title Title that will be displayed on the shortcut.
+     * @param iconCss CSS class related to the shortcut icon.
+     * @param category Defines the group inside which the shortcut will be.
+     * @param command Command to be executed when the shortcut is accessed.
+     */
+    void addItem( String title,
+                  String iconCss,
+                  String category,
+                  Command command );
+
+    /**
+     * Returns all added shortcuts and root preference beans shortcuts, grouped
+     * by their category.
+     * @return A map containing a list of shortcuts by each category.
+     */
+    Map<String, List<SettingShortcut>> getSettingsByCategory();
+}

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-webapp/src/main/java/org/uberfire/ext/wires/client/preferences/settings/home/register/WorkbenchSettingsImpl.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-webapp/src/main/java/org/uberfire/ext/wires/client/preferences/settings/home/register/WorkbenchSettingsImpl.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.ext.wires.client.preferences.settings.home.register;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.inject.Inject;
+
+import org.jboss.errai.common.client.api.Caller;
+import org.jboss.errai.common.client.api.RemoteCallback;
+import org.jboss.errai.ioc.client.api.AfterInitialization;
+import org.jboss.errai.ioc.client.api.EntryPoint;
+import org.jboss.errai.ui.client.local.spi.TranslationService;
+import org.uberfire.client.mvp.PlaceManager;
+import org.uberfire.ext.preferences.shared.bean.PreferenceBeanServerStore;
+import org.uberfire.ext.preferences.shared.bean.PreferenceRootElement;
+import org.uberfire.ext.wires.client.preferences.central.PreferencesCentralPerspective;
+import org.uberfire.mvp.Command;
+import org.uberfire.mvp.impl.DefaultPlaceRequest;
+
+@EntryPoint
+public class WorkbenchSettingsImpl implements WorkbenchSettings {
+
+    private Caller<PreferenceBeanServerStore> preferenceBeanServerStoreCaller;
+
+    private PlaceManager placeManager;
+
+    private TranslationService translationService;
+
+    private Map<String, List<SettingShortcut>> settingsByCategory;
+
+    public WorkbenchSettingsImpl() {
+    }
+
+    @Inject
+    public WorkbenchSettingsImpl( final Caller<PreferenceBeanServerStore> preferenceBeanServerStoreCaller,
+                                  final PlaceManager placeManager,
+                                  final TranslationService translationService ) {
+        this.preferenceBeanServerStoreCaller = preferenceBeanServerStoreCaller;
+        this.placeManager = placeManager;
+        this.translationService = translationService;
+        this.settingsByCategory = new HashMap<>();
+    }
+
+    @AfterInitialization
+    public void includeAllPreferences() {
+        preferenceBeanServerStoreCaller.call( new RemoteCallback<Map<String, List<PreferenceRootElement>>>() {
+            @Override
+            public void callback( final Map<String, List<PreferenceRootElement>> preferencesByCategory ) {
+                preferencesByCategory.forEach( ( category, preferences ) -> {
+                    preferences.forEach( preference -> {
+                        final String title = translationService.format( preference.getBundleKey() );
+
+                        addItem( preference.getIdentifier(),
+                                 title,
+                                 preference.getIconCss(),
+                                 preference.getCategory(),
+                                 () -> {
+                                     Map<String, String> parameters = new HashMap<>();
+                                     parameters.put( "identifier", preference.getIdentifier() );
+                                     parameters.put( "title", title );
+                                     placeManager.goTo( new DefaultPlaceRequest( PreferencesCentralPerspective.IDENTIFIER, parameters ) );
+                                 } );
+                    } );
+                } );
+            }
+        }, ( message, throwable ) -> {
+            throw new RuntimeException( throwable );
+        } ).buildCategoryStructure();
+    }
+
+    @Override
+    public void addItem( final String title,
+                         final String iconCss,
+                         final String category,
+                         final Command command ) {
+        addItem( null, title, iconCss, category, command );
+    }
+
+    private void addItem( final String identifier,
+                          final String title,
+                          final String iconCss,
+                          final String category,
+                          final Command command ) {
+        if ( category == null || category.isEmpty()) {
+            throw new RuntimeException( "The category must be not empty." );
+        }
+
+        List<SettingShortcut> settings = settingsByCategory.get( category );
+
+        if ( settings == null ) {
+            settings = new ArrayList<>();
+            settingsByCategory.put( category, settings );
+        }
+
+        SettingShortcut setting = new SettingShortcut( identifier, title, iconCss, category, command );
+        settings.add( setting );
+    }
+
+    @Override
+    public Map<String, List<SettingShortcut>> getSettingsByCategory() {
+        settingsByCategory.forEach( ( category, settings ) -> {
+            settings.sort( ( o1, o2 ) -> o1.getTitle().compareTo( o2.getTitle() ) );
+        } );
+
+        return this.settingsByCategory;
+    }
+}

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-webapp/src/main/java/org/uberfire/ext/wires/shared/preferences/bean/MyInnerPreference.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-webapp/src/main/java/org/uberfire/ext/wires/shared/preferences/bean/MyInnerPreference.java
@@ -20,7 +20,8 @@ import org.uberfire.ext.preferences.shared.annotations.Property;
 import org.uberfire.ext.preferences.shared.annotations.WorkbenchPreference;
 import org.uberfire.ext.preferences.shared.bean.BasePreference;
 
-@WorkbenchPreference(root = false, bundleKey = "MyInnerPreference.Label")
+@WorkbenchPreference(identifier = "MyInnerPreference",
+        bundleKey = "MyInnerPreference.Label")
 public class MyInnerPreference implements BasePreference<MyInnerPreference> {
 
     @Property(bundleKey = "MyInnerPreference.Text")

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-webapp/src/main/java/org/uberfire/ext/wires/shared/preferences/bean/MyInnerPreference2.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-webapp/src/main/java/org/uberfire/ext/wires/shared/preferences/bean/MyInnerPreference2.java
@@ -20,12 +20,10 @@ import org.uberfire.ext.preferences.shared.annotations.Property;
 import org.uberfire.ext.preferences.shared.annotations.WorkbenchPreference;
 import org.uberfire.ext.preferences.shared.bean.BasePreference;
 
-@WorkbenchPreference(root = false, bundleKey = "MyInnerPreference2.Label")
+@WorkbenchPreference(identifier = "MyInnerPreference2",
+        bundleKey = "MyInnerPreference2.Label")
 public class MyInnerPreference2 implements BasePreference<MyInnerPreference2> {
 
     @Property(bundleKey = "MyInnerPreference2.Text")
     String text;
-
-    @Property(inherited = true, bundleKey = "MyInnerPreference2.MyInheritedPreference2")
-    MyInheritedPreference2 myInheritedPreference2;
 }

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-webapp/src/main/java/org/uberfire/ext/wires/shared/preferences/bean/MyPreference.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-webapp/src/main/java/org/uberfire/ext/wires/shared/preferences/bean/MyPreference.java
@@ -21,7 +21,10 @@ import org.uberfire.ext.preferences.shared.annotations.Property;
 import org.uberfire.ext.preferences.shared.annotations.WorkbenchPreference;
 import org.uberfire.ext.preferences.shared.bean.BasePreference;
 
-@WorkbenchPreference(bundleKey = "MyPreference.Label")
+@WorkbenchPreference(identifier = "MyPreference",
+        category = "MyCategory",
+        bundleKey = "MyPreference.Label",
+        iconCss = "fa-gear")
 public class MyPreference implements BasePreference<MyPreference> {
 
     @Property(bundleKey = "MyPreference.Text")
@@ -42,8 +45,8 @@ public class MyPreference implements BasePreference<MyPreference> {
     @Property(bundleKey = "MyPreference.MyInnerPreference")
     MyInnerPreference myInnerPreference;
 
-    @Property(inherited = true, bundleKey = "MyPreference.MyInheritedPreference")
-    MyInheritedPreference myInheritedPreference;
+    @Property(shared = true, bundleKey = "MyPreference.MySharedPreference")
+    MySharedPreference mySharedPreference;
 
     @Override
     public MyPreference defaultValue( final MyPreference defaultValue ) {
@@ -53,9 +56,8 @@ public class MyPreference implements BasePreference<MyPreference> {
         defaultValue.age = 27;
         defaultValue.password = "password";
         defaultValue.myInnerPreference.text = "text";
-        defaultValue.myInheritedPreference.text = "text";
-        defaultValue.myInheritedPreference.myInnerPreference2.text = "text";
-        defaultValue.myInheritedPreference.myInnerPreference2.myInheritedPreference2.text = "text";
+        defaultValue.mySharedPreference.text = "text";
+        defaultValue.mySharedPreference.myInnerPreference2.text = "text";
 
         return defaultValue;
     }

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-webapp/src/main/java/org/uberfire/ext/wires/shared/preferences/bean/MySharedPreference.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-webapp/src/main/java/org/uberfire/ext/wires/shared/preferences/bean/MySharedPreference.java
@@ -14,18 +14,19 @@
  * limitations under the License.
  */
 
-package org.uberfire.ext.preferences.processors;
+package org.uberfire.ext.wires.shared.preferences.bean;
 
 import org.uberfire.ext.preferences.shared.annotations.Property;
 import org.uberfire.ext.preferences.shared.annotations.WorkbenchPreference;
 import org.uberfire.ext.preferences.shared.bean.BasePreference;
 
-@WorkbenchPreference(root = false, bundleKey = "MyInheritedPreference.Label")
-public class MyInheritedPreference implements BasePreference<MyInheritedPreference> {
+@WorkbenchPreference(identifier = "MySharedPreference",
+        bundleKey = "MySharedPreference.Label")
+public class MySharedPreference implements BasePreference<MySharedPreference> {
 
-    @Property(bundleKey = "MyInheritedPreference.Text")
+    @Property(bundleKey = "MySharedPreference.Text")
     String text;
 
-    @Property(bundleKey = "MyInheritedPreference.MyInnerPreference2")
+    @Property(bundleKey = "MySharedPreference.MyInnerPreference2")
     MyInnerPreference2 myInnerPreference2;
 }

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-webapp/src/main/java/org/uberfire/ext/wires/shared/preferences/bean/MySharedPreference2.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-webapp/src/main/java/org/uberfire/ext/wires/shared/preferences/bean/MySharedPreference2.java
@@ -14,18 +14,26 @@
  * limitations under the License.
  */
 
-package org.uberfire.ext.preferences.backend;
+package org.uberfire.ext.wires.shared.preferences.bean;
 
 import org.uberfire.ext.preferences.shared.annotations.Property;
 import org.uberfire.ext.preferences.shared.annotations.WorkbenchPreference;
 import org.uberfire.ext.preferences.shared.bean.BasePreference;
 
-@WorkbenchPreference(root = false, bundleKey = "MyInheritedPreference.Label")
-public class MyInheritedPreference implements BasePreference<MyInheritedPreference> {
+@WorkbenchPreference(identifier = "MySharedPreference2",
+        parents = "MyInnerPreference2",
+        bundleKey = "MySharedPreference2.Label",
+        category = "MyCategory",
+        iconCss = "fa-pie-chart")
+public class MySharedPreference2 implements BasePreference<MySharedPreference2> {
 
-    @Property(bundleKey = "MyInheritedPreference.Text")
+    @Property(bundleKey = "MySharedPreference2.Text")
     String text;
 
-    @Property(bundleKey = "MyInheritedPreference.MyInnerPreference2")
-    MyInnerPreference2 myInnerPreference2;
+    @Override
+    public MySharedPreference2 defaultValue( final MySharedPreference2 defaultValue ) {
+        defaultValue.text = "text";
+
+        return defaultValue;
+    }
 }

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-webapp/src/main/resources/org/uberfire/ext/wires/client/preferences/resources/i18n/PreferencesConstants.properties
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-webapp/src/main/resources/org/uberfire/ext/wires/client/preferences/resources/i18n/PreferencesConstants.properties
@@ -14,16 +14,16 @@
 # limitations under the License.
 #
 
-MyInheritedPreference.Label=My Inherited Preference
-MyInheritedPreference.Text=Text
-MyInheritedPreference.MyInnerPreference2=My Inner Preference 2 inside My Inherited Preference
-MyInheritedPreference2.Label=My Inherited Preference 2
-MyInheritedPreference2.Text=Text
+MySharedPreference.Label=My Shared Preference
+MySharedPreference.Text=Text
+MySharedPreference.MyInnerPreference2=My Inner Preference 2 inside My Shared Preference
+MySharedPreference2.Label=My Shared Preference 2
+MySharedPreference2.Text=Text
 MyInnerPreference.Label=My Inner Preference
 MyInnerPreference.Text=Text
 MyInnerPreference2.Label=My Inner Preference 2
 MyInnerPreference2.Text=Text
-MyInnerPreference2.MyInheritedPreference2=My Inherited Preference 2 inside My Inner Preference 2
+MyInnerPreference2.MySharedPreference2=My Shared Preference 2 inside My Inner Preference 2
 MyPreference.Label=My Preference
 MyPreference.Text=Text
 MyPreference.SendReports=Send reports?
@@ -31,4 +31,4 @@ MyPreference.BackgroundColor=Background color
 MyPreference.Age=Age
 MyPreference.Password=Password
 MyPreference.MyInnerPreference=My Inner Preference inside My Preference
-MyPreference.MyInheritedPreference=My Inherited Preference inside My Preference
+MyPreference.MySharedPreference=My Shared Preference inside My Preference


### PR DESCRIPTION
* API now supports categories of preference beans (for UI purposes);
* A draft of the Settings UI was made on uberfire-wires-webapp:
    * Allow registration of custom shortcuts;
    * Allow separation by category;
    * Automatically loads shortcuts for root preference beans.

![gif](https://dl.dropboxusercontent.com/u/77725356/settings-1.gif)
