### PR TITLE
[0.9.x] RHBRMS-2519: Upload File doesn't support multi-byte symbols in file name

### DIFF
--- a/uberfire-server/src/main/java/org/uberfire/server/FileUploadServlet.java
+++ b/uberfire-server/src/main/java/org/uberfire/server/FileUploadServlet.java
@@ -50,6 +50,8 @@ public class FileUploadServlet
                            HttpServletResponse response ) throws ServletException, IOException {
 
         try {
+            request.setCharacterEncoding( "UTF-8" );
+
             if ( request.getParameter( PARAM_PATH ) != null ) {
 
                 //See https://bugzilla.redhat.com/show_bug.cgi?id=1202926

--- a/uberfire-server/src/test/java/org/uberfire/server/FileUploadServletTest.java
+++ b/uberfire-server/src/test/java/org/uberfire/server/FileUploadServletTest.java
@@ -168,6 +168,8 @@ public class FileUploadServletTest {
         //FileUploadServlet uploadServlet = new FileUploadServlet();
         uploadServlet.doPost( request, response );
 
+        verify( request, times( 1 ) ).setCharacterEncoding( "UTF-8" );
+
         verify( request, times( 1 ) ).getParameter( PARAM_PATH );
         verify( request, times( 2 ) ).getParameter( PARAM_FOLDER );
         verify( request, times( 1 ) ).getParameter( PARAM_FILENAME );
@@ -209,6 +211,8 @@ public class FileUploadServletTest {
         when( response.getWriter() ).thenReturn( printWriter );
 
         uploadServlet.doPost( request, response );
+
+        verify( request, times( 1 ) ).setCharacterEncoding( "UTF-8" );
 
         verify( request, times( 2 ) ).getParameter( PARAM_PATH );
 


### PR DESCRIPTION
Only on EAP 6.4 (running the version from the 6.5.x branch), [this solution](https://github.com/droolsjbpm/kie-docker-ci-images/pull/7) was not enough to solve this issue: https://issues.jboss.org/browse/RHBRMS-2519

So this workaround is needed:
```
request.setCharacterEncoding( "UTF-8" );
```
