### PR TITLE
UF-320: Adding counters for roles, groups and users on admin page

### DIFF
--- a/uberfire-extensions/uberfire-preferences/uberfire-preferences-client/src/main/java/org/uberfire/ext/preferences/client/admin/AdminPageView.css
+++ b/uberfire-extensions/uberfire-preferences/uberfire-preferences-client/src/main/java/org/uberfire/ext/preferences/client/admin/AdminPageView.css
@@ -30,6 +30,6 @@
     margin: auto;
 }
 
-.full-height {
-    height: 100%;
+.full-min-height {
+    min-height: 100%;
 }

--- a/uberfire-extensions/uberfire-preferences/uberfire-preferences-client/src/main/java/org/uberfire/ext/preferences/client/admin/AdminPageView.html
+++ b/uberfire-extensions/uberfire-preferences/uberfire-preferences-client/src/main/java/org/uberfire/ext/preferences/client/admin/AdminPageView.html
@@ -14,7 +14,7 @@
   ~ limitations under the License.
   -->
 
-<div class="admin-page full-height">
+<div class="admin-page full-min-height">
     <div id="admin-page-content" class="admin-page-content">
         <div class="admin-page-title-container">
             <h1 id="admin-page-title"></h1>

--- a/uberfire-extensions/uberfire-preferences/uberfire-preferences-client/src/main/java/org/uberfire/ext/preferences/client/admin/AdminPageView.java
+++ b/uberfire-extensions/uberfire-preferences/uberfire-preferences-client/src/main/java/org/uberfire/ext/preferences/client/admin/AdminPageView.java
@@ -67,4 +67,14 @@ public class AdminPageView implements IsElement,
 
         return title;
     }
+
+    @Override
+    public String getNoScreenParameterError() {
+        return translationService.format( Constants.AdminPagePresenter_NoScreenParameterError );
+    }
+
+    @Override
+    public String getNoScreenFoundError( final String screen ) {
+        return translationService.format( Constants.AdminPagePresenter_NoScreenFoundError, screen );
+    }
 }

--- a/uberfire-extensions/uberfire-preferences/uberfire-preferences-client/src/main/java/org/uberfire/ext/preferences/client/admin/page/AdminPageImpl.java
+++ b/uberfire-extensions/uberfire-preferences/uberfire-preferences-client/src/main/java/org/uberfire/ext/preferences/client/admin/page/AdminPageImpl.java
@@ -58,6 +58,7 @@ public class AdminPageImpl implements AdminPage {
         }
 
         screenTitleByIdentifier.put( identifier, title );
+        toolsByCategoryByScreen.put( identifier, new LinkedHashMap<>() );
     }
 
     @Override
@@ -80,12 +81,6 @@ public class AdminPageImpl implements AdminPage {
         }
 
         Map<String, List<AdminTool>> toolsByCategory = toolsByCategoryByScreen.get( screen );
-
-        if ( toolsByCategory == null ) {
-            toolsByCategory = new LinkedHashMap<>();
-            toolsByCategoryByScreen.put( screen, toolsByCategory );
-        }
-
         List<AdminTool> tools = toolsByCategory.get( category );
 
         if ( tools == null ) {

--- a/uberfire-extensions/uberfire-preferences/uberfire-preferences-client/src/main/java/org/uberfire/ext/preferences/client/resources/i18n/Constants.java
+++ b/uberfire-extensions/uberfire-preferences/uberfire-preferences-client/src/main/java/org/uberfire/ext/preferences/client/resources/i18n/Constants.java
@@ -21,11 +21,14 @@ import org.jboss.errai.ui.shared.api.annotations.TranslationKey;
 public class Constants {
 
     @TranslationKey(defaultValue = "")
-    public static final String SettingsPerspective_Title = "SettingsPerspective.Title";
-
-    @TranslationKey(defaultValue = "")
     public static final String PreferencesCentralActionsView_ChangesUndone = "PreferencesCentralActionsView.ChangesUndone";
 
     @TranslationKey(defaultValue = "")
     public static final String TreeHierarchyStructureView_SaveSuccess = "TreeHierarchyStructureView.SaveSuccess";
+
+    @TranslationKey(defaultValue = "")
+    public static final String AdminPagePresenter_NoScreenParameterError = "AdminPagePresenter.NoScreenParameterError";
+
+    @TranslationKey(defaultValue = "")
+    public static final String AdminPagePresenter_NoScreenFoundError = "AdminPagePresenter.NoScreenFoundError";
 }

--- a/uberfire-extensions/uberfire-preferences/uberfire-preferences-client/src/main/resources/org/uberfire/ext/preferences/client/resources/i18n/Constants.properties
+++ b/uberfire-extensions/uberfire-preferences/uberfire-preferences-client/src/main/resources/org/uberfire/ext/preferences/client/resources/i18n/Constants.properties
@@ -14,8 +14,9 @@
 # limitations under the License.
 #
 
-SettingsPerspective.Title=Admin
 PreferencesCentralActionsView.Save=Save
 PreferencesCentralActionsView.Cancel=Cancel
 PreferencesCentralActionsView.ChangesUndone=Changes undone.
 TreeHierarchyStructureView.SaveSuccess=Changes saved successfully!
+AdminPagePresenter.NoScreenParameterError=A parameter named screen containing the screen name is expected in the place request.
+AdminPagePresenter.NoScreenFoundError=No screen named {0} was added to the admin page.

--- a/uberfire-extensions/uberfire-preferences/uberfire-preferences-client/src/test/java/org/uberfire/ext/preferences/client/admin/AdminPagePresenterTest.java
+++ b/uberfire-extensions/uberfire-preferences/uberfire-preferences-client/src/test/java/org/uberfire/ext/preferences/client/admin/AdminPagePresenterTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.ext.preferences.client.admin;
+
+import java.util.HashMap;
+import java.util.Map;
+import javax.enterprise.event.Event;
+
+import org.jboss.errai.ioc.client.api.ManagedInstance;
+import org.junit.Before;
+import org.junit.Test;
+import org.uberfire.ext.preferences.client.admin.category.AdminPageCategoryPresenter;
+import org.uberfire.ext.preferences.client.admin.page.AdminPage;
+import org.uberfire.ext.preferences.client.admin.page.AdminPageImpl;
+import org.uberfire.mocks.EventSourceMock;
+import org.uberfire.mvp.PlaceRequest;
+import org.uberfire.mvp.impl.DefaultPlaceRequest;
+import org.uberfire.workbench.events.NotificationEvent;
+
+import static org.mockito.Mockito.*;
+
+public class AdminPagePresenterTest {
+
+    private AdminPagePresenter.View view;
+
+    private AdminPage adminPage;
+
+    private ManagedInstance<AdminPageCategoryPresenter> categoryPresenterProvider;
+
+    private Event<NotificationEvent> notification;
+
+    private AdminPagePresenter presenter;
+
+    @Before
+    public void setup() {
+        view = mock( AdminPagePresenter.View.class );
+        adminPage = new AdminPageImpl();
+        categoryPresenterProvider = mock( ManagedInstance.class );
+        notification = mock( EventSourceMock.class );
+
+        presenter = spy( new AdminPagePresenter( view, adminPage, categoryPresenterProvider, notification ) );
+    }
+
+    @Test
+    public void onStartupWithScreenTest() {
+        doNothing().when( presenter ).init( anyString() );
+
+        Map<String, String> params = new HashMap<>();
+        params.put( "screen", "my-screen" );
+        PlaceRequest placeRequest = new DefaultPlaceRequest( "AdminPagePresenter", params );
+
+        presenter.onStartup( placeRequest );
+
+        verify( view ).init( presenter );
+        verify( notification, never() ).fire( any( NotificationEvent.class ) );
+        verify( presenter ).init( "my-screen" );
+    }
+
+    @Test
+    public void onStartupWithoutScreenTest() {
+        PlaceRequest placeRequest = new DefaultPlaceRequest( "AdminPagePresenter" );
+
+        presenter.onStartup( placeRequest );
+
+        verify( view ).init( presenter );
+        verify( notification ).fire( any( NotificationEvent.class ) );
+        verify( presenter, never() ).init( anyString() );
+    }
+
+    @Test
+    public void initWithNotAddedScreenTest() {
+        presenter.init( "not-added-screen" );
+
+        verify( notification ).fire( any( NotificationEvent.class ) );
+    }
+
+    @Test
+    public void initWithAddedScreenTest() {
+        adminPage.addScreen( "added-screen", "Screen title" );
+
+        presenter.init( "added-screen" );
+
+        verify( notification, never() ).fire( any( NotificationEvent.class ) );
+    }
+}

--- a/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-webapp/pom.xml
+++ b/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-webapp/pom.xml
@@ -273,6 +273,25 @@
       <scope>provided</scope>
     </dependency>
 
+    <!-- UberFire Preferences -->
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-preferences-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-preferences-backend</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-preferences-client</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-preferences-processors</artifactId>
+      <scope>provided</scope>
+    </dependency>
 
     <!-- UberFire Plugins Extension -->
     <dependency>
@@ -412,6 +431,8 @@
             <compileSourcesArtifact>org.uberfire:uberfire-backend-api</compileSourcesArtifact>
 
             <!-- UF-ext -->
+            <compileSourcesArtifact>org.uberfire:uberfire-preferences-api</compileSourcesArtifact>
+            <compileSourcesArtifact>org.uberfire:uberfire-preferences-client</compileSourcesArtifact>
             <compileSourcesArtifact>org.uberfire:uberfire-runtime-plugins-api</compileSourcesArtifact>
             <compileSourcesArtifact>org.uberfire:uberfire-runtime-plugins-client</compileSourcesArtifact>
             <compileSourcesArtifact>org.uberfire:uberfire-apps-api</compileSourcesArtifact>

--- a/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-webapp/src/main/java/org/uberfire/ext/security/management/client/ShowcaseEntryPoint.java
+++ b/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-webapp/src/main/java/org/uberfire/ext/security/management/client/ShowcaseEntryPoint.java
@@ -15,27 +15,40 @@
  */
 package org.uberfire.ext.security.management.client;
 
+import java.util.HashMap;
+import java.util.Map;
+import javax.inject.Inject;
+
 import com.google.gwt.animation.client.Animation;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.dom.client.Element;
 import com.google.gwt.dom.client.Style;
 import com.google.gwt.user.client.ui.RootPanel;
 import org.jboss.errai.common.client.api.Caller;
+import org.jboss.errai.common.client.api.ErrorCallback;
 import org.jboss.errai.common.client.api.RemoteCallback;
 import org.jboss.errai.ioc.client.api.AfterInitialization;
 import org.jboss.errai.ioc.client.api.EntryPoint;
+import org.jboss.errai.security.shared.api.Group;
+import org.jboss.errai.security.shared.api.Role;
+import org.jboss.errai.security.shared.api.identity.User;
 import org.jboss.errai.security.shared.service.AuthenticationService;
 import org.uberfire.client.mvp.ActivityManager;
 import org.uberfire.client.mvp.PlaceManager;
 import org.uberfire.client.workbench.widgets.menu.WorkbenchMenuBarPresenter;
+import org.uberfire.ext.preferences.client.admin.AdminPagePerspective;
+import org.uberfire.ext.preferences.client.admin.page.AdminPage;
+import org.uberfire.ext.security.management.api.AbstractEntityManager;
 import org.uberfire.ext.security.management.client.acl.PermissionTreeSetup;
+import org.uberfire.ext.security.management.client.widgets.management.list.EntitiesList;
+import org.uberfire.ext.security.management.impl.SearchRequestImpl;
 import org.uberfire.mvp.Command;
+import org.uberfire.mvp.ParameterizedCommand;
+import org.uberfire.mvp.impl.DefaultPlaceRequest;
 import org.uberfire.workbench.model.menu.MenuFactory;
 import org.uberfire.workbench.model.menu.Menus;
 
-import javax.inject.Inject;
-
-import static org.uberfire.workbench.model.menu.MenuFactory.newTopLevelMenu;
+import static org.uberfire.workbench.model.menu.MenuFactory.*;
 
 /**
  * GWT's entry-point for users management showcase.
@@ -61,34 +74,94 @@ public class ShowcaseEntryPoint {
     @Inject
     private PermissionTreeSetup permissionTreeSetup;
 
+    @Inject
+    private AdminPage adminPage;
+
     @AfterInitialization
     public void startApp() {
         // Wait for user management services to be initialized, if any.
         if ( null != userSystemManager ) {
-            userSystemManager.waitForInitialization(() -> {
+            userSystemManager.waitForInitialization( () -> {
                 permissionTreeSetup.configureTree();
                 setupMenu();
+                setupAdminPage();
                 hideLoadingPopup();
-            });
+            } );
         }
     }
 
     private void setupMenu() {
         final MenuFactory.TopLevelMenusBuilder<MenuFactory.MenuBuilder> builder =
-                newTopLevelMenu("Home")
-                        .perspective("HomePerspective")
+                newTopLevelMenu( "Home" )
+                        .perspective( "HomePerspective" )
                         .endMenu()
-                .newTopLevelMenu("Security")
-                        .perspective("SecurityManagementPerspective")
+                        .newTopLevelMenu( "Security" )
+                        .perspective( "SecurityManagementPerspective" )
+                        .endMenu()
+                        .newTopLevelMenu( "Admin" )
+                        .respondsWith( () -> {
+                            Map<String, String> params = new HashMap<>();
+                            params.put( "screen", "root" );
+                            placeManager.goTo( new DefaultPlaceRequest( AdminPagePerspective.IDENTIFIER, params ) );
+                        } )
                         .endMenu();
 
-        Menus logoutMenus = MenuFactory.newSimpleItem("Logout")
-                .respondsWith(new LogoutCommand())
+        Menus logoutMenus = MenuFactory.newSimpleItem( "Logout" )
+                .respondsWith( new LogoutCommand() )
                 .endMenu().build();
 
         final Menus menus = builder.build();
-        menubar.addMenus(menus);
-        menubar.addMenus(logoutMenus);
+        menubar.addMenus( menus );
+        menubar.addMenus( logoutMenus );
+    }
+
+    private void setupAdminPage() {
+        adminPage.addScreen( "root", "Settings" );
+
+        adminPage.addTool( "root",
+                           "Roles",
+                           "fa-unlock-alt",
+                           "security",
+                           () -> {
+                               Map<String, String> params = new HashMap<>();
+                               params.put( "activeTab", "RolesTab" );
+                               placeManager.goTo( new DefaultPlaceRequest( "SecurityManagementPerspective", params ) );
+                           },
+                           command -> userSystemManager.roles( ( AbstractEntityManager.SearchResponse<Role> response ) -> {
+                               if ( response != null ) {
+                                   command.execute( response.getTotal() );
+                               }
+                           }, ( o, throwable ) -> false ).search( new SearchRequestImpl( "", 1, 15, null ) ) );
+
+        adminPage.addTool( "root",
+                           "Groups",
+                           "fa-users",
+                           "security",
+                           () -> {
+                               Map<String, String> params = new HashMap<>();
+                               params.put( "activeTab", "GroupsTab" );
+                               placeManager.goTo( new DefaultPlaceRequest( "SecurityManagementPerspective", params ) );
+                           },
+                           command -> userSystemManager.groups( ( AbstractEntityManager.SearchResponse<Group> response ) -> {
+                               if ( response != null ) {
+                                   command.execute( response.getTotal() );
+                               }
+                           }, ( o, throwable ) -> false ).search( new SearchRequestImpl( "", 1, 15, null ) ) );
+
+        adminPage.addTool( "root",
+                           "Users",
+                           "fa-user",
+                           "security",
+                           () -> {
+                               Map<String, String> params = new HashMap<>();
+                               params.put( "activeTab", "UsersTab" );
+                               placeManager.goTo( new DefaultPlaceRequest( "SecurityManagementPerspective", params ) );
+                           },
+                           command -> userSystemManager.users( ( AbstractEntityManager.SearchResponse<User> response ) -> {
+                               if ( response != null ) {
+                                   command.execute( response.getTotal() );
+                               }
+                           }, ( o, throwable ) -> false ).search( new SearchRequestImpl( "", 1, 1, null ) ) );
     }
 
     private class LogoutCommand implements Command {
@@ -104,7 +177,7 @@ public class ShowcaseEntryPoint {
             } ).logout();
         }
     }
-    
+
     // Fade out the "Loading application" pop-up
     private void hideLoadingPopup() {
         final Element e = RootPanel.get( "loading" ).getElement();

--- a/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-webapp/src/main/resources/org/uberfire/ext/security/management/UberfireSecurityManagementShowcase.gwt.xml
+++ b/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-security-management-webapp/src/main/resources/org/uberfire/ext/security/management/UberfireSecurityManagementShowcase.gwt.xml
@@ -23,6 +23,7 @@
   <inherits name="org.uberfire.UberfireClientAll"/>
   <inherits name="org.uberfire.UberfireBackend"/>
   <inherits name="org.uberfire.client.views.PatternFlyTheme"/>
+  <inherits name="org.uberfire.ext.preferences.UberfirePreferences"/>
   <inherits name="org.uberfire.ext.plugin.RuntimePluginClient"/>
   <inherits name="org.uberfire.ext.apps.UberfireAppsClient"/>
   <inherits name="org.uberfire.ext.security.management.UberfireSecurityManagementWorkbench"/>


### PR DESCRIPTION
* Handled admin page wrong usage errors.
* Fixed admin page container height.
* Added counters for roles, groups and users on admin page on uberfire-security-management-webapp.

![adminpage2](https://cloud.githubusercontent.com/assets/832830/19662461/5ffd2c10-9a16-11e6-92db-26c532cab4b2.png)
