### PR TITLE
PLANNER-679: Workbench: Termination type tooltips are not displayed in the termination editor

### DIFF
--- a/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/main/java/org/uberfire/client/views/pfly/widgets/FormLabelHelp.java
+++ b/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/main/java/org/uberfire/client/views/pfly/widgets/FormLabelHelp.java
@@ -16,6 +16,7 @@
 
 package org.uberfire.client.views.pfly.widgets;
 
+import com.google.gwt.core.client.GWT;
 import com.google.gwt.user.client.ui.Composite;
 import com.google.gwt.user.client.ui.FlowPanel;
 import com.google.gwt.user.client.ui.HasText;
@@ -23,27 +24,44 @@ import org.gwtbootstrap3.client.ui.FormLabel;
 
 public class FormLabelHelp extends Composite implements HasText {
 
+    private final FormLabel formLabel;
+    private final FlowPanel panel;
+
     private HelpIcon helpIcon;
-    private final FormLabel formLabel = new FormLabel();
-    private final FlowPanel panel = new FlowPanel();
 
     public FormLabelHelp() {
+        this( new FormLabel(), new FlowPanel() );
+    }
+
+    // Defined for testing purposes
+    FormLabelHelp( FormLabel formLabel, FlowPanel panel ) {
+        this.formLabel = formLabel;
+        this.panel = panel;
+
+        init();
+    }
+
+    private void init() {
         initWidget( panel );
         addStyleName( "uf-form-label" );
         panel.add( formLabel );
     }
 
     public void setHelpTitle( final String title ) {
-        getHelpIcon().setHelpTitle( title );
+        if ( title != null ) {
+            getHelpIcon().setHelpTitle( title );
+        }
     }
 
     public void setHelpContent( final String content ) {
-        getHelpIcon().setHelpContent( content );
+        if ( content != null ) {
+            getHelpIcon().setHelpContent( content );
+        }
     }
 
     private HelpIcon getHelpIcon() {
         if ( helpIcon == null ) {
-            helpIcon = new HelpIcon();
+            helpIcon = GWT.create( HelpIcon.class );
             panel.add( helpIcon );
         }
         return helpIcon;
@@ -63,7 +81,7 @@ public class FormLabelHelp extends Composite implements HasText {
         formLabel.setFor( forValue );
     }
 
-    public void setShowRequiredIndicator( final boolean required ){
+    public void setShowRequiredIndicator( final boolean required ) {
         formLabel.setShowRequiredIndicator( required );
     }
 }

--- a/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/main/java/org/uberfire/client/views/pfly/widgets/HelpIcon.java
+++ b/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/main/java/org/uberfire/client/views/pfly/widgets/HelpIcon.java
@@ -25,46 +25,45 @@ import org.gwtbootstrap3.client.ui.constants.Placement;
 
 public class HelpIcon extends Composite {
 
-    private final Icon icon = new Icon( IconType.INFO_CIRCLE );
-    private final SimplePanel panel = new SimplePanel();
-    private String title;
-    private String content;
-
+    private Icon icon;
+    private SimplePanel panel;
     private Popover popover;
 
     public HelpIcon() {
-        initWidget( panel );
-        addStyleName( "uf-help-icon" );
+        this( new Icon(), new SimplePanel(), new Popover() );
     }
 
-    @Override
-    protected void onLoad() {
-        super.onLoad();
-        if ( title != null || content != null ) {
-            this.popover = new Popover( icon );
-            popover.setContent( content );
-            popover.setTitle( title );
-            popover.setContainer( "body" );
-            popover.setIsHtml( true );
-            popover.setPlacement( Placement.AUTO );
-            panel.setWidget( popover );
-        }
+    // Defined for testing purposes
+    HelpIcon( Icon icon, SimplePanel panel, Popover popover ) {
+        this.icon = icon;
+        this.popover = popover;
+        this.panel = panel;
+
+        init();
+    }
+
+    private void init() {
+        initWidget( panel );
+        addStyleName( "uf-help-icon" );
+
+        icon.setType( IconType.INFO_CIRCLE );
+
+        popover.setWidget( icon );
+        popover.setContainer( "body" );
+        popover.setIsHtml( true );
+        popover.setPlacement( Placement.AUTO );
+
+        panel.setWidget( popover );
     }
 
     public void setHelpTitle( final String title ) {
-        this.title = title;
-        if (popover != null) {
-            popover.setTitle( title );
-            popover.reconfigure();
-        }
+        popover.setTitle( title );
+        popover.reconfigure();
     }
 
     public void setHelpContent( final String content ) {
-        this.content = content;
-        if (popover != null) {
-            popover.setContent( content );
-            popover.reconfigure();
-        }
+        popover.setContent( content );
+        popover.reconfigure();
     }
 
 }

--- a/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/test/java/org/uberfire/client/views/pfly/widgets/FormLabelHelpTest.java
+++ b/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/test/java/org/uberfire/client/views/pfly/widgets/FormLabelHelpTest.java
@@ -1,0 +1,90 @@
+package org.uberfire.client.views.pfly.widgets;
+
+import com.google.gwt.user.client.ui.FlowPanel;
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import org.gwtbootstrap3.client.ui.FormLabel;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.*;
+import static org.mockito.Mockito.*;
+
+@RunWith(GwtMockitoTestRunner.class)
+public class FormLabelHelpTest {
+
+    @Mock
+    private FormLabel formLabel;
+
+    @Mock
+    private FlowPanel panel;
+
+    private FormLabelHelp formLabelHelp;
+
+    @Before
+    public void setUp() {
+        this.formLabelHelp = new FormLabelHelp( formLabel, panel );
+    }
+
+    @Test
+    public void setHelpTitleNull() {
+        Mockito.reset( panel );
+
+        formLabelHelp.setHelpTitle( null );
+
+        verify( panel, times( 0 ) ).add( isA( HelpIcon.class ) );
+    }
+
+
+    @Test
+    public void setHelpTitleNotNull() {
+        Mockito.reset( panel );
+
+        formLabelHelp.setHelpTitle( "testTitle" );
+
+        verify( panel ).add( isA( HelpIcon.class ) );
+    }
+
+    @Test
+    public void setHelpContentNull() {
+        Mockito.reset( panel );
+
+        formLabelHelp.setHelpContent( null );
+
+        verify( panel, times( 0 ) ).add( isA( HelpIcon.class ) );
+    }
+
+    @Test
+    public void setHelpContentNotNull() {
+        Mockito.reset( panel );
+
+        formLabelHelp.setHelpContent( "testContent" );
+
+        verify( panel ).add( isA( HelpIcon.class ) );
+    }
+
+    @Test
+    public void setText() {
+        formLabelHelp.setText( "testText" );
+
+        verify( formLabel ).setText( "testText" );
+    }
+
+    @Test
+    public void getText() {
+        Mockito.when( formLabel.getText() ).thenReturn( "testText" );
+
+        assertEquals( "testText", formLabelHelp.getText() );
+    }
+
+    @Test
+    public void setFor() {
+        formLabelHelp.setFor( "testFor" );
+
+        verify( formLabel ).setFor( "testFor" );
+    }
+
+}

--- a/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/test/java/org/uberfire/client/views/pfly/widgets/HelpIconTest.java
+++ b/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/test/java/org/uberfire/client/views/pfly/widgets/HelpIconTest.java
@@ -1,0 +1,47 @@
+package org.uberfire.client.views.pfly.widgets;
+
+import com.google.gwt.user.client.ui.SimplePanel;
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import org.gwtbootstrap3.client.ui.Icon;
+import org.gwtbootstrap3.client.ui.Popover;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+
+import static org.mockito.Mockito.*;
+
+@RunWith(GwtMockitoTestRunner.class)
+public class HelpIconTest {
+
+    @Mock
+    private Icon icon;
+
+    @Mock
+    private SimplePanel panel;
+
+    @Mock
+    private Popover popover;
+
+    private HelpIcon helpIcon;
+
+    @Before
+    public void setUp() {
+        this.helpIcon = new HelpIcon( icon, panel, popover );
+    }
+
+    @Test
+    public void setHelpContent() {
+        helpIcon.setHelpContent( "testContent" );
+
+        verify( popover ).setContent( "testContent" );
+    }
+
+    @Test
+    public void setHelpTitle() {
+        helpIcon.setHelpTitle( "testTitle" );
+
+        verify( popover ).setTitle( "testTitle" );
+    }
+
+}


### PR DESCRIPTION
Make sure popover instance exists when setting help title/content.
