### PR TITLE
[0.9.x] RHBPMS-4129: Unlocalized 'Please wait. Loading application...' spinner.

### DIFF
--- a/uberfire-server/src/main/java/org/uberfire/server/locale/GWTLocaleHeaderFilter.java
+++ b/uberfire-server/src/main/java/org/uberfire/server/locale/GWTLocaleHeaderFilter.java
@@ -29,6 +29,7 @@ import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpServletResponseWrapper;
 
+import org.apache.commons.lang3.LocaleUtils;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 
@@ -67,7 +68,7 @@ public class GWTLocaleHeaderFilter implements Filter {
 
         final byte[] outputBytes = output.getBytes( "UTF-8" );
         response.setContentLength( outputBytes.length );
-        response.getOutputStream().write( outputBytes );
+        response.getWriter().print( output );
     }
 
     protected CharResponseWrapper getWrapper( final HttpServletResponse response ) {
@@ -75,11 +76,15 @@ public class GWTLocaleHeaderFilter implements Filter {
     }
 
     private Locale getLocale( final ServletRequest request ) {
-        Locale locale = null;
+        Locale locale = request.getLocale();
+        final String paramLocale = request.getParameter( "locale" );
+        if ( paramLocale == null || paramLocale.isEmpty() ) {
+            return locale;
+        }
         try {
-            locale = new Locale( request.getParameter( "locale" ) );
+            locale = LocaleUtils.toLocale( paramLocale );
         } catch ( Exception e ) {
-            locale = request.getLocale();
+            //Swallow. Locale is initially set to ServletRequest locale
         }
         return locale;
     }

--- a/uberfire-server/src/test/java/org/uberfire/server/locale/GWTLocaleHeaderFilterTest.java
+++ b/uberfire-server/src/test/java/org/uberfire/server/locale/GWTLocaleHeaderFilterTest.java
@@ -16,13 +16,14 @@
 
 package org.uberfire.server.locale;
 
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.io.Writer;
 import java.util.Locale;
 import java.util.Scanner;
 import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
-import javax.servlet.ServletOutputStream;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
@@ -37,7 +38,7 @@ public class GWTLocaleHeaderFilterTest {
     public void testLocaleDefault() throws IOException, ServletException {
         final GWTLocaleHeaderFilter localeHeaderFilter = getFilter();
 
-        final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        final Writer sw = new StringWriter();
 
         final HttpServletRequest req = mock( HttpServletRequest.class );
         final HttpServletResponse resp = mock( HttpServletResponse.class );
@@ -45,47 +46,56 @@ public class GWTLocaleHeaderFilterTest {
 
         when( req.getLocale() ).thenReturn( Locale.US );
 
-        when( resp.getOutputStream() ).thenReturn( new ServletOutputStream() {
-            @Override
-            public void write( final int b ) throws IOException {
-                baos.write( b );
-            }
-        } );
+        when( resp.getWriter() ).thenReturn( new PrintWriter( sw ) );
 
         localeHeaderFilter.doFilter( req, resp, chain );
 
-        assertEquals( new Scanner( getClass().getResourceAsStream( "/expected-sample.html" ), "UTF-8" ).useDelimiter( "\\A" ).next(), baos.toString() );
+        assertEquals( new Scanner( getClass().getResourceAsStream( "/expected-sample.html" ), "UTF-8" ).useDelimiter( "\\A" ).next(), sw.toString() );
     }
 
     @Test
-    public void testLocaleParameter() throws IOException, ServletException {
+    public void testLocaleWithLanguageParameter() throws IOException, ServletException {
         final GWTLocaleHeaderFilter localeHeaderFilter = getFilter();
 
-        final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        final Writer sw = new StringWriter();
 
         final HttpServletRequest req = mock( HttpServletRequest.class );
         final HttpServletResponse resp = mock( HttpServletResponse.class );
         final FilterChain chain = mock( FilterChain.class );
 
-        when( req.getParameter( "locale" ) ).thenReturn( "jp" );
+        when( req.getParameter( "locale" ) ).thenReturn( "ja" );
 
-        when( resp.getOutputStream() ).thenReturn( new ServletOutputStream() {
-            @Override
-            public void write( final int b ) throws IOException {
-                baos.write( b );
-            }
-        } );
+        when( resp.getWriter() ).thenReturn( new PrintWriter( sw ) );
 
         localeHeaderFilter.doFilter( req, resp, chain );
 
-        assertEquals( new Scanner( getClass().getResourceAsStream( "/expected-2-sample.html" ), "UTF-8" ).useDelimiter( "\\A" ).next(), baos.toString() );
+        assertEquals( new Scanner( getClass().getResourceAsStream( "/expected-2-sample.html" ), "UTF-8" ).useDelimiter( "\\A" ).next(), sw.toString() );
+    }
+
+    @Test
+    public void testLocaleWithLanguageAndCountryParameter() throws IOException, ServletException {
+        final GWTLocaleHeaderFilter localeHeaderFilter = getFilter();
+
+        final Writer sw = new StringWriter();
+
+        final HttpServletRequest req = mock( HttpServletRequest.class );
+        final HttpServletResponse resp = mock( HttpServletResponse.class );
+        final FilterChain chain = mock( FilterChain.class );
+
+        when( req.getParameter( "locale" ) ).thenReturn( "ja_JP" );
+
+        when( resp.getWriter() ).thenReturn( new PrintWriter( sw ) );
+
+        localeHeaderFilter.doFilter( req, resp, chain );
+
+        assertEquals( new Scanner( getClass().getResourceAsStream( "/expected-3-sample.html" ), "UTF-8" ).useDelimiter( "\\A" ).next(), sw.toString() );
     }
 
     @Test
     public void testNonExistentLocaleParameter() throws IOException, ServletException {
         final GWTLocaleHeaderFilter localeHeaderFilter = getFilter();
 
-        final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        final Writer sw = new StringWriter();
 
         final HttpServletRequest req = mock( HttpServletRequest.class );
         final HttpServletResponse resp = mock( HttpServletResponse.class );
@@ -94,16 +104,11 @@ public class GWTLocaleHeaderFilterTest {
         when( req.getParameter( "locale" ) ).thenReturn( "xxx" );
         when( req.getLocale() ).thenReturn( Locale.US );
 
-        when( resp.getOutputStream() ).thenReturn( new ServletOutputStream() {
-            @Override
-            public void write( final int b ) throws IOException {
-                baos.write( b );
-            }
-        } );
+        when( resp.getWriter() ).thenReturn( new PrintWriter( sw ) );
 
         localeHeaderFilter.doFilter( req, resp, chain );
 
-        assertEquals( new Scanner( getClass().getResourceAsStream( "/expected-3-sample.html" ), "UTF-8" ).useDelimiter( "\\A" ).next(), baos.toString() );
+        assertEquals( new Scanner( getClass().getResourceAsStream( "/expected-4-sample.html" ), "UTF-8" ).useDelimiter( "\\A" ).next(), sw.toString() );
     }
 
     private GWTLocaleHeaderFilter getFilter() {

--- a/uberfire-server/src/test/resources/expected-2-sample.html
+++ b/uberfire-server/src/test/resources/expected-2-sample.html
@@ -16,7 +16,7 @@
   -->
 <html>
  <head> 
-  <meta name="gwt:property" content="locale=jp">
+  <meta name="gwt:property" content="locale=ja">
  </head> 
  <body>   
  </body>

--- a/uberfire-server/src/test/resources/expected-4-sample.html
+++ b/uberfire-server/src/test/resources/expected-4-sample.html
@@ -16,7 +16,7 @@
   -->
 <html>
  <head> 
-  <meta name="gwt:property" content="locale=ja_JP">
+  <meta name="gwt:property" content="locale=en_US">
  </head> 
  <body>   
  </body>


### PR DESCRIPTION
See https://issues.jboss.org/browse/RHBPMS-4129

Use of ```response.getOutputStream().write( outputBytes )``` was double-encoding translated text.

I also updated to use ```org.apache.commons.lang3.LocaleUtils``` as Java's ```Locale``` constructor does not handle Language and Country locale formats (e.g. en_US).