### PR TITLE
[UF-370]: update security modal dialogs layout

### DIFF
--- a/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-widgets-security-management/src/main/java/org/uberfire/ext/security/management/client/widgets/management/ChangePasswordView.ui.xml
+++ b/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-widgets-security-management/src/main/java/org/uberfire/ext/security/management/client/widgets/management/ChangePasswordView.ui.xml
@@ -31,6 +31,9 @@
     .button {
       margin-left: 2px;
     }
+    .buttonGroup {
+      text-align: right;
+    }
   </ui:style>
 
   <g:FlowPanel ui:field="mainPanel" addStyleNames="{style.mainPanel}">
@@ -53,10 +56,10 @@
           </g:FlowPanel>
         </b:FormGroup>
 
-        <b:FormGroup>
+        <b:FormGroup addStyleNames="{style.buttonGroup}">
           <g:FlowPanel addStyleNames="col-md-12">
-            <b:Button ui:field="clearButton" type="DEFAULT" title="{i18n.clear}" text="{i18n.clear}" addStyleNames="{style.button}"/>
             <b:Button ui:field="updateButton" type="PRIMARY" title="{i18n.change}" text="{i18n.change}" addStyleNames="{style.button}"/>
+            <b:Button ui:field="clearButton" type="DEFAULT" title="{i18n.clear}" text="{i18n.clear}" addStyleNames="{style.button}"/>
           </g:FlowPanel>
         </b:FormGroup>
 

--- a/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-widgets-security-management/src/main/java/org/uberfire/ext/security/management/client/widgets/management/editor/AssignedEntitiesModalEditorView.ui.xml
+++ b/uberfire-extensions/uberfire-security/uberfire-security-management/uberfire-widgets-security-management/src/main/java/org/uberfire/ext/security/management/client/widgets/management/editor/AssignedEntitiesModalEditorView.ui.xml
@@ -36,8 +36,8 @@
         <explorer:EntitiesExplorerView ui:field="entitiesExplorerView"/>
       </b:ModalBody>
       <b:ModalFooter>
-        <b:Button type="DEFAULT"  ui:field="closeButton" text="{i18n.cancel}" title="{i18n.cancel}"/>
         <b:Button type="PRIMARY" ui:field="saveButton" text="{i18n.save}" title="{i18n.save}"/>
+        <b:Button type="DEFAULT"  ui:field="closeButton" text="{i18n.cancel}" title="{i18n.cancel}"/>
       </b:ModalFooter>
     </b:Modal>
       


### PR DESCRIPTION
Moves primary buttons to left to be the first button as in other modal dialogs and moves buttons from center to right in change password dialog.