### PR TITLE
GUVNOR-2734: Guided Decision Table Editor: Close Analysis Report for graph editor

### DIFF
--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/layer/impl/DefaultGridLayer.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/layer/impl/DefaultGridLayer.java
@@ -182,8 +182,7 @@ public class DefaultGridLayer extends Layer implements GridLayer {
     /**
      * Add a child to this Layer. If the child is a GridWidget then also add
      * a Connector between the Grid Widget and any "linked" GridWidgets.
-     * @param child
-     *         Primitive to add to the Layer
+     * @param child Primitive to add to the Layer
      * @return The Layer
      */
     @Override
@@ -264,10 +263,8 @@ public class DefaultGridLayer extends Layer implements GridLayer {
     /**
      * Add a child and other children to this Layer. If the child or any children is a GridWidget
      * then also add a Connector between the Grid Widget and any "linked" GridWidgets.
-     * @param child
-     *         Primitive to add to the Layer
-     * @param children
-     *         Additional primitive(s) to add to the Layer
+     * @param child Primitive to add to the Layer
+     * @param children Additional primitive(s) to add to the Layer
      * @return The Layer
      */
     @Override
@@ -283,8 +280,7 @@ public class DefaultGridLayer extends Layer implements GridLayer {
      * Remove a child from this Layer. if the child is a GridWidget also remove
      * any Connectors that have been added between the GridWidget being removed
      * and any of GridWidgets.
-     * @param child
-     *         Primitive to remove from the Layer
+     * @param child Primitive to remove from the Layer
      * @return The Layer
      */
     @Override
@@ -325,6 +321,7 @@ public class DefaultGridLayer extends Layer implements GridLayer {
     @Override
     public Layer removeAll() {
         gridWidgets.clear();
+        gridWidgetConnectors.clear();
         return super.removeAll();
     }
 


### PR DESCRIPTION
See https://issues.jboss.org/browse/GUVNOR-2734

Cached "Connectors" were not being cleared when the Canvas was cleared.