### PR TITLE
maven-compiler-plugin: disable forking + remove duplicated config

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -239,17 +239,6 @@
           </executions>
         </plugin>
         <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-compiler-plugin</artifactId>
-          <configuration>
-            <fork>true</fork>
-            <meminitial>128m</meminitial>
-            <maxmem>512m</maxmem>
-            <showDeprecation>true</showDeprecation>
-            <showWarnings>true</showWarnings>
-          </configuration>
-        </plugin>
-        <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>gwt-maven-plugin</artifactId>
           <version>${version.com.google.gwt}</version>


### PR DESCRIPTION
 * jboss-parent already defines source, target, warnings and deprecation
 * fork config removed == forking disabled (default is false)
 * meminitial and memmax are only needed when forking