### PR TITLE
[UF-444] Avoid concurrent Freemarker setup

### DIFF
--- a/uberfire-workbench/uberfire-workbench-processors/src/main/java/org/uberfire/annotations/processors/AbstractGenerator.java
+++ b/uberfire-workbench/uberfire-workbench-processors/src/main/java/org/uberfire/annotations/processors/AbstractGenerator.java
@@ -40,10 +40,12 @@ public abstract class AbstractGenerator {
             throw new NoClassDefFoundError( "Failing for testing purposes" );
         }
         try {
-            config = new Configuration();
-            config.setClassForTemplateLoading( getClass(),
-                    "templates" );
-            config.setObjectWrapper( new DefaultObjectWrapper() );
+            synchronized (AbstractGenerator.class) {
+                config = new Configuration();
+                config.setClassForTemplateLoading( getClass(),
+                        "templates" );
+                config.setObjectWrapper( new DefaultObjectWrapper() );
+            }
         } catch (NoClassDefFoundError ex) {
             if (ex.getCause() == null) {
                 ex.initCause( INITIALIZER_EXCEPTION );


### PR DESCRIPTION
The annotation processor sometimes failed when used
concurrently (e.g. in parallel Maven build). The reason
seems to be the fact that Freemarker's Configuration class
(or its dependencies) is not thread safe.

Synchronizing the Freemarker setup will likely make the init
sligthly slower, but since this is only build-time
(compile-time) processor it should not matter much.

@ederign, @manstis this seems to fix the issue we talked about today. I am running more build locally to make sure. However, I am not 100% sure about the implications of this change. WDYT? Is this OK?