### PR TITLE
Upgrade IP BOM to 7.0.0.CR5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <groupId>org.jboss.integration-platform</groupId>
     <artifactId>jboss-integration-platform-bom</artifactId>
     <!-- Keep in sync with the parent version of uberfire-bom/pom.xml -->
-    <version>7.0.0.CR4</version>
+    <version>7.0.0.CR5</version>
   </parent>
 
   <groupId>org.uberfire</groupId>

--- a/uberfire-archetype/uberfire-project-archetype/src/main/resources/archetype-resources/__rootArtifactId__-parent-with-dependencies/pom.xml
+++ b/uberfire-archetype/uberfire-project-archetype/src/main/resources/archetype-resources/__rootArtifactId__-parent-with-dependencies/pom.xml
@@ -52,7 +52,7 @@
     <version.com.google.guava>${version.com.google.guava}</version.com.google.guava>
     <version.com.sun.xml.bind>${version.com.sun.xml.bind}</version.com.sun.xml.bind>
 
-    <version.org.hibernate.javax.persistence.hibernate-jpa-2_0-api>${version.org.hibernate.javax.persistence.hibernate-jpa-2.0-api}</version.org.hibernate.javax.persistence.hibernate-jpa-2_0-api>
+    <version.org.hibernate.javax.persistence.hibernate-jpa-2_1-api>${version.org.hibernate.javax.persistence.hibernate-jpa-2.1-api}</version.org.hibernate.javax.persistence.hibernate-jpa-2_1-api>
     <version.org.jasypt>${version.org.jasypt.jasypt}</version.org.jasypt>
     <version.org.javassist>${version.org.javassist}</version.org.javassist>
     <version.org.scannotation>${version.org.scannotation}</version.org.scannotation>
@@ -711,8 +711,8 @@
 
       <dependency><!-- JPA 2 implementation agnostic jar -->
         <groupId>org.hibernate.javax.persistence</groupId>
-        <artifactId>hibernate-jpa-2.0-api</artifactId>
-        <version>\${version.org.hibernate.javax.persistence.hibernate-jpa-2_0-api}</version>
+        <artifactId>hibernate-jpa-2.1-api</artifactId>
+        <version>\${version.org.hibernate.javax.persistence.hibernate-jpa-2_1-api}</version>
       </dependency>
 
       <dependency>

--- a/uberfire-archetype/uberfire-project-archetype/src/main/resources/archetype-resources/__rootArtifactId__-showcase/__rootArtifactId__-distribution-wars/pom.xml
+++ b/uberfire-archetype/uberfire-project-archetype/src/main/resources/archetype-resources/__rootArtifactId__-showcase/__rootArtifactId__-distribution-wars/pom.xml
@@ -135,7 +135,7 @@
 
     <dependency>
       <groupId>org.hibernate.javax.persistence</groupId>
-      <artifactId>hibernate-jpa-2.0-api</artifactId>
+      <artifactId>hibernate-jpa-2.1-api</artifactId>
     </dependency>
 
     <dependency>

--- a/uberfire-archetype/uberfire-project-archetype/src/main/resources/archetype-resources/__rootArtifactId__-showcase/__rootArtifactId__-distribution-wars/src/main/assembly/assembly-showcase-tomcat-7_0.xml
+++ b/uberfire-archetype/uberfire-project-archetype/src/main/resources/archetype-resources/__rootArtifactId__-showcase/__rootArtifactId__-distribution-wars/src/main/assembly/assembly-showcase-tomcat-7_0.xml
@@ -33,7 +33,7 @@
         <include>org.slf4j:slf4j-ext:jar</include>
         <include>ch.qos.cal10n:cal10n-api:jar</include>
 
-        <include>org.hibernate.javax.persistence:hibernate-jpa-2.0-api:jar</include>
+        <include>org.hibernate.javax.persistence:hibernate-jpa-2.1-api:jar</include>
         <include>org.jboss.logging:jboss-logging:jar</include>
 
         <include>org.jboss.weld:weld-api:jar</include>

--- a/uberfire-bom/pom.xml
+++ b/uberfire-bom/pom.xml
@@ -23,7 +23,7 @@
     <groupId>org.jboss.integration-platform</groupId>
     <artifactId>jboss-integration-platform-parent</artifactId>
     <!-- Keep in sync with the parent version of ../pom.xml -->
-    <version>7.0.0.CR4</version>
+    <version>7.0.0.CR5</version>
     <relativePath/>
   </parent>
 

--- a/uberfire-showcase/showcase-distribution-wars/pom.xml
+++ b/uberfire-showcase/showcase-distribution-wars/pom.xml
@@ -145,7 +145,7 @@
 
     <dependency>
       <groupId>org.hibernate.javax.persistence</groupId>
-      <artifactId>hibernate-jpa-2.0-api</artifactId>
+      <artifactId>hibernate-jpa-2.1-api</artifactId>
     </dependency>
 
     <dependency>

--- a/uberfire-showcase/showcase-distribution-wars/src/main/assembly/assembly-showcase-tomcat-7_0.xml
+++ b/uberfire-showcase/showcase-distribution-wars/src/main/assembly/assembly-showcase-tomcat-7_0.xml
@@ -38,7 +38,7 @@
 
         <include>org.jboss.spec.javax.interceptor:jboss-interceptors-api_1.2_spec:jar</include>
         <include>org.jboss.spec.javax.annotation:jboss-annotations-api_1.2_spec:jar</include>
-        <include>org.hibernate.javax.persistence:hibernate-jpa-2.0-api:jar</include>
+        <include>org.hibernate.javax.persistence:hibernate-jpa-2.1-api:jar</include>
         <include>org.jboss.spec.javax.ws.rs:jboss-jaxrs-api_2.0_spec:jar</include>
         <include>com.sun.xml.bind:jaxb-impl:jar</include>
         <include>com.sun.xml.bind:jaxb-xjc:jar</include>


### PR DESCRIPTION
 * CR5 brings JPA 2.1 + Hibernate 5.x
   (upgraded from JPA 2.0 + Hibernate 4.x)

Please don't merge yet. All the IP BOM 7.0.0.CR5 PRs need to be merged together.