### PR TITLE
UF-444: Avoid concurrent Freemarker setup (uberfire-preferences-processors)

### DIFF
--- a/uberfire-extensions/uberfire-preferences/uberfire-preferences-processors/src/main/java/org/uberfire/ext/preferences/processors/AbstractGenerator.java
+++ b/uberfire-extensions/uberfire-preferences/uberfire-preferences-processors/src/main/java/org/uberfire/ext/preferences/processors/AbstractGenerator.java
@@ -43,10 +43,12 @@ public abstract class AbstractGenerator {
             throw new NoClassDefFoundError( "Failing for testing purposes" );
         }
         try {
-            config = new Configuration();
-            config.setClassForTemplateLoading( getClass(),
-                                               "templates" );
-            config.setObjectWrapper( new DefaultObjectWrapper() );
+            synchronized ( AbstractGenerator.class ) {
+                config = new Configuration();
+                config.setClassForTemplateLoading( getClass(),
+                                                   "templates" );
+                config.setObjectWrapper( new DefaultObjectWrapper() );
+            }
         } catch ( NoClassDefFoundError ex ) {
             if ( ex.getCause() == null ) {
                 ex.initCause( INITIALIZER_EXCEPTION );


### PR DESCRIPTION
@psiroky Could you please take a look? As mentioned in my email, it would be nice to test it in a Jenkins/release build, checking if the "Home" > "Admin" page is loading correctly.