### PR TITLE
Avoid logging of plugin watcher errors during shutdown

### DIFF
--- a/uberfire-backend/uberfire-backend-server/src/test/java/org/uberfire/backend/server/plugin/GwtRuntimePluginWatcherTest.java
+++ b/uberfire-backend/uberfire-backend-server/src/test/java/org/uberfire/backend/server/plugin/GwtRuntimePluginWatcherTest.java
@@ -19,30 +19,40 @@ package org.uberfire.backend.server.plugin;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+import java.nio.file.Path;
 import java.util.concurrent.ExecutorService;
 
 import org.junit.After;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.runners.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class GwtRuntimePluginWatcherTest extends AbstractGwtRuntimePluginTest {
-    
-    @InjectMocks
+
+    @Spy
     private GwtRuntimePluginWatcher pluginWatcher;
     
     @Mock
     private GwtRuntimePluginLoader pluginLoader;
-    
+
     @Mock
     private ExecutorService executor;
+
+    @Mock
+    private Path plugin;
+
+    @Mock
+    private Path fileName;
+
     
     @After
     public void tearDown() {
@@ -52,29 +62,63 @@ public class GwtRuntimePluginWatcherTest extends AbstractGwtRuntimePluginTest {
     @Test
     public void startSubmitsWatcherThread() throws Exception {
         pluginWatcher.start( pluginDir, executor, pluginLoader );
-        verify(executor, times(1)).submit( any (Runnable.class));
+        verify( executor, times( 1 ) ).submit( any( Runnable.class ) );
     }
-    
+
     @Test
     public void startDoesNotSubmitWatcherThreadIfPluginDirDoesNotExist() throws Exception {
         pluginWatcher.start( pluginDir + "invalid", executor, pluginLoader );
-        verify(executor, never()).submit( any (Runnable.class));        
+        verify( executor, never() ).submit( any( Runnable.class ) );
     }
-    
+
     @Test
     public void startOnlyOnce() throws Exception {
         pluginWatcher.start( pluginDir, executor, pluginLoader );
         pluginWatcher.start( pluginDir, executor, pluginLoader );
-        verify(executor, times(1)).submit( any (Runnable.class));
+        verify( executor, times( 1 ) ).submit( any( Runnable.class ) );
     }
-    
+
     @Test
     public void stopEndsWatcherThread() throws Exception {
         pluginWatcher.start( pluginDir, executor, pluginLoader );
-        assertTrue(pluginWatcher.active);
+        assertTrue( pluginWatcher.active );
         pluginWatcher.stop();
-        assertFalse(pluginWatcher.active);
-        verify(executor, times(1)).shutdown( );
+        assertFalse( pluginWatcher.active );
+        verify( executor, times( 1 ) ).shutdown();
     }
 
+    @Test
+    public void loadPluginLogsError() throws Exception {
+        pluginWatcher.start( pluginDir, executor, pluginLoader );
+        
+        when( fileName.toString() ).thenReturn( "fileName.jar" );
+        when( plugin.getFileName() ).thenReturn( fileName );
+
+        Exception e = new RuntimeException();
+        doThrow( e ).when( pluginLoader ).loadPlugin( any( Path.class ), any( Boolean.class ) );
+        pluginWatcher.loadPlugin( plugin );
+        verify( pluginWatcher, times( 1 ) ).logPluginWatcherError( "Failed to process new plugin fileName.jar", e, false );
+        
+        pluginWatcher.stop();
+        pluginWatcher.loadPlugin( plugin );
+        verify( pluginWatcher, times( 1 ) ).logPluginWatcherError( "Failed to process new plugin fileName.jar", e, true );
+    }
+
+    @Test
+    public void reloadPluginsLogsError() throws Exception {
+        pluginWatcher.start( pluginDir, executor, pluginLoader );
+        
+        when( fileName.toString() ).thenReturn( "fileName.js" );
+        when( plugin.getFileName() ).thenReturn( fileName );
+
+        Exception e = new RuntimeException();
+        doThrow( e ).when( pluginLoader ).reload();
+        pluginWatcher.reloadPlugins( plugin );
+        verify( pluginWatcher, times( 1 ) ).logPluginWatcherError( "Failed to delete plugin fileName.js", e, false );
+        
+        pluginWatcher.stop();
+        pluginWatcher.reloadPlugins( plugin );
+        verify( pluginWatcher, times( 1 ) ).logPluginWatcherError( "Failed to delete plugin fileName.js", e, true );
+    }
+    
 }


### PR DESCRIPTION
- An additional check makes sure the watcher is active
before processing plugin changes. This makes it much
less likely to happen but there's still a time window
in which it could occur

- Therefore if an error is thrown during shutdown
we just log it in debug level