### PR TITLE
UF-456: Rename .gitignore file created in empty directory to .gitkeep

### DIFF
--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/main/java/org/uberfire/java/nio/fs/jgit/JGitFileSystemProvider.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/main/java/org/uberfire/java/nio/fs/jgit/JGitFileSystemProvider.java
@@ -1251,8 +1251,7 @@ public class JGitFileSystemProvider implements SecuredFileSystemProvider,
         }
 
         try {
-            final OutputStream outputStream = newOutputStream( path.resolve( ".gitignore" ) );
-            outputStream.write( "# empty\n".getBytes() );
+            final OutputStream outputStream = newOutputStream( path.resolve( ".gitkeep" ) );
             outputStream.close();
         } catch ( final Exception e ) {
             throw new IOException( "Failed to write to or close the output stream.", e );
@@ -1322,8 +1321,8 @@ public class JGitFileSystemProvider implements SecuredFileSystemProvider,
                 return;
             }
             final List<JGitPathInfo> content = listPathContent( path.getFileSystem().gitRepo(), path.getRefTree(), path.getPath() );
-            if ( content.size() == 1 && content.get( 0 ).getPath().equals( path.getPath().substring( 1 ) + "/.gitignore" ) ) {
-                delete( path.resolve( ".gitignore" ) );
+            if ( content.size() == 1 && content.get( 0 ).getPath().equals( path.getPath().substring( 1 ) + "/.gitkeep" ) ) {
+                delete( path.resolve( ".gitkeep" ) );
                 deleteResource( path, options );
                 return;
             }
@@ -1414,8 +1413,8 @@ public class JGitFileSystemProvider implements SecuredFileSystemProvider,
                 return true;
             }
             final List<JGitPathInfo> content = listPathContent( path.getFileSystem().gitRepo(), path.getRefTree(), path.getPath() );
-            if ( content.size() == 1 && content.get( 0 ).getPath().equals( path.getPath().substring( 1 ) + "/.gitignore" ) ) {
-                delete( path.resolve( ".gitignore" ) );
+            if ( content.size() == 1 && content.get( 0 ).getPath().equals( path.getPath().substring( 1 ) + "/.gitkeep" ) ) {
+                delete( path.resolve( ".gitkeep" ) );
                 return true;
             }
             throw new DirectoryNotEmptyException( path.toString() );

--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/JGitFileSystemProviderTest.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/JGitFileSystemProviderTest.java
@@ -856,6 +856,9 @@ public class JGitFileSystemProviderTest extends AbstractTestInfra {
         final Pair<PathType, ObjectId> resultAfter = JGitUtil.checkPath( path.getFileSystem().gitRepo(), path.getRefTree(), path.getPath() );
         assertThat( resultAfter.getK1() ).isEqualTo( PathType.DIRECTORY );
 
+        final Path gitkeepPath = path.resolve( ".gitkeep" );
+        assertThat( provider.exists( gitkeepPath ) ).isEqualTo( true );
+
         try {
             provider.createDirectory( path );
             failBecauseExceptionWasNotThrown( FileAlreadyExistsException.class );


### PR DESCRIPTION
Rename .gitignore to .gitkeep to describe the purpose of the file in a better way.