### PR TITLE
Fix initialization ordering problem in GridLayerRedrawManager

### DIFF
--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/layer/impl/GridLayerRedrawManager.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/main/java/org/uberfire/ext/wires/core/grids/client/widget/layer/impl/GridLayerRedrawManager.java
@@ -28,7 +28,7 @@ public class GridLayerRedrawManager {
 
     private static final GridLayerRedrawManager instance = new GridLayerRedrawManager();
 
-    private static final Comparator<PrioritizedCommand> COMPARATOR = new Comparator<PrioritizedCommand>() {
+    private final Comparator<PrioritizedCommand> COMPARATOR = new Comparator<PrioritizedCommand>() {
         @Override
         public int compare( final PrioritizedCommand o1,
                             final PrioritizedCommand o2 ) {
@@ -36,7 +36,7 @@ public class GridLayerRedrawManager {
         }
     };
 
-    private SortedSet<PrioritizedCommand> commands = new TreeSet<PrioritizedCommand>( COMPARATOR );
+    SortedSet<PrioritizedCommand> commands = new TreeSet<PrioritizedCommand>( COMPARATOR );
 
     private AnimationScheduler.AnimationCallback callback;
 

--- a/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/layer/impl/GridLayerRedrawManagerTest.java
+++ b/uberfire-extensions/uberfire-wires/uberfire-wires-core/uberfire-wires-core-grids/src/test/java/org/uberfire/ext/wires/core/grids/client/widget/layer/impl/GridLayerRedrawManagerTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.uberfire.ext.wires.core.grids.client.widget.layer.impl;
+
+import static org.junit.Assert.assertSame;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.uberfire.ext.wires.core.grids.client.widget.layer.impl.GridLayerRedrawManager.PrioritizedCommand;
+
+import com.ait.lienzo.test.LienzoMockitoTestRunner;
+
+@RunWith(LienzoMockitoTestRunner.class)
+public class GridLayerRedrawManagerTest {
+
+    private static class TestPrioritizedCommand extends GridLayerRedrawManager.PrioritizedCommand implements Comparable<GridLayerRedrawManager.PrioritizedCommand> {
+
+        public TestPrioritizedCommand( int priority ) {
+            super( priority );
+        }
+
+        @Override
+        public void execute() {
+        }
+
+        @Override
+        public int compareTo( PrioritizedCommand o ) {
+            throw new RuntimeException( "Should not be used as comparator is provided by GridLayerRedrawManager" );
+        }
+
+    }
+
+    @Test
+    public void comparatorUsedInsteadOfNaturalOrdering() {
+        final TestPrioritizedCommand c1 = new TestPrioritizedCommand( 1 );
+        final TestPrioritizedCommand c2 = new TestPrioritizedCommand( 2 );
+        
+        final GridLayerRedrawManager gridLayerRedrawManager = GridLayerRedrawManager.get();
+        gridLayerRedrawManager.schedule( c1 );
+        gridLayerRedrawManager.schedule( c2 );
+        
+        assertSame(c1, gridLayerRedrawManager.commands.first());
+    }
+
+}


### PR DESCRIPTION
The comparator was initialized after the singleton instance was created,
causing a null comparator to be passed to the constructor of the commands
TreeSet and hence natural ordering to be used instead which didn't work
as Commands are not Comparable.

Since this type is a singleton it shouldn't have any other static fields
than instance to guarantee that the instance is in a proper state when
created.

This also caused ClassCastExceptions with generateJsInteropExports=true.