### PR TITLE
[UF-453]: WorkspaceScoped Beans added

### DIFF
--- a/uberfire-backend/uberfire-backend-api/src/main/java/org/uberfire/backend/cdi/workspace/Workspace.java
+++ b/uberfire-backend/uberfire-backend-api/src/main/java/org/uberfire/backend/cdi/workspace/Workspace.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.backend.cdi.workspace;
+
+/**
+ * Represents a workspace. Every WorkspaceScoped bean instance has a relationship with a workspace. Workspaces right now
+ * has a one-to-one relationship with a user, so I can't exists more than a workspace per user.
+ */
+public interface Workspace {
+
+    /**
+     * Returns the workspace name. At this moment is the username.
+     * @return the workspace name.
+     */
+    String getName();
+
+}

--- a/uberfire-backend/uberfire-backend-cdi/pom.xml
+++ b/uberfire-backend/uberfire-backend-cdi/pom.xml
@@ -53,6 +53,71 @@
       <artifactId>jboss-el-api_3.0_spec</artifactId>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-preferences-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-preferences-backend</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-preferences-processors</artifactId>
+    </dependency>
+
+
+    <dependency>
+      <groupId>org.jboss.weld.se</groupId>
+      <artifactId>weld-se-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+
+    <dependency>
+      <groupId>org.jboss.arquillian.junit</groupId>
+      <artifactId>arquillian-junit-container</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jboss.arquillian.container</groupId>
+      <artifactId>arquillian-weld-se-embedded-1.1</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-nio2-jgit</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-testing-utils</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jboss.errai</groupId>
+      <artifactId>errai-cdi-jboss</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
 </project>

--- a/uberfire-backend/uberfire-backend-cdi/src/main/java/org/uberfire/backend/server/cdi/model/WorkspaceImpl.java
+++ b/uberfire-backend/uberfire-backend-cdi/src/main/java/org/uberfire/backend/server/cdi/model/WorkspaceImpl.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.backend.server.cdi.model;
+
+import org.uberfire.backend.cdi.workspace.Workspace;
+
+public class WorkspaceImpl implements Workspace {
+
+    private final String name;
+
+    public WorkspaceImpl( String name ) {
+        this.name = name;
+    }
+
+    @Override
+    public String getName() {
+        return this.name;
+    }
+
+    @Override
+    public boolean equals( final Object obj ) {
+        if ( obj instanceof WorkspaceImpl ) {
+            return this.getName() == ( (WorkspaceImpl) obj ).getName() ||
+                    this.getName().equals( ( (WorkspaceImpl) obj ).getName() );
+        } else {
+            return super.equals( obj );
+        }
+    }
+
+    @Override
+    public int hashCode() {
+        int result = name != null ? name.hashCode() : 0;
+        result = ~~result;
+        return result;
+    }
+}

--- a/uberfire-backend/uberfire-backend-cdi/src/main/java/org/uberfire/backend/server/cdi/workspace/WorkspaceManager.java
+++ b/uberfire-backend/uberfire-backend-cdi/src/main/java/org/uberfire/backend/server/cdi/workspace/WorkspaceManager.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.backend.server.cdi.workspace;
+
+import java.util.NoSuchElementException;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import javax.annotation.PostConstruct;
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.uberfire.backend.cdi.workspace.Workspace;
+import org.uberfire.backend.server.cdi.model.WorkspaceImpl;
+
+/**
+ * Contains every workspace created in the application and the beans for those workspaces.
+ * Beans are stored into a cache, with size and time expiration.
+ */
+@ApplicationScoped
+public class WorkspaceManager {
+
+    private Logger logger = LoggerFactory.getLogger( WorkspaceManager.class );
+    private WorkspaceManagerPreferences preferences;
+    private ConcurrentHashMap<Workspace, Cache<String, Object>> workspaces;
+
+    public WorkspaceManager() {
+    }
+
+    @Inject
+    public WorkspaceManager( WorkspaceManagerPreferences workspaceManagerPreferences ) {
+        this.preferences = workspaceManagerPreferences;
+    }
+
+    @PostConstruct
+    public void initialize() {
+        this.workspaces = new ConcurrentHashMap<>();
+    }
+
+    /**
+     * Returns a workspace, but if it does not exists, it creates a new one.
+     * @param name The name of the workspace.
+     * @return The existent or the new workspace.
+     */
+    public Workspace getOrCreateWorkspace( String name ) {
+        Workspace workspace = new WorkspaceImpl( name );
+        workspaces.computeIfAbsent( new WorkspaceImpl( name ), w -> this.createCache() );
+        return this.getWorkspace( name );
+    }
+
+    protected synchronized Cache<String, Object> createCache() {
+        preferences.load();
+        final Cache<String, Object> cache = CacheBuilder.newBuilder()
+                .maximumSize( preferences.getCacheMaximumSize() )
+                .expireAfterAccess( preferences.getCacheExpirationTime(), TimeUnit.valueOf( preferences.getCacheExpirationUnit() ) )
+                .removalListener( removalNotification -> {
+                    if ( logger.isDebugEnabled() ) {
+                        logger.debug( "[{},{}] {}",
+                                      removalNotification.getKey().toString(),
+                                      removalNotification.getValue().toString(),
+                                      removalNotification.getCause().toString() );
+                    }
+                } )
+                .build();
+        return cache;
+    }
+
+    /**
+     * Returns a workspace. If the workspace does ont exists it throws {@link NoSuchElementException}
+     * @param name Workspace name
+     * @return The workspace object
+     */
+    public Workspace getWorkspace( String name ) {
+        Optional<Workspace> optionalWorkspace = this.workspaces.keySet()
+                .stream()
+                .filter( w -> w.equals( new WorkspaceImpl( name ) ) )
+                .findAny();
+        return optionalWorkspace
+                .orElseThrow( () -> new NoSuchElementException( String.format( "Workspace <<%s>> not found", name ) ) );
+    }
+
+    /**
+     * Returns a bean based on a workspace and a bean name. If the bean does not exist, returns null
+     * @param workspace The workspace name.
+     * @param beanName The bean name for that workspace.
+     * @return the bean instance
+     */
+    public <T> T getBean( Workspace workspace,
+                          String beanName ) {
+        return (T) this.workspaces.get( workspace ).getIfPresent( beanName );
+    }
+
+    /**
+     * Put a bean instance into a Workspace.
+     * @param workspace The workspace to store beans
+     * @param beanName The bean name
+     * @param instance The bean instance
+     */
+    public <T> void putBean( Workspace workspace,
+                             String beanName,
+                             T instance ) {
+        try {
+            this.workspaces.get( workspace ).get( beanName, () -> instance );
+        } catch ( ExecutionException e ) {
+            logger.error( "An error ocurred trying to store bean <<{}>>", instance.getClass().getSimpleName(), e );
+        }
+    }
+
+    /**
+     * Deletes a workspace and its beans
+     * @param workspace the workspace to delete
+     */
+    public void delete( final Workspace workspace ) {
+        this.workspaces.remove( workspace );
+    }
+
+    /**
+     * Returns the workspace count
+     * @return the number of workspaces
+     */
+    public int getWorkspaceCount() {
+        return this.workspaces.size();
+    }
+
+    /**
+     * Return the beans count for a workspace
+     * @param workspace The workspace to count beans
+     * @return The number of beans for a workspace
+     */
+    public long getBeansCount( final Workspace workspace ) {
+        return this.workspaces.get( workspace ).size();
+    }
+}

--- a/uberfire-backend/uberfire-backend-cdi/src/main/java/org/uberfire/backend/server/cdi/workspace/WorkspaceManagerPreferences.java
+++ b/uberfire-backend/uberfire-backend-cdi/src/main/java/org/uberfire/backend/server/cdi/workspace/WorkspaceManagerPreferences.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.backend.server.cdi.workspace;
+
+import java.util.concurrent.TimeUnit;
+
+import org.jboss.errai.common.client.api.annotations.Portable;
+import org.uberfire.preferences.shared.annotations.Property;
+import org.uberfire.preferences.shared.annotations.WorkbenchPreference;
+import org.uberfire.preferences.shared.bean.BasePreference;
+
+@WorkbenchPreference(identifier = "WorkspaceManagerPreferences", bundleKey = "WorkspaceManagerPreferences.Label")
+@Portable
+public class WorkspaceManagerPreferences implements BasePreference<WorkspaceManagerPreferences> {
+
+    @Property(bundleKey = "WorkspaceManagerPreferences.CacheMaximumSize")
+    private int cacheMaximumSize;
+
+    @Property(bundleKey = "WorkspaceManagerPreferences.CacheExpirationTime")
+    private int cacheExpirationTime;
+
+    @Property(bundleKey = "WorkspaceManagerPreferences.CacheExpirationUnit")
+    private String cacheExpirationUnit;
+
+    @Override
+    public WorkspaceManagerPreferences defaultValue( final WorkspaceManagerPreferences defaultValue ) {
+        defaultValue.cacheMaximumSize = 10;
+        defaultValue.cacheExpirationTime = 10;
+        defaultValue.cacheExpirationUnit = TimeUnit.MINUTES.toString();
+        return defaultValue;
+    }
+
+    public int getCacheMaximumSize() {
+        return cacheMaximumSize;
+    }
+
+    public void setCacheMaximumSize( final int cacheMaximumSize ) {
+        this.cacheMaximumSize = cacheMaximumSize;
+    }
+
+    public int getCacheExpirationTime() {
+        return cacheExpirationTime;
+    }
+
+    public void setCacheExpirationTime( final int cacheExpirationTime ) {
+        this.cacheExpirationTime = cacheExpirationTime;
+    }
+
+    public String getCacheExpirationUnit() {
+        return this.cacheExpirationUnit;
+    }
+
+    public void setCacheExpirationUnit( final String cacheExpirationUnit ) {
+        this.cacheExpirationUnit = cacheExpirationUnit;
+    }
+}

--- a/uberfire-backend/uberfire-backend-cdi/src/main/java/org/uberfire/backend/server/cdi/workspace/WorkspaceScopeContext.java
+++ b/uberfire-backend/uberfire-backend-cdi/src/main/java/org/uberfire/backend/server/cdi/workspace/WorkspaceScopeContext.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.backend.server.cdi.workspace;
+
+import java.lang.annotation.Annotation;
+import java.util.NoSuchElementException;
+import javax.enterprise.context.spi.Context;
+import javax.enterprise.context.spi.Contextual;
+import javax.enterprise.context.spi.CreationalContext;
+import javax.enterprise.inject.spi.Bean;
+import javax.enterprise.inject.spi.BeanManager;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.uberfire.backend.cdi.workspace.Workspace;
+import org.uberfire.rpc.SessionInfo;
+
+/**
+ * Workspace context.
+ * Uses {@link WorkspaceManager} to create beans. Those beans must be annotated with
+ * {@link WorkspaceScoped} annotation. Every bean has only one instance per workspace.
+ */
+public class WorkspaceScopeContext implements Context {
+
+    private static Logger logger = LoggerFactory.getLogger( WorkspaceScopeContext.class );
+    private final BeanManager beanManager;
+
+    public WorkspaceScopeContext( BeanManager beanManager ) {
+        this.beanManager = beanManager;
+    }
+
+    @Override
+    public Class<? extends Annotation> getScope() {
+        return WorkspaceScoped.class;
+    }
+
+    @Override
+    public <T> T get( final Contextual<T> contextual,
+                      final CreationalContext<T> creationalContext ) {
+
+        Bean<T> bean = getBean( contextual );
+        Workspace workspace = this.getWorkspaceManager().getOrCreateWorkspace( getWorkspaceName() );
+        final T instance = getWorkspaceManager().getBean( workspace, bean.getBeanClass().getSimpleName() );
+
+        if ( instance == null ) {
+            if ( logger.isDebugEnabled() ) {
+                logger.debug( "Creating Bean <<{}>> with creational context for workspace <<{}>>", bean.getBeanClass(), workspace.getName() );
+            }
+            final T created = bean.create( creationalContext );
+            this.getWorkspaceManager().putBean( workspace, bean.getBeanClass().getSimpleName(), created );
+            return created;
+        } else {
+            if ( logger.isDebugEnabled() ) {
+                logger.debug( "Bean <<{}>> found for workspace <<{}>>", bean.getBeanClass(), workspace.getName() );
+            }
+            return instance;
+        }
+
+    }
+
+    @Override
+    public <T> T get( final Contextual<T> contextual ) {
+        Bean<T> bean = getBean( contextual );
+        Workspace workspace = this.getWorkspaceManager().getOrCreateWorkspace( getWorkspaceName() );
+        if ( logger.isDebugEnabled() ) {
+            logger.debug( "Getting Bean <<{}>> for workspace <<{}>>", bean.getBeanClass(), workspace.getName() );
+        }
+        return this.getWorkspaceManager().getBean( workspace, bean.getBeanClass().toString() );
+    }
+
+    private String getWorkspaceName() {
+        try {
+            return this.getSessionInfo().getIdentity().getIdentifier();
+        } catch ( NoSuchElementException e ) {
+            return "default";
+        }
+    }
+
+    @Override
+    public boolean isActive() {
+        return true;
+    }
+
+    private <T> Bean<T> getBean( final Contextual contextual ) {
+        return (Bean<T>) contextual;
+
+    }
+
+    protected SessionInfo getSessionInfo() {
+        final Bean<SessionInfo> bean = (Bean<SessionInfo>) this.beanManager.getBeans( SessionInfo.class ).iterator().next();
+        final CreationalContext<SessionInfo> creationalContext = this.beanManager.createCreationalContext( bean );
+        return (SessionInfo) this.beanManager.getReference( bean, SessionInfo.class, creationalContext );
+    }
+
+    protected WorkspaceManager getWorkspaceManager() {
+        final Bean<WorkspaceManager> bean = (Bean<WorkspaceManager>) this.beanManager.getBeans( WorkspaceManager.class ).iterator().next();
+        final CreationalContext<WorkspaceManager> creationalContext = this.beanManager.createCreationalContext( bean );
+        return (WorkspaceManager) this.beanManager.getReference( bean, WorkspaceManager.class, creationalContext );
+    }
+}

--- a/uberfire-backend/uberfire-backend-cdi/src/main/java/org/uberfire/backend/server/cdi/workspace/WorkspaceScoped.java
+++ b/uberfire-backend/uberfire-backend-cdi/src/main/java/org/uberfire/backend/server/cdi/workspace/WorkspaceScoped.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.backend.server.cdi.workspace;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import javax.enterprise.context.NormalScope;
+import javax.interceptor.InterceptorBinding;
+
+/**
+ * Like @ApplicationScoped, this bean is going to have a single instance but
+ * instead of living for the duration of the application it lives for the duration of the workspace and its cache.
+ * So you can have two instances of the same bean in different workspaces at the same time. This bean is going to expire
+ * depending on cache configuration. Check {@link WorkspaceManager}.
+ */
+@Documented
+@NormalScope
+@InterceptorBinding
+@Inherited
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.TYPE })
+public @interface WorkspaceScoped {
+
+}

--- a/uberfire-backend/uberfire-backend-cdi/src/main/java/org/uberfire/backend/server/cdi/workspace/WorkspaceScopedExtension.java
+++ b/uberfire-backend/uberfire-backend-cdi/src/main/java/org/uberfire/backend/server/cdi/workspace/WorkspaceScopedExtension.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.backend.server.cdi.workspace;
+
+import javax.enterprise.event.Observes;
+import javax.enterprise.inject.spi.AfterBeanDiscovery;
+import javax.enterprise.inject.spi.BeanManager;
+import javax.enterprise.inject.spi.BeforeBeanDiscovery;
+import javax.enterprise.inject.spi.Extension;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Workspace Scoped CDI Extension to add WorkspaceScoped behavior into Uberfire
+ */
+public class WorkspaceScopedExtension implements Extension {
+
+    private Logger logger = LoggerFactory.getLogger( WorkspaceScopedExtension.class );
+
+    public void beforeBeanDiscovery( @Observes BeforeBeanDiscovery bbd ) {
+        if ( logger.isDebugEnabled() ) {
+            logger.debug( "Before bean discovery, adding WosrkspaceScoped" );
+        }
+        bbd.addScope( WorkspaceScoped.class, true, false );
+    }
+
+    public void afterBeanDiscovery( @Observes AfterBeanDiscovery abd,
+                                    BeanManager beanManager ) {
+        if ( logger.isDebugEnabled() ) {
+            logger.debug( "After bean discovery, adding WorkspaceScopeContext" );
+        }
+        abd.addContext( new WorkspaceScopeContext( beanManager ) );
+    }
+
+}

--- a/uberfire-backend/uberfire-backend-cdi/src/main/resources/ErraiApp.properties
+++ b/uberfire-backend/uberfire-backend-cdi/src/main/resources/ErraiApp.properties
@@ -1,0 +1,17 @@
+#
+# Copyright 2017 Red Hat, Inc. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+

--- a/uberfire-backend/uberfire-backend-cdi/src/main/resources/META-INF/beans.xml
+++ b/uberfire-backend/uberfire-backend-cdi/src/main/resources/META-INF/beans.xml
@@ -1,0 +1,21 @@
+<!--
+  ~ Copyright 2014 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~       http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/beans_1_2.xsd"
+       bean-discovery-mode="all">
+</beans>

--- a/uberfire-backend/uberfire-backend-cdi/src/main/resources/META-INF/services/javax.enterprise.inject.spi.Extension
+++ b/uberfire-backend/uberfire-backend-cdi/src/main/resources/META-INF/services/javax.enterprise.inject.spi.Extension
@@ -1,1 +1,2 @@
 org.uberfire.backend.server.cdi.SystemConfigProducer
+org.uberfire.backend.server.cdi.workspace.WorkspaceScopedExtension

--- a/uberfire-backend/uberfire-backend-cdi/src/test/java/org/uberfire/backend/server/cdi/SessionBasedBean.java
+++ b/uberfire-backend/uberfire-backend-cdi/src/test/java/org/uberfire/backend/server/cdi/SessionBasedBean.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.backend.server.cdi;
+
+import java.io.Serializable;
+import javax.ejb.Stateless;
+import javax.inject.Inject;
+
+@Stateless
+public class SessionBasedBean implements Serializable {
+
+    @Inject
+    private WorkspaceBuilderService service;
+
+    public void build( String gav ) {
+        service.build( gav );
+    }
+
+}

--- a/uberfire-backend/uberfire-backend-cdi/src/test/java/org/uberfire/backend/server/cdi/WorkspaceBuilderService.java
+++ b/uberfire-backend/uberfire-backend-cdi/src/test/java/org/uberfire/backend/server/cdi/WorkspaceBuilderService.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.backend.server.cdi;
+
+import java.io.Serializable;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.uberfire.backend.server.cdi.workspace.WorkspaceScoped;
+
+/**
+ * Just for testing purposes
+ */
+@WorkspaceScoped
+public class WorkspaceBuilderService implements Serializable {
+
+    private Logger logger = LoggerFactory.getLogger( WorkspaceBuilderService.class );
+
+    public void build( String gav ) {
+        try {
+            logger.info( "Building {} ...", gav );
+            Thread.currentThread().sleep( 5000l );
+            logger.info( "Building finished {}", gav );
+        } catch ( InterruptedException e ) {
+            e.printStackTrace();
+        }
+
+    }
+
+}

--- a/uberfire-backend/uberfire-backend-cdi/src/test/java/org/uberfire/backend/server/cdi/WorkspaceBuilderServiceTest.java
+++ b/uberfire-backend/uberfire-backend-cdi/src/test/java/org/uberfire/backend/server/cdi/WorkspaceBuilderServiceTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.backend.server.cdi;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import javax.enterprise.inject.Produces;
+import javax.enterprise.inject.spi.Extension;
+import javax.enterprise.inject.spi.InjectionPoint;
+import javax.inject.Inject;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.errai.security.shared.api.identity.UserImpl;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.uberfire.backend.server.cdi.model.WorkspaceImpl;
+import org.uberfire.backend.server.cdi.workspace.WorkspaceManager;
+import org.uberfire.backend.server.cdi.workspace.WorkspaceScopedExtension;
+import org.uberfire.java.nio.fs.jgit.JGitFileSystemProvider;
+import org.uberfire.rpc.SessionInfo;
+import org.uberfire.rpc.impl.SessionInfoImpl;
+
+import static org.junit.Assert.*;
+
+@RunWith(Arquillian.class)
+public class WorkspaceBuilderServiceTest {
+
+    @Deployment
+    public static JavaArchive createDeployment() {
+
+        System.setProperty( "errai.marshalling.force_static_marshallers", Boolean.toString( true ) );
+
+        return ShrinkWrap.create( JavaArchive.class )
+                .addPackages( true, "org.uberfire.preferences" )
+                .addPackages( true, "org.uberfire.mvp" )
+                .addPackages( true, "org.uberfire.commons" )
+                .addPackages( true, "org.uberfire.backend.java" )
+                .addPackages( true, "org.uberfire.backend.server.cdi" )
+                .addPackages( true, "org.uberfire.backend.server.cluster" )
+                .addPackages( true, "org.uberfire.backend.server.io" )
+                .addPackages( true, "org.uberfire.java.nio.fs.jgit" )
+                .addClass( JGitFileSystemProvider.class )
+                .addAsManifestResource( EmptyAsset.INSTANCE, "beans.xml" )
+                .addAsResource( "ErraiApp.properties", "ErraiApp.properties" )
+                .addAsManifestResource( "META-INF/services/org.uberfire.java.nio.file.spi.FileSystemProvider", "services/org.uberfire.java.nio.file.spi.FileSystemProvider" )
+                .addAsServiceProvider( Extension.class, WorkspaceScopedExtension.class );
+    }
+
+    @Inject
+    private WorkspaceManager workspaceManager;
+
+    @Inject
+    SessionBasedBean bean;
+
+    @Produces
+    protected SessionInfo createSessionInfo( InjectionPoint injectionPoint ) {
+        return new SessionInfoImpl( new UserImpl( Thread.currentThread().getName() ) );
+    }
+
+    @BeforeClass
+    public static void setUp() {
+
+    }
+
+    @Test
+    public void testConcurrentWorkspaceBeans() {
+
+        String THREAD_NAME_2 = "ray vaughan";
+        String THREAD_NAME_1 = "hendrix";
+
+        CountDownLatch latch = new CountDownLatch( 2 );
+
+        Thread thread1 = createThread( bean, "a:b:c", latch );
+        Thread thread2 = createThread( bean, "d:e:f", latch );
+
+        thread1.setName( THREAD_NAME_1 );
+        thread2.setName( THREAD_NAME_2 );
+        thread1.start();
+        thread2.start();
+
+        try {
+            latch.await( 7000, TimeUnit.SECONDS );
+            final WorkspaceImpl workspace1 = (WorkspaceImpl) workspaceManager.getWorkspace( THREAD_NAME_1 );
+            assertEquals( 1, workspaceManager.getBeansCount( workspace1 ) );
+
+            final WorkspaceImpl workspace2 = (WorkspaceImpl) workspaceManager.getWorkspace( THREAD_NAME_2 );
+            assertEquals( 1, workspaceManager.getBeansCount( workspace2 ) );
+
+            assertEquals( 2, workspaceManager.getWorkspaceCount() );
+        } catch ( InterruptedException e ) {
+            fail();
+        }
+    }
+
+    private Thread createThread( final SessionBasedBean bean,
+                                 final String gav,
+                                 final CountDownLatch latch ) {
+        return new Thread( () -> {
+            bean.build( gav );
+            latch.countDown();
+        } );
+    }
+
+}

--- a/uberfire-backend/uberfire-backend-cdi/src/test/java/org/uberfire/backend/server/cdi/workspace/WorkspaceManagerTest.java
+++ b/uberfire-backend/uberfire-backend-cdi/src/test/java/org/uberfire/backend/server/cdi/workspace/WorkspaceManagerTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.uberfire.backend.server.cdi.workspace;
+
+import java.util.NoSuchElementException;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.uberfire.backend.cdi.workspace.Workspace;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class WorkspaceManagerTest {
+
+    @Mock
+    private WorkspaceManagerPreferences preferences;
+
+    private WorkspaceManager workspaceManager;
+
+    @Before
+    public void setUp() {
+        when( preferences.getCacheExpirationTime() ).thenReturn( 10 );
+        when( preferences.getCacheExpirationUnit() ).thenReturn( "MINUTES" );
+        when( preferences.getCacheMaximumSize() ).thenReturn( 3 );
+
+        this.workspaceManager = new WorkspaceManager( preferences );
+        this.workspaceManager.initialize();
+    }
+
+    @Test(expected = NoSuchElementException.class)
+    public void testWorkspaceNotFound() {
+        this.workspaceManager.getWorkspace( "none" );
+    }
+
+    @Test
+    public void testCreateWorkspace() {
+        final Workspace workspace = this.workspaceManager.getOrCreateWorkspace( "hendrix" );
+        assertEquals( "hendrix", workspace.getName() );
+    }
+
+    @Test
+    public void testWorkspaceCount() {
+        this.workspaceManager.getOrCreateWorkspace( "hendrix" );
+        assertEquals( 1, this.workspaceManager.getWorkspaceCount() );
+    }
+
+    @Test
+    public void testDeleteWorkspace() {
+        final Workspace workspace = this.workspaceManager.getOrCreateWorkspace( "hendrix" );
+        assertEquals( 1, this.workspaceManager.getWorkspaceCount() );
+        this.workspaceManager.delete( workspace );
+        assertEquals( 0, this.workspaceManager.getWorkspaceCount() );
+    }
+
+    @Test
+    public void testStoreBeansWithCacheSizeEviction() {
+        final Workspace workspace = this.workspaceManager.getOrCreateWorkspace( "hendrix" );
+
+        this.workspaceManager.putBean( workspace, "a", new Object() );
+        this.workspaceManager.putBean( workspace, "b", new Object() );
+        this.workspaceManager.putBean( workspace, "c", new Object() );
+        this.workspaceManager.putBean( workspace, "d", new Object() );
+        this.workspaceManager.putBean( workspace, "e", new Object() );
+
+        assertEquals( 3, this.workspaceManager.getBeansCount( workspace ) );
+    }
+
+    @Test
+    public void testGetBeanDoesNotExists() {
+        final Workspace workspace = this.workspaceManager.getOrCreateWorkspace( "hendrix" );
+        assertNull( this.workspaceManager.getBean( workspace, "a" ) );
+    }
+
+}

--- a/uberfire-backend/uberfire-backend-cdi/src/test/resources/ErraiApp.properties
+++ b/uberfire-backend/uberfire-backend-cdi/src/test/resources/ErraiApp.properties
@@ -1,0 +1,17 @@
+#
+# Copyright 2017 Red Hat, Inc. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+

--- a/uberfire-backend/uberfire-backend-cdi/src/test/resources/META-INF/services/org.uberfire.java.nio.file.spi.FileSystemProvider
+++ b/uberfire-backend/uberfire-backend-cdi/src/test/resources/META-INF/services/org.uberfire.java.nio.file.spi.FileSystemProvider
@@ -1,0 +1,18 @@
+#
+# Copyright 2017 Red Hat, Inc. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+org.uberfire.java.nio.fs.jgit.JGitFileSystemProvider
+org.uberfire.java.nio.fs.file.SimpleFileSystemProvider

--- a/uberfire-backend/uberfire-backend-cdi/src/test/resources/logback.xml
+++ b/uberfire-backend/uberfire-backend-cdi/src/test/resources/logback.xml
@@ -1,0 +1,13 @@
+<configuration>
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <logger name="org.uberfire.backend.server.cdi" level="DEBUG"/>
+
+  <root level="INFO">
+    <appender-ref ref="STDOUT"/>
+  </root>
+</configuration>


### PR DESCRIPTION
_NOTE: I don't know if the files from the beginning should be there, so please let me know._

The Idea is to have a CDI Annotation to replace the @ApplicationScoped with it. This annotations lets a bean enter a Workspace context, so those beans have a single instance per workspace. Right now there is only one workspace per user, but that is going to change in the future.
