### PR TITLE
Breadcrumbs, PlaceManager and ListBar improvements

### DIFF
--- a/uberfire-api/src/main/java/org/uberfire/mvp/impl/ConditionalPlaceRequest.java
+++ b/uberfire-api/src/main/java/org/uberfire/mvp/impl/ConditionalPlaceRequest.java
@@ -79,7 +79,7 @@ public class ConditionalPlaceRequest extends DefaultPlaceRequest {
         if ( invalidConditionalPlaceRequest() ) {
             return this;
         }
-        if ( predicate.test( this ) ) {
+        if ( predicate == null || predicate.test( this ) ) {
             return this;
         } else {
             return resolve();
@@ -104,7 +104,7 @@ public class ConditionalPlaceRequest extends DefaultPlaceRequest {
             return identifier;
         }
 
-        if ( predicate.test( this ) ) {
+        if ( predicate == null || predicate.test( this ) ) {
             return identifier;
         } else {
             return resolve().getIdentifier();
@@ -117,7 +117,7 @@ public class ConditionalPlaceRequest extends DefaultPlaceRequest {
             return parameters;
         }
 
-        if ( predicate.test( this ) ) {
+        if ( predicate == null || predicate.test( this ) ) {
             return parameters;
         } else {
             return resolve().getParameters();
@@ -158,7 +158,7 @@ public class ConditionalPlaceRequest extends DefaultPlaceRequest {
             return super.equals( that );
         }
 
-        if ( predicate.test( this ) ) {
+        if ( predicate == null || predicate.test( this ) ) {
             return super.equals( that );
         } else {
             return resolve().equals( that );
@@ -171,7 +171,7 @@ public class ConditionalPlaceRequest extends DefaultPlaceRequest {
             return super.hashCode();
         }
 
-        if ( predicate.test( this ) ) {
+        if ( predicate == null || predicate.test( this ) ) {
             return super.hashCode();
         } else {
             return resolve().hashCode();
@@ -180,10 +180,10 @@ public class ConditionalPlaceRequest extends DefaultPlaceRequest {
 
     @Override
     public String toString() {
-        return "ConditionalPlaceRequest[" +
-                super.toString() +
-                ", orElsePlaceRequest=" + orElsePlaceRequest +
-                ", predicate=" + predicate +
-                ']';
+        if ( predicate == null || predicate.test( this ) ) {
+            return super.toString();
+        } else {
+            return resolve().toString();
+        }
     }
 }

--- a/uberfire-api/src/main/java/org/uberfire/mvp/impl/DefaultPlaceRequest.java
+++ b/uberfire-api/src/main/java/org/uberfire/mvp/impl/DefaultPlaceRequest.java
@@ -246,6 +246,7 @@ public class DefaultPlaceRequest implements PlaceRequest {
     @Override
     public int hashCode() {
         int result = identifier.hashCode();
+        result = ~~result;
         result = 31 * result + parameters.hashCode();
         result = ~~result;
         return result;

--- a/uberfire-api/src/main/java/org/uberfire/mvp/impl/PathPlaceRequest.java
+++ b/uberfire-api/src/main/java/org/uberfire/mvp/impl/PathPlaceRequest.java
@@ -104,11 +104,11 @@ public class PathPlaceRequest extends DefaultPlaceRequest {
     }
 
     @Override
-    public boolean equals( Object o ) {
+    public boolean equals( final Object o ) {
         if ( this == o ) {
             return true;
         }
-        if ( o == null || getClass() != o.getClass() ) {
+        if ( !( o instanceof PathPlaceRequest ) ) {
             return false;
         }
         if ( !super.equals( o ) ) {
@@ -117,17 +117,19 @@ public class PathPlaceRequest extends DefaultPlaceRequest {
 
         final PathPlaceRequest that = (PathPlaceRequest) o;
 
-        return getPath().equals( that.getPath() );
+        return !( getPath() != null ? !getPath().equals( that.getPath() ) : that.getPath() != null );
+
     }
 
     @Override
     public int hashCode() {
         int result = super.hashCode();
-        result = 31 * result + ((getPath() != null) ? getPath().hashCode() : 0);
+        result = ~~result;
+        result = 31 * result + ( getPath() != null ? getPath().hashCode() : 0 );
         result = ~~result;
         return result;
     }
-    
+
     @Override
     public String toString() {
         return "PathPlaceRequest[\"" + identifier + "\" " + parameters + "\" " + path + "]";

--- a/uberfire-api/src/main/java/org/uberfire/util/URIUtil.java
+++ b/uberfire-api/src/main/java/org/uberfire/util/URIUtil.java
@@ -18,6 +18,7 @@ package org.uberfire.util;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URI;
+import java.net.URLDecoder;
 import java.net.URLEncoder;
 
 /**
@@ -31,6 +32,14 @@ public final class URIUtil {
     public static String encode( final String content ) {
         try {
             return URLEncoder.encode( content, "UTF-8" );
+        } catch ( UnsupportedEncodingException e ) {
+        }
+        return null;
+    }
+
+    public static String decode( final String content ) {
+        try {
+            return URLDecoder.decode( content, "UTF-8" );
         } catch ( UnsupportedEncodingException e ) {
         }
         return null;

--- a/uberfire-api/src/main/java/org/uberfire/workbench/model/PartDefinition.java
+++ b/uberfire-api/src/main/java/org/uberfire/workbench/model/PartDefinition.java
@@ -49,4 +49,7 @@ public interface PartDefinition {
     default String asString() {
         return this.toString();
     }
+
+    boolean isSelectable();
+    void setSelectable( boolean selectable );
 }

--- a/uberfire-api/src/main/java/org/uberfire/workbench/model/impl/PartDefinitionImpl.java
+++ b/uberfire-api/src/main/java/org/uberfire/workbench/model/impl/PartDefinitionImpl.java
@@ -39,6 +39,8 @@ PartDefinition {
     private ContextDefinition contextDefinition;
     private ContextDisplayMode contextDisplayMode = SHOW;
 
+    private boolean selectable = true;
+
     public PartDefinitionImpl() {
     }
 
@@ -99,6 +101,16 @@ PartDefinition {
     @Override
     public void setContextDisplayMode( final ContextDisplayMode contextDisplayMode ) {
         this.contextDisplayMode = contextDisplayMode;
+    }
+
+    @Override
+    public boolean isSelectable() {
+        return this.selectable;
+    }
+
+    @Override
+    public void setSelectable( final boolean selectable ) {
+        this.selectable = selectable;
     }
 
     @Override

--- a/uberfire-api/src/main/resources/org/uberfire/jre/org/uberfire/util/URIUtil.java
+++ b/uberfire-api/src/main/resources/org/uberfire/jre/org/uberfire/util/URIUtil.java
@@ -43,6 +43,10 @@ public final class URIUtil {
         return URL.encode( content );
     }
 
+    public static String decode( String content ) {
+        return URL.decode( content );
+    }
+
     public static String encodeQueryString( String content ) {
         return URL.encodeQueryString( content );
     }

--- a/uberfire-extensions/uberfire-widgets/uberfire-widgets-commons/src/main/java/org/uberfire/ext/widgets/common/client/breadcrumbs/UberfireBreadcrumbs.java
+++ b/uberfire-extensions/uberfire-widgets/uberfire-widgets-commons/src/main/java/org/uberfire/ext/widgets/common/client/breadcrumbs/UberfireBreadcrumbs.java
@@ -20,7 +20,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.function.Predicate;
 import javax.enterprise.event.Observes;
 import javax.inject.Inject;
@@ -36,7 +35,7 @@ import org.uberfire.client.workbench.docks.UberfireDocksContainer;
 import org.uberfire.client.workbench.events.PerspectiveChange;
 import org.uberfire.ext.widgets.common.client.breadcrumbs.widget.BreadcrumbsPresenter;
 import org.uberfire.mvp.Command;
-import org.uberfire.mvp.impl.DefaultPlaceRequest;
+import org.uberfire.mvp.PlaceRequest;
 
 /**
  * A container for breadcrumbs and a toolbar area.
@@ -101,16 +100,40 @@ public class UberfireBreadcrumbs {
         uberfireDocksContainer.addBreadcrumbs( getView(), SIZE );
     }
 
+    /**
+     * Clears the breadcrumbs associated with a perspective.
+     *
+     * @param associatedPerspective perspective associated with the breadcrumb
+     */
+    public void clearBreadCrumbs( final String associatedPerspective ) {
+        breadcrumbsPerPerspective.put( associatedPerspective, new ArrayList<>() );
+    }
 
     /**
-     * Clear the breadcrumbs and toolbars
-     * associated with a perspective.
+     * Clears the breadcrumbs and toolbars associated with a perspective.
      *
      * @param associatedPerspective perspective associated with the breadcrumb
      */
     public void clearBreadCrumbsAndToolBars( final String associatedPerspective ) {
         breadcrumbsPerPerspective.put( associatedPerspective, new ArrayList<>() );
         breadcrumbsToolBarPerPerspective.remove( associatedPerspective );
+    }
+
+    /**
+     * Creates a breadcrumb associated with a perspective.
+     *
+     * @param associatedPerspective  perspective associated with the breadcrumb
+     * @param breadCrumbLabel        label of the breadcrumb
+     * @param command                command to be executed after the associated place request is accessed
+     */
+    public void addBreadCrumb( final String associatedPerspective,
+                               final String breadCrumbLabel,
+                               final Command command ) {
+        addBreadCrumb( associatedPerspective,
+                       breadCrumbLabel,
+                       null,
+                       null,
+                       command );
     }
 
     /**
@@ -123,7 +146,7 @@ public class UberfireBreadcrumbs {
      */
     public void addBreadCrumb( final String associatedPerspective,
                                final String breadCrumbLabel,
-                               final DefaultPlaceRequest associatedPlaceRequest ) {
+                               final PlaceRequest associatedPlaceRequest ) {
         addBreadCrumb( associatedPerspective,
                        breadCrumbLabel,
                        associatedPlaceRequest,
@@ -142,7 +165,7 @@ public class UberfireBreadcrumbs {
      */
     public void addBreadCrumb( final String associatedPerspective,
                                final String breadCrumbLabel,
-                               final DefaultPlaceRequest associatedPlaceRequest,
+                               final PlaceRequest associatedPlaceRequest,
                                final HasWidgets addTo ) {
         addBreadCrumb( associatedPerspective,
                        breadCrumbLabel,
@@ -162,7 +185,7 @@ public class UberfireBreadcrumbs {
      */
     public void addBreadCrumb( final String associatedPerspective,
                                final String breadCrumbLabel,
-                               final DefaultPlaceRequest associatedPlaceRequest,
+                               final PlaceRequest associatedPlaceRequest,
                                final Command command ) {
         addBreadCrumb( associatedPerspective,
                        breadCrumbLabel,
@@ -183,7 +206,7 @@ public class UberfireBreadcrumbs {
      */
     public void addBreadCrumb( final String associatedPerspective,
                                final String breadCrumbLabel,
-                               final DefaultPlaceRequest associatedPlaceRequest,
+                               final PlaceRequest associatedPlaceRequest,
                                final HasWidgets addTo,
                                final Command command ) {
         List<BreadcrumbsPresenter> breadCrumbs = getBreadcrumbs( associatedPerspective );
@@ -196,9 +219,8 @@ public class UberfireBreadcrumbs {
     }
 
     /**
-     * Add a toolbar to a a perspective.
-     * Toolbar is placed in the right side of
-     * breadcrumbs area.
+     * Adds a toolbar to a perspective.
+     * Toolbar is placed in the right side of the breadcrumbs area.
      *
      * @param associatedPerspective perspective associated with the toolbar
      * @param toolbar               toolbar that will be added
@@ -227,7 +249,7 @@ public class UberfireBreadcrumbs {
 
     private BreadcrumbsPresenter createBreadCrumb( final String perspective,
                                                    final String label,
-                                                   final DefaultPlaceRequest placeRequest,
+                                                   final PlaceRequest placeRequest,
                                                    final HasWidgets addTo,
                                                    final Command command ) {
 
@@ -241,13 +263,15 @@ public class UberfireBreadcrumbs {
 
     Command generateBreadCrumbSelectCommand( final String perspective,
                                              final BreadcrumbsPresenter breadCrumb,
-                                             final DefaultPlaceRequest placeRequest,
+                                             final PlaceRequest placeRequest,
                                              final HasWidgets addTo,
                                              final Command command ) {
         return () -> {
             removeDeepLevelBreadcrumbs( perspective, breadCrumb );
             breadCrumb.activate();
-            goToBreadCrumb( placeRequest, addTo );
+            if ( placeRequest != null ) {
+                goToBreadCrumb( placeRequest, addTo );
+            }
             updateView();
             if ( command != null ) {
                 command.execute();
@@ -255,7 +279,7 @@ public class UberfireBreadcrumbs {
         };
     }
 
-    private void goToBreadCrumb( final DefaultPlaceRequest placeRequest,
+    private void goToBreadCrumb( final PlaceRequest placeRequest,
                                  final HasWidgets addTo ) {
         if ( addTo != null ) {
             placeManager.goTo( placeRequest, addTo );

--- a/uberfire-extensions/uberfire-widgets/uberfire-widgets-commons/src/main/java/org/uberfire/ext/widgets/common/client/breadcrumbs/widget/BreadcrumbsPresenter.java
+++ b/uberfire-extensions/uberfire-widgets/uberfire-widgets-commons/src/main/java/org/uberfire/ext/widgets/common/client/breadcrumbs/widget/BreadcrumbsPresenter.java
@@ -15,17 +15,17 @@
  */
 package org.uberfire.ext.widgets.common.client.breadcrumbs.widget;
 
-import org.uberfire.client.mvp.UberElement;
-import org.uberfire.mvp.Command;
-import org.uberfire.mvp.impl.DefaultPlaceRequest;
-
 import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
+
+import org.uberfire.client.mvp.UberElement;
+import org.uberfire.mvp.Command;
+import org.uberfire.mvp.PlaceRequest;
 
 @Dependent
 public class BreadcrumbsPresenter {
 
-    private DefaultPlaceRequest placeRequest;
+    private PlaceRequest placeRequest;
 
     public interface View extends UberElement<BreadcrumbsPresenter> {
 
@@ -51,12 +51,14 @@ public class BreadcrumbsPresenter {
         view.deactivate();
     }
 
-    public void setup( String label, DefaultPlaceRequest placeRequest, Command selectCommand ) {
+    public void setup( final String label,
+                       final PlaceRequest placeRequest,
+                       final Command selectCommand ) {
         this.placeRequest = placeRequest;
         view.setup( label, selectCommand );
     }
 
-    public DefaultPlaceRequest getPlaceRequest() {
+    public PlaceRequest getPlaceRequest() {
         return placeRequest;
     }
 

--- a/uberfire-extensions/uberfire-widgets/uberfire-widgets-commons/src/main/java/org/uberfire/ext/widgets/common/client/breadcrumbs/widget/BreadcrumbsView.css
+++ b/uberfire-extensions/uberfire-widgets/uberfire-widgets-commons/src/main/java/org/uberfire/ext/widgets/common/client/breadcrumbs/widget/BreadcrumbsView.css
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+.breadcrumb {
+    cursor: pointer;
+}

--- a/uberfire-extensions/uberfire-widgets/uberfire-widgets-commons/src/main/java/org/uberfire/ext/widgets/common/client/breadcrumbs/widget/BreadcrumbsView.html
+++ b/uberfire-extensions/uberfire-widgets/uberfire-widgets-commons/src/main/java/org/uberfire/ext/widgets/common/client/breadcrumbs/widget/BreadcrumbsView.html
@@ -15,7 +15,7 @@
   -->
 
 <li>
-    <a data-field="breadcrumb">
+    <a class="breadcrumb" data-field="breadcrumb">
 
     </a>
 </li>

--- a/uberfire-extensions/uberfire-widgets/uberfire-widgets-commons/src/test/java/org/uberfire/ext/widgets/common/client/breadcrumbs/UberfireBreadcrumbsTest.java
+++ b/uberfire-extensions/uberfire-widgets/uberfire-widgets-commons/src/test/java/org/uberfire/ext/widgets/common/client/breadcrumbs/UberfireBreadcrumbsTest.java
@@ -104,10 +104,23 @@ public class UberfireBreadcrumbsTest {
         assertEquals( 2, uberfireBreadcrumbs.breadcrumbsPerPerspective.get( "myperspective" ).size() );
     }
 
+    @Test
+    public void clearBreadCrumbsTest() {
+        uberfireBreadcrumbs.currentPerspective = "myperspective";
+        uberfireBreadcrumbs.addToolbar( "myperspective", mock( Element.class ) );
+        uberfireBreadcrumbs.addBreadCrumb( "myperspective", "label", new DefaultPlaceRequest( "screen" ) );
+
+        assertFalse( uberfireBreadcrumbs.breadcrumbsPerPerspective.get( "myperspective" ).isEmpty() );
+        assertFalse( uberfireBreadcrumbs.breadcrumbsToolBarPerPerspective.isEmpty() );
+
+        uberfireBreadcrumbs.clearBreadCrumbs( "myperspective" );
+
+        assertTrue( uberfireBreadcrumbs.breadcrumbsPerPerspective.get( "myperspective" ).isEmpty() );
+        assertFalse( uberfireBreadcrumbs.breadcrumbsToolBarPerPerspective.isEmpty() );
+    }
 
     @Test
-    public void clearBreadCrumbs() {
-
+    public void clearBreadCrumbsAndToolBarsTest() {
         uberfireBreadcrumbs.currentPerspective = "myperspective";
         uberfireBreadcrumbs.addToolbar( "myperspective", mock( Element.class ) );
         uberfireBreadcrumbs.addBreadCrumb( "myperspective", "label", new DefaultPlaceRequest( "screen" ) );
@@ -119,7 +132,6 @@ public class UberfireBreadcrumbsTest {
 
         assertTrue( uberfireBreadcrumbs.breadcrumbsPerPerspective.get( "myperspective" ).isEmpty() );
         assertTrue( uberfireBreadcrumbs.breadcrumbsToolBarPerPerspective.isEmpty() );
-
     }
 
     @Test
@@ -198,6 +210,13 @@ public class UberfireBreadcrumbsTest {
 
         verify( view, times( 2 ) ).addBreadcrumb( any( UberElement.class ) );
         verify( view, times( 1 ) ).addBreadcrumbToolbar( any( Element.class ) );
+    }
+
+    @Test
+    public void addBreadcrumbAssociatedWithACommandTest() {
+        final Command command = mock( Command.class );
+        uberfireBreadcrumbs.addBreadCrumb( "myperspective", "label", command );
+        verify( uberfireBreadcrumbs ).addBreadCrumb( "myperspective", "label", null, null, command );
     }
 
     @Test

--- a/uberfire-workbench/uberfire-workbench-client-views-patternfly/pom.xml
+++ b/uberfire-workbench/uberfire-workbench-client-views-patternfly/pom.xml
@@ -188,24 +188,6 @@
             </configuration>
           </execution>
           <execution>
-            <id>copy-patternfly-less-resources</id>
-            <phase>process-resources</phase>
-            <goals>
-              <goal>copy-resources</goal>
-            </goals>
-            <configuration>
-              <outputDirectory>${project.build.outputDirectory}/org/uberfire/client/views/static/patternfly/less</outputDirectory>
-              <resources>
-                <resource>
-                  <directory>${project.build.directory}/patternfly/META-INF/resources/webjars/patternfly/${version.org.webjars.bower.org.patternfly}/less</directory>
-                  <includes>
-                    <include>**</include>
-                  </includes>
-                </resource>
-              </resources>
-            </configuration>
-          </execution>
-          <execution>
             <id>copy-prettify-resources</id>
             <phase>process-resources</phase>
             <goals>

--- a/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/main/java/org/uberfire/client/views/pfly/listbar/ListBarWidgetImpl.java
+++ b/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/main/java/org/uberfire/client/views/pfly/listbar/ListBarWidgetImpl.java
@@ -75,9 +75,8 @@ import org.uberfire.workbench.model.menu.MenuItem;
 import org.uberfire.workbench.model.menu.MenuItemCommand;
 import org.uberfire.workbench.model.menu.impl.BaseMenuVisitor;
 
-import static com.google.gwt.dom.client.Style.Display.BLOCK;
-import static com.google.gwt.dom.client.Style.Display.NONE;
-import static org.uberfire.plugin.PluginUtil.ensureIterable;
+import static com.google.gwt.dom.client.Style.Display.*;
+import static org.uberfire.plugin.PluginUtil.*;
 
 /**
  * Implementation of ListBarWidget based on PatternFly components.
@@ -248,7 +247,9 @@ public class ListBarWidgetImpl
         // IMPORTANT! if you change what goes in this map, update the remove(PartDefinition) method
         partContentView.put( partDefinition, panel );
 
-        titleDropDown.addPart( view );
+        if ( partDefinition.isSelectable() ) {
+            titleDropDown.addPart( view );
+        }
 
         header.setVisible( true );
 
@@ -260,7 +261,9 @@ public class ListBarWidgetImpl
     public void changeTitle( final PartDefinition part,
                              final String title,
                              final IsWidget titleDecoration ) {
-        titleDropDown.changeTitle( part, title, titleDecoration );
+        if ( part.isSelectable() ) {
+            titleDropDown.changeTitle( part, title, titleDecoration );
+        }
     }
 
     @Override
@@ -283,8 +286,13 @@ public class ListBarWidgetImpl
         currentPart.getK2().getElement().getStyle().setDisplay( BLOCK );
         parts.remove( currentPart.getK1() );
 
-        titleDropDown.selectPart( part );
-        setupContextMenu();
+        if ( part.isSelectable() ) {
+            titleDropDown.selectPart( part );
+            setupContextMenu();
+            header.setVisible( true );
+        } else {
+            header.setVisible( false );
+        }
 
         scheduleResize();
 
@@ -309,8 +317,11 @@ public class ListBarWidgetImpl
 
     @Override
     public boolean remove( final PartDefinition part ) {
-        titleDropDown.removePart( part );
-        if ( currentPart.getK1().asString().equals( part.asString() ) ) {
+        if ( part.isSelectable() ) {
+            titleDropDown.removePart( part );
+        }
+
+        if ( currentPart != null && currentPart.getK1().asString().equals( part.asString() ) ) {
             if ( parts.size() > 0 ) {
                 presenter.selectPart( parts.iterator().next() );
             } else {
@@ -504,7 +515,7 @@ public class ListBarWidgetImpl
         } );
     }
 
-    private void resizePanelBody() {
+    void resizePanelBody() {
         //When an Item is added to the PanelHeader recalculate the PanelBody size.
         //This cannot be performed in either the @PostConstruct or onAttach() methods as at
         //these times the PanelHeader may not have any content and hence have no size.

--- a/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/test/java/org/uberfire/client/views/pfly/listbar/ListBarWidgetImplTest.java
+++ b/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/test/java/org/uberfire/client/views/pfly/listbar/ListBarWidgetImplTest.java
@@ -19,12 +19,15 @@ package org.uberfire.client.views.pfly.listbar;
 import java.util.List;
 
 import com.google.gwt.user.client.ui.FlowPanel;
+import com.google.gwt.user.client.ui.IsWidget;
 import com.google.gwt.user.client.ui.Widget;
 import com.google.gwtmockito.GwtMockitoTestRunner;
 import org.gwtbootstrap3.client.ui.AnchorListItem;
 import org.gwtbootstrap3.client.ui.Button;
 import org.gwtbootstrap3.client.ui.ButtonGroup;
 import org.gwtbootstrap3.client.ui.DropDownMenu;
+import org.gwtbootstrap3.client.ui.PanelBody;
+import org.gwtbootstrap3.client.ui.PanelHeader;
 import org.jboss.errai.security.shared.api.identity.User;
 import org.junit.Before;
 import org.junit.Test;
@@ -34,6 +37,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
 import org.uberfire.client.workbench.PanelManager;
+import org.uberfire.client.workbench.part.WorkbenchPartPresenter;
 import org.uberfire.commons.data.Pair;
 import org.uberfire.security.Resource;
 import org.uberfire.security.ResourceAction;
@@ -45,6 +49,7 @@ import org.uberfire.workbench.model.menu.Menus;
 
 import static org.junit.Assert.*;
 import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.anyBoolean;
 import static org.mockito.Mockito.*;
 
 @RunWith( GwtMockitoTestRunner.class )
@@ -67,29 +72,31 @@ public class ListBarWidgetImplTest {
         when(authzManager.authorize(any(Resource.class), any(ResourceAction.class), any(User.class))).thenReturn(true);
 
         doNothing().when(listBar).setupContextMenu();
+        doNothing().when( listBar ).resizePanelBody();
+
+        listBar.panelManager = mock( PanelManager.class );
+        listBar.titleDropDown = mock( PartListDropdown.class );
+        listBar.content = mock( PanelBody.class );
+        listBar.header = mock( PanelHeader.class );
     }
 
     @Test
-    public void onSelectPartOnPartHiddenEventIsFired() {
-
+    public void onSelectPartOnPartHiddenEventIsFiredTest() {
         final PartDefinition selectedPart = mock( PartDefinition.class );
         final PartDefinition currentPart = mock( PartDefinition.class );
 
-        listBar.panelManager = mock( PanelManager.class );
         listBar.partContentView.put( selectedPart, new FlowPanel() );
         listBar.parts.add( selectedPart );
         listBar.currentPart = Pair.newPair( currentPart, new FlowPanel() );
         listBar.partContentView.put( currentPart, new FlowPanel() );
-        listBar.titleDropDown = mock( PartListDropdown.class );
 
         listBar.selectPart( selectedPart );
 
         verify( listBar.panelManager ).onPartHidden( currentPart );
-
     }
 
     @Test
-    public void partsIsAddedToListBar() {
+    public void partsIsAddedToListBarTest() {
         final PartDefinition firstPart = mock( PartDefinition.class );
         final PartDefinition secondPart = mock( PartDefinition.class );
 
@@ -97,7 +104,142 @@ public class ListBarWidgetImplTest {
         listBar.parts.add( secondPart );
 
         assertEquals(2, listBar.getParts().size());
+    }
 
+    @Test
+    public void changeTitleForSelectablePart() {
+        final PartDefinition part = getPartDefinition( true, false );
+        final IsWidget widget = mock( IsWidget.class );
+
+        listBar.changeTitle( part, "title", widget );
+
+        verify( listBar.titleDropDown ).changeTitle( part, "title", widget );
+    }
+
+    @Test
+    public void changeTitleForUnselectablePart() {
+        final PartDefinition part = getPartDefinition( false, false );
+        final IsWidget widget = mock( IsWidget.class );
+
+        listBar.changeTitle( part, "title", widget );
+
+        verify( listBar.titleDropDown, never() ).changeTitle( part, "title", widget );
+    }
+
+    @Test
+    public void addNewSelectablePartTest() {
+        final PartDefinition part = getPartDefinition( true, false );
+        final WorkbenchPartPresenter presenter = getWorkbenchPartPresenter( part );
+        final WorkbenchPartPresenter.View view = getWorkbenchPartView( presenter );
+
+        listBar.addPart( view );
+
+        verify( listBar, never() ).selectPart( part );
+        verify( listBar.titleDropDown ).addPart( view );
+    }
+
+    @Test
+    public void addNewUnselectablePartTest() {
+        final PartDefinition part = getPartDefinition( false, false );
+        final WorkbenchPartPresenter presenter = getWorkbenchPartPresenter( part );
+        final WorkbenchPartPresenter.View view = getWorkbenchPartView( presenter );
+
+        listBar.addPart( view );
+
+        verify( listBar, never() ).selectPart( part );
+        verify( listBar.titleDropDown, never() ).addPart( view );
+    }
+
+    @Test
+    public void addExistentPartTest() {
+        final PartDefinition part = getPartDefinition( true, true );
+        final WorkbenchPartPresenter presenter = getWorkbenchPartPresenter( part );
+        final WorkbenchPartPresenter.View view = getWorkbenchPartView( presenter );
+
+        listBar.addPart( view );
+
+        verify( listBar ).selectPart( part );
+        verify( listBar.titleDropDown, never() ).addPart( view );
+    }
+
+    @Test
+    public void selectNewPartTest() {
+        final PartDefinition part = getPartDefinition( true, false );
+
+        final boolean selected = listBar.selectPart( part );
+
+        assertFalse( selected );
+        verify( listBar.titleDropDown, never() ).selectPart( part );
+        verify( listBar, never() ).setupContextMenu();
+        verify( listBar.header, never() ).setVisible( anyBoolean() );
+    }
+
+    @Test
+    public void selectExistentUnselectablePartTest() {
+        final PartDefinition part = getPartDefinition( false, true );
+
+        final boolean selected = listBar.selectPart( part );
+
+        assertTrue( selected );
+        verify( listBar.titleDropDown, never() ).selectPart( part );
+        verify( listBar, never() ).setupContextMenu();
+        verify( listBar.header ).setVisible( false );
+    }
+
+    @Test
+    public void selectExistentSelectablePartTest() {
+        final PartDefinition part = getPartDefinition( true, true );
+
+        final boolean selected = listBar.selectPart( part );
+
+        assertTrue( selected );
+        verify( listBar.titleDropDown ).selectPart( part );
+        verify( listBar ).setupContextMenu();
+        verify( listBar.header ).setVisible( true );
+    }
+
+    @Test
+    public void removeUnselectablePartTest() {
+        final PartDefinition part = getPartDefinition( false, true );
+
+        listBar.remove( part );
+
+        verify( listBar.titleDropDown, never() ).removePart( part );
+    }
+
+    @Test
+    public void removeSelectablePartTest() {
+        final PartDefinition part = getPartDefinition( true, true );
+
+        listBar.remove( part );
+
+        verify( listBar.titleDropDown ).removePart( part );
+    }
+
+    private PartDefinition getPartDefinition( final boolean selectable,
+                                              final boolean existent ) {
+        final PartDefinition part = mock( PartDefinition.class );
+        doReturn( selectable ).when( part ).isSelectable();
+
+        if ( existent ) {
+            listBar.partContentView.put( part, new FlowPanel() );
+            listBar.parts.add( part );
+            listBar.partContentView.put( part, new FlowPanel() );
+        }
+
+        return part;
+    }
+
+    private WorkbenchPartPresenter getWorkbenchPartPresenter( final PartDefinition part ) {
+        final WorkbenchPartPresenter presenter = mock( WorkbenchPartPresenter.class );
+        doReturn( part ).when( presenter ).getDefinition();
+        return presenter;
+    }
+
+    private WorkbenchPartPresenter.View getWorkbenchPartView( final WorkbenchPartPresenter presenter ) {
+        final WorkbenchPartPresenter.View view = mock( WorkbenchPartPresenter.View.class );
+        doReturn( presenter ).when( view ).getPresenter();
+        return view;
     }
 
     @Test

--- a/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/test/java/org/uberfire/client/views/pfly/mock/MockPlaceManager.java
+++ b/uberfire-workbench/uberfire-workbench-client-views-patternfly/src/test/java/org/uberfire/client/views/pfly/mock/MockPlaceManager.java
@@ -147,6 +147,16 @@ public class MockPlaceManager implements PlaceManager {
     }
 
     @Override
+    public void forceCloseAllPlaces() {
+        throw new UnsupportedOperationException( "Not implemented." );
+    }
+
+    @Override
+    public boolean closeAllPlacesOrNothing() {
+        throw new UnsupportedOperationException( "Not implemented." );
+    }
+
+    @Override
     public void registerOnOpenCallback( PlaceRequest place,
                                         Command command ) {
         throw new UnsupportedOperationException( "Not implemented." );

--- a/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/mvp/PlaceManager.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/mvp/PlaceManager.java
@@ -143,7 +143,7 @@ public interface PlaceManager {
     void closePlace( final String id );
 
     void closePlace( final PlaceRequest placeToClose );
-    
+
     void tryClosePlace( final PlaceRequest placeToClose,
                         final Command onAfterClose );
 
@@ -154,6 +154,10 @@ public interface PlaceManager {
     void forceClosePlace( final PlaceRequest place );
 
     void closeAllPlaces();
+
+    void forceCloseAllPlaces();
+
+    boolean closeAllPlacesOrNothing();
 
     void registerOnOpenCallback( final PlaceRequest place,
                                  final Command command );

--- a/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/mvp/PluginPlaceManagerImpl.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/mvp/PluginPlaceManagerImpl.java
@@ -197,6 +197,17 @@ public class PluginPlaceManagerImpl implements PlaceManager {
     }
 
     @Override
+    public void forceCloseAllPlaces() {
+        fail();
+    }
+
+    @Override
+    public boolean closeAllPlacesOrNothing() {
+        fail();
+        return false;
+    }
+
+    @Override
     public void registerOnOpenCallback( final PlaceRequest place,
                                         final Command command ) {
         fail();


### PR DESCRIPTION
* Breadcrumbs now can depend only on `Command`s;
* Breadcrumbs now can be cleared without clearing the toolbar;
* The cursor shown over breadcrumb items is now `pointer` (hand);
* A `MultiListWorkbenchPanelPresenter` can have unselectable parts, which means that the part can only be activated programmatically, it won't show in the header list and the header will be hidden. This improvement won't change the current default behavior;
* The `PlaceManager` now offers an option to close all places only if all of them can be closed. Otherwise, none will be;
* When going to a `PartDefinition`, the `PlaceManager` now checks if the part already is there, and select it. This behavior was only implemented when going to `PlaceRequest`s.