### PR TITLE
Fix support for menus in dynamic plugins

### DIFF
--- a/uberfire-api/src/main/java/org/uberfire/workbench/model/menu/EnabledStateChangeListener.java
+++ b/uberfire-api/src/main/java/org/uberfire/workbench/model/menu/EnabledStateChangeListener.java
@@ -20,7 +20,7 @@ import jsinterop.annotations.JsType;
 /**
  * A Listener for changes in a Widget's enabled state
  */
-@JsType
+@JsType(isNative = true)
 public interface EnabledStateChangeListener {
 
     /**

--- a/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/widgets/menu/WorkbenchMenuBarPresenter.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/workbench/widgets/menu/WorkbenchMenuBarPresenter.java
@@ -15,6 +15,8 @@
  */
 package org.uberfire.client.workbench.widgets.menu;
 
+import static org.uberfire.plugin.PluginUtil.ensureIterable;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -395,7 +397,7 @@ public class WorkbenchMenuBarPresenter implements WorkbenchMenuBar {
 
     //Force UI to update to state of MenuItems. Should be called after MenuItems are configured with EnabledStateChangeListener's.
     void synchronizeUIWithMenus( final List<MenuItem> menuItems ) {
-        for ( MenuItem menuItem : menuItems ) {
+        for ( MenuItem menuItem : ensureIterable ( menuItems ) ) {
             if ( menuItem instanceof MenuGroup ) {
                 synchronizeUIWithMenus( ( (MenuGroup) menuItem ).getItems() );
 


### PR DESCRIPTION
- Make sure EnableStateChangeListeners can be shared
across scripts including their enclosing scope

- Make sure menu items are iterable even if provided
by external script