### PR TITLE
Refactor EnableStateChangeListener to a JsFunction

### DIFF
--- a/uberfire-api/src/main/java/org/uberfire/workbench/model/menu/EnabledStateChangeListener.java
+++ b/uberfire-api/src/main/java/org/uberfire/workbench/model/menu/EnabledStateChangeListener.java
@@ -15,12 +15,12 @@
  */
 package org.uberfire.workbench.model.menu;
 
-import jsinterop.annotations.JsType;
+import jsinterop.annotations.JsFunction;
 
 /**
  * A Listener for changes in a Widget's enabled state
  */
-@JsType(isNative = true)
+@JsFunction
 public interface EnabledStateChangeListener {
 
     /**


### PR DESCRIPTION
- This allows us to postpone activating jsinteropexports for all apps
while at the same time preventing the compiler optimization (inlining)
that caused problems for dynamic menus