### PR TITLE
Ensure UiBinder is instantiated before the instance of BusyPopup.

### DIFF
--- a/uberfire-extensions/uberfire-widgets/uberfire-widgets-commons/src/main/java/org/uberfire/ext/widgets/common/client/common/BusyPopup.java
+++ b/uberfire-extensions/uberfire-widgets/uberfire-widgets-commons/src/main/java/org/uberfire/ext/widgets/common/client/common/BusyPopup.java
@@ -31,8 +31,8 @@ import org.uberfire.ext.widgets.common.client.animations.LinearFadeOutAnimation;
  */
 public class BusyPopup extends DecoratedPopupPanel {
 
-    private static final BusyPopup INSTANCE = new BusyPopup();
     private static LoadingViewBinder uiBinder = GWT.create(LoadingViewBinder.class);
+    private static final BusyPopup INSTANCE = new BusyPopup();
 
     private static Timer deferredShowTimer = new Timer() {
         @Override


### PR DESCRIPTION
PR https://github.com/droolsjbpm/kie-wb-common/pull/711 has a failing test caused by the instantiation order of the ```BusyPopup``` "View" and ```BusyPopup``` "instance". The "View" needs to be instantiated before the popup "instance".