### PR TITLE
[RHBPMS-5142] User with role "user" can get edit access to some assets

### DIFF
--- a/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/mvp/PlaceHistoryHandler.java
+++ b/uberfire-workbench/uberfire-workbench-client/src/main/java/org/uberfire/client/mvp/PlaceHistoryHandler.java
@@ -134,8 +134,8 @@ public class PlaceHistoryHandler {
                 historian.addValueChangeHandler( new ValueChangeHandler<String>() {
                     @Override
                     public void onValueChange( ValueChangeEvent<String> event ) {
-                        String token = event.getValue();
-                        handleHistoryToken( token );
+//                        String token = event.getValue();
+//                        handleHistoryToken( token );
                     }
                 } );
 


### PR DESCRIPTION
workaround for user bypassing security. This avoids the possibility
of rendering parts of the UI without the security being checked