### PR TITLE
Fix test for newer java versions on Jenkins for 6.4.x product

### DIFF
--- a/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/JGitFileSystemProviderSSHTest.java
+++ b/uberfire-nio2-backport/uberfire-nio2-impls/uberfire-nio2-jgit/src/test/java/org/uberfire/java/nio/fs/jgit/JGitFileSystemProviderSSHTest.java
@@ -42,6 +42,7 @@ public class JGitFileSystemProviderSSHTest extends AbstractTestInfra {
     public Map<String, String> getGitPreferences() {
         Map<String, String> gitPrefs = super.getGitPreferences();
 
+        gitPrefs.put( "org.uberfire.nio.git.ssh.algorithm", "RSA" );
         gitPrefs.put( "org.uberfire.nio.git.ssh.enabled", "true" );
         gitSSHPort = findFreePort();
         gitPrefs.put( "org.uberfire.nio.git.ssh.port", String.valueOf( gitSSHPort ) );


### PR DESCRIPTION
Hi @ederign, 

there is a fix for test. DSA algorithm is outdated and removed from newer versions of Java, so I updated test to fix it on our Jenkins machines.

